### PR TITLE
feat: upgrade agent coordinator — PR flow, objective verification, bounded retry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,5 @@
 - The app deploys to Vercel automatically from `main`. Do not add local deploy or pm2 steps.
 - The product name in UI copy is **"AdmitDay"** (the repo was renamed from hs-navigator; don't reintroduce the old name).
 - Never push, never merge, never switch branches — the coordinator owns git remotes.
+- `LESSONS.md` is coordinator-owned runtime state — read it for context, but never commit it (use `git add -A -- ':(exclude)LESSONS.md'`).
+- Stay strictly within the scope of the issue you were given; an independent reviewer rejects scope creep.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# AdmitDay — house rules for agents
+
+- **Never modify `data/schools.json`.** It is curated source data.
+- Filtering logic lives in `lib/school-list-utils.ts` — look there first for anything about school list filtering.
+- Tests live in `__tests__/`. **Add** new test files or cases; never overwrite or delete existing tests.
+- Run `npm test` and `npm run build` before considering any change done; both must exit 0.
+- The app deploys to Vercel automatically from `main`. Do not add local deploy or pm2 steps.
+- The product name in UI copy is **"AdmitDay"** (the repo was renamed from hs-navigator; don't reintroduce the old name).
+- Never push, never merge, never switch branches — the coordinator owns git remotes.

--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -95,22 +95,38 @@ describe('parseIssueCommand', () => {
   })
 })
 
-// ── Issue #6: agent-coordinator.sh build before pm2 restart ─────────────────
+// ── agent-coordinator.sh: PR-flow invariants (replaces retired pm2 deploy) ──
+// The coordinator no longer deploys from the VPS (Vercel deploys from main).
+// It runs the agent on a branch, verifies objectively, and opens a PR for
+// human review. These tests pin that contract so a regression can't quietly
+// reintroduce self-merge-to-main or VPS deploy steps.
 
-describe('agent-coordinator.sh deploy sequence', () => {
+describe('agent-coordinator.sh PR flow', () => {
   const coordinatorSource = fs.readFileSync(path.join(__dirname, '../agent-coordinator.sh'), 'utf-8')
 
-  it('runs npm run build before pm2 restart', () => {
-    expect(coordinatorSource).toContain('npm run build >> "$LOG_FILE" 2>&1 && pm2 restart hs-navigator')
+  it('uses the "agent-ok" trigger label (nothing runs unless deliberately labeled)', () => {
+    expect(coordinatorSource).toContain('TRIGGER_LABEL="agent-ok"')
   })
 
-  it('does NOT call bare pm2 restart without a preceding build', () => {
-    // The only pm2 restart line should be preceded by npm run build
-    const lines = coordinatorSource.split('\n')
-    const pm2Lines = lines.filter(l => l.includes('pm2 restart hs-navigator'))
-    pm2Lines.forEach(line => {
-      expect(line).toContain('npm run build')
-    })
+  it('does NOT reference pm2 (VPS deploy retired; Vercel deploys from main)', () => {
+    expect(coordinatorSource).not.toMatch(/pm2/)
+  })
+
+  it('never merges or pushes to main — it opens a PR for review instead', () => {
+    expect(coordinatorSource).not.toMatch(/git merge/)
+    expect(coordinatorSource).not.toMatch(/git push origin main\b/)
+  })
+
+  it('opens a pull request against main via the PR API', () => {
+    expect(coordinatorSource).toContain('github_open_pr')
+    expect(coordinatorSource).toContain('POST "/pulls"')
+    // JSON body is embedded in a shell double-quoted string, so quotes are escaped
+    expect(coordinatorSource).toMatch(/\\"base\\":\\"main\\"/)
+  })
+
+  it('objectively verifies by running npm test and npm run build itself', () => {
+    expect(coordinatorSource).toContain('npm test')
+    expect(coordinatorSource).toContain('npm run build')
   })
 })
 

--- a/agent-coordinator.sh
+++ b/agent-coordinator.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
-# Load credentials
-source /root/.env.agents
-ANTHROPIC_API_KEY=$(grep ANTHROPIC_API_KEY /root/app/.env.local | cut -d '=' -f2 | tr -d '"' | tr -d "'")
+# AdmitDay autonomous coding agent coordinator.
+# Polls GitHub for open issues labeled "agent-ok", runs a Claude agent per issue
+# on a branch, verifies with npm test + npm run build, and opens a PR.
+# This coordinator NEVER pushes to main and NEVER merges.
 
-APP_DIR="/root/app"
-LOG_FILE="/root/agent-coordinator.log"
-OFFSET_FILE="/tmp/tg_offset"
+# Load credentials
+source /home/agent/.env.agents
+ANTHROPIC_API_KEY=$(grep ANTHROPIC_API_KEY /home/agent/app/.env.local | cut -d '=' -f2 | tr -d '"' | tr -d "'")
+
+APP_DIR="/home/agent/app"
+LOG_FILE="/home/agent/agent-coordinator.log"
+OFFSET_FILE="/home/agent/.tg_offset"
+TRIGGER_LABEL="agent-ok"
+CLAUDE_TIMEOUT=1800
 
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
@@ -19,40 +26,57 @@ telegram() {
     -d "text=${MSG}" > /dev/null
 }
 
+gh_api() {
+  # gh_api METHOD PATH [DATA]
+  local METHOD="$1" PATH_="$2" DATA="$3"
+  if [ -n "$DATA" ]; then
+    curl -sL -X "$METHOD" \
+      -H "Authorization: token ${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${GITHUB_REPO}${PATH_}" \
+      -d "$DATA"
+  else
+    curl -sL -X "$METHOD" \
+      -H "Authorization: token ${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/${GITHUB_REPO}${PATH_}"
+  fi
+}
+
+json_escape() {
+  python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))"
+}
+
 github_label() {
-  curl -s -X POST \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${GITHUB_REPO}/issues/$1/labels" \
-    -d "{\"labels\":[\"$2\"]}" > /dev/null
+  gh_api POST "/issues/$1/labels" "{\"labels\":[\"$2\"]}" > /dev/null
 }
 
 github_remove_label() {
-  curl -s -X DELETE \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${GITHUB_REPO}/issues/$1/labels/$2" > /dev/null
+  gh_api DELETE "/issues/$1/labels/$2" > /dev/null
 }
 
-github_close() {
-  curl -s -X PATCH \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${GITHUB_REPO}/issues/$1" \
-    -d '{"state":"closed"}' > /dev/null
+github_comment() {
+  local BODY
+  BODY=$(printf '%s' "$2" | json_escape)
+  gh_api POST "/issues/$1/comments" "{\"body\":${BODY}}" > /dev/null
 }
 
 github_create_issue() {
-  local TITLE="$1"
-  local TITLE_JSON
-  TITLE_JSON=$(printf '%s' "$TITLE" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))")
-  local RESPONSE
-  RESPONSE=$(curl -s -X POST \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${GITHUB_REPO}/issues" \
-    -d "{\"title\":${TITLE_JSON},\"labels\":[\"todo\"]}")
+  # github_create_issue TITLE [BODY] -> echoes issue number
+  local TITLE_JSON BODY_JSON RESPONSE
+  TITLE_JSON=$(printf '%s' "$1" | json_escape)
+  BODY_JSON=$(printf '%s' "${2:-}" | json_escape)
+  RESPONSE=$(gh_api POST "/issues" "{\"title\":${TITLE_JSON},\"body\":${BODY_JSON},\"labels\":[\"${TRIGGER_LABEL}\"]}")
   echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('number',''))" 2>/dev/null
+}
+
+github_open_pr() {
+  # github_open_pr BRANCH TITLE BODY -> echoes html_url (empty on failure)
+  local TITLE_JSON BODY_JSON RESPONSE
+  TITLE_JSON=$(printf '%s' "$2" | json_escape)
+  BODY_JSON=$(printf '%s' "$3" | json_escape)
+  RESPONSE=$(gh_api POST "/pulls" "{\"title\":${TITLE_JSON},\"head\":\"$1\",\"base\":\"main\",\"body\":${BODY_JSON}}")
+  echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('html_url',''))" 2>/dev/null
 }
 
 handle_telegram_commands() {
@@ -64,7 +88,7 @@ handle_telegram_commands() {
   local UPDATES
   UPDATES=$(curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates?offset=${OFFSET}&timeout=0")
 
-  while IFS='|||' read -r UPDATE_ID TEXT; do
+  while IFS=$'\t' read -r UPDATE_ID TEXT; do
     if [ -z "$UPDATE_ID" ]; then continue; fi
     echo $((UPDATE_ID + 1)) > "$OFFSET_FILE"
 
@@ -85,203 +109,265 @@ import json, sys
 data = json.load(sys.stdin)
 for u in data.get('result', []):
     uid = u.get('update_id', 0)
-    text = u.get('message', {}).get('text', '').replace('|||', ' ')
-    print(f'{uid}|||{text}')
+    text = u.get('message', {}).get('text', '').replace('\t', ' ').replace('\n', ' ')
+    print(f'{uid}\t{text}')
 ")
 }
 
-github_comment() {
-  local BODY=$(echo "$2" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))")
-  curl -s -X POST \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${GITHUB_REPO}/issues/$1/comments" \
-    -d "{\"body\":${BODY}}" > /dev/null
+# Run one claude agent call with timeout, capturing session id and result text.
+# run_claude OUTPUT_JSON_FILE [RESUME_SESSION_ID] <<< prompt on stdin via $PROMPT env
+# Returns: 0 if claude ran and reported success, 1 on error, 124 on timeout.
+run_claude() {
+  local OUT_FILE="$1"
+  local RESUME_ID="$2"
+  local RESUME_ARGS=()
+  if [ -n "$RESUME_ID" ]; then
+    RESUME_ARGS=(--resume "$RESUME_ID")
+  fi
+  ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" timeout "$CLAUDE_TIMEOUT" claude \
+    -p "$PROMPT" \
+    --output-format json \
+    --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
+    "${RESUME_ARGS[@]}" \
+    > "$OUT_FILE" 2>> "$LOG_FILE"
+  local RC=$?
+  if [ $RC -eq 124 ]; then
+    return 124
+  fi
+  # Treat as success only if the JSON parses and is_error is false
+  python3 -c "
+import json,sys
+try:
+    d = json.load(open('$OUT_FILE'))
+    sys.exit(0 if not d.get('is_error') else 1)
+except Exception:
+    sys.exit(1)
+" && return 0 || return 1
+}
+
+claude_json_field() {
+  # claude_json_field FILE FIELD
+  python3 -c "
+import json,sys
+try:
+    d = json.load(open('$1'))
+    print(d.get('$2','') or '')
+except Exception:
+    pass
+"
+}
+
+# Coordinator-owned verification: the ONLY success signal.
+# Prunes the Next.js webpack cache afterwards — this VPS has very little free
+# disk and the cache alone is ~400MB.
+verify_app() {
+  local OUT="$1" RC=0
+  (cd "$APP_DIR" && npm test) > "$OUT" 2>&1 || RC=1
+  if [ $RC -eq 0 ]; then
+    (cd "$APP_DIR" && npm run build) >> "$OUT" 2>&1 || RC=1
+  fi
+  rm -rf "$APP_DIR/.next/cache"
+  return $RC
 }
 
 run_agent() {
   local ISSUE_NUMBER=$1
-  local ISSUE_TITLE=$2
-  local ISSUE_BODY=$3
+
+  # Fetch full issue (title + body with newlines preserved) and its comments
+  local ISSUE_FILE="/tmp/issue-${ISSUE_NUMBER}.json"
+  gh_api GET "/issues/${ISSUE_NUMBER}" > "$ISSUE_FILE"
+  local ISSUE_TITLE ISSUE_BODY ISSUE_COMMENTS
+  ISSUE_TITLE=$(python3 -c "import json; print(json.load(open('$ISSUE_FILE')).get('title',''))")
+  ISSUE_BODY=$(python3 -c "import json; print(json.load(open('$ISSUE_FILE')).get('body') or '(no body)')")
+  ISSUE_COMMENTS=$(gh_api GET "/issues/${ISSUE_NUMBER}/comments" | python3 -c "
+import json,sys
+try:
+    cs = json.load(sys.stdin)
+    out = '\n\n'.join(f\"[{c['user']['login']}]: {c['body']}\" for c in cs)
+    print(out if out else '(no comments)')
+except Exception:
+    print('(no comments)')
+")
+  rm -f "$ISSUE_FILE"
+
+  if [ -z "$ISSUE_TITLE" ]; then
+    log "Could not fetch issue #${ISSUE_NUMBER}, skipping"
+    return
+  fi
+
   local SAFE_TITLE=$(echo "$ISSUE_TITLE" | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | tr -dc 'a-z0-9-' | cut -c1-30)
   local BRANCH="task-${ISSUE_NUMBER}-${SAFE_TITLE}"
-  local SUMMARY_FILE="/tmp/summary-issue-${ISSUE_NUMBER}.md"
-  local OUTPUT_FILE="/tmp/output-issue-${ISSUE_NUMBER}.log"
+  local COMMIT_TITLE="fix: issue #${ISSUE_NUMBER} - ${ISSUE_TITLE}"
+  local CLAUDE_OUT="/tmp/claude-issue-${ISSUE_NUMBER}.json"
+  local VERIFY_OUT="/tmp/verify-issue-${ISSUE_NUMBER}.log"
 
   log "Starting issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
   telegram "Starting issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
 
-  # Remove todo immediately so a crash mid-run never causes an infinite loop
-  github_remove_label "$ISSUE_NUMBER" "todo"
+  # Remove trigger label immediately so a crash mid-run never causes an infinite loop
+  github_remove_label "$ISSUE_NUMBER" "$TRIGGER_LABEL"
   github_label "$ISSUE_NUMBER" "in-progress"
 
-  cd "$APP_DIR" || exit 1
-  git checkout main && git pull origin main
-  # Delete branch if it already exists from a previous failed attempt
+  cd "$APP_DIR" || { log "FATAL: cannot cd to $APP_DIR"; return; }
+  git checkout main >> "$LOG_FILE" 2>&1 && git pull origin main >> "$LOG_FILE" 2>&1
   git branch -D "$BRANCH" 2>/dev/null
-  git checkout -b "$BRANCH"
-  rm -f "$SUMMARY_FILE" "$OUTPUT_FILE"
+  git checkout -b "$BRANCH" >> "$LOG_FILE" 2>&1
+  rm -f "$CLAUDE_OUT" "$VERIFY_OUT"
 
-  local PROMPT="You are a senior full-stack engineer working on the hs-navigator Next.js app at /root/app.
-Fix GitHub issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+  local BRIEF="You are fixing a GitHub issue in the AdmitDay Next.js app.
+
+Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+
 ${ISSUE_BODY}
 
-Send progress updates throughout using: /root/notify.sh \"message\"
+Issue comments:
+${ISSUE_COMMENTS}
 
-Work through these phases IN ORDER. Complete each fully before moving on.
+Instructions:
+- Work in /home/agent/app on branch ${BRANCH} (already checked out). Read /home/agent/app/CLAUDE.md first.
+- Fix the issue. Add tests for your change in __tests__/ (add, don't overwrite existing tests).
+- Run 'cd /home/agent/app && npm test' and 'cd /home/agent/app && npm run build' and iterate until both are green.
+- Commit your work: cd /home/agent/app && git add -A && git commit -m \"${COMMIT_TITLE}\"
+- Never modify data/schools.json.
+- Never push, never merge, never switch branches.
+- You can send the owner a short progress update with: /home/agent/notify.sh \"message\"
+- End with a short summary of what you changed and why (it becomes the pull request description)."
 
-## Phase 1 — DIAGNOSE (no file edits)
-1. Extract 2-4 keywords from the issue title and body
-2. For each keyword run: grep -r \"<keyword>\" /root/app --include='*.ts' --include='*.tsx' --include='*.js' -l
-3. Read every relevant file
-4. Trace the full data flow end to end (entry point → processing → render)
-5. Identify the exact file, function, and line that needs to change
-6. Run: /root/notify.sh \"#${ISSUE_NUMBER} diagnosis done — found: <one line summary of root cause>\"
+  local ATTEMPT=1
+  local SESSION_ID=""
+  local SUCCESS=0
+  local PROMPT="$BRIEF"
 
-## Phase 2 — PLAN (no file edits)
-State exactly:
-- Which file and function to change
-- The precise change: old value → new value
-- What tests will verify the fix
-Then run: /root/notify.sh \"#${ISSUE_NUMBER} plan: <one line summary of what will change>\"
+  while [ $ATTEMPT -le 2 ]; do
+    log "Issue #${ISSUE_NUMBER}: agent attempt ${ATTEMPT}"
+    run_claude "$CLAUDE_OUT" "$([ $ATTEMPT -gt 1 ] && echo "$SESSION_ID")"
+    local RC=$?
+    if [ $RC -eq 124 ]; then
+      log "Issue #${ISSUE_NUMBER}: claude timed out on attempt ${ATTEMPT}"
+      telegram "Timeout: agent hit the 30min limit on issue #${ISSUE_NUMBER} (attempt ${ATTEMPT})"
+    elif [ $RC -ne 0 ]; then
+      log "Issue #${ISSUE_NUMBER}: claude errored on attempt ${ATTEMPT}"
+    fi
+    [ -z "$SESSION_ID" ] && SESSION_ID=$(claude_json_field "$CLAUDE_OUT" "session_id")
 
-## Phase 3 — IMPLEMENT
-Make exactly the changes from your plan. Nothing more. Do not modify schools.json.
-Then run: /root/notify.sh \"#${ISSUE_NUMBER} code changes done\"
+    # Objective verification by the coordinator — the only success signal.
+    # Also require that the branch actually differs from main.
+    if [ $RC -eq 0 ] && verify_app "$VERIFY_OUT"; then
+      cd "$APP_DIR"
+      # Fallback: commit anything the agent left uncommitted
+      if [ -n "$(git status --porcelain)" ]; then
+        git add -A && git commit -m "$COMMIT_TITLE" >> "$LOG_FILE" 2>&1
+      fi
+      if [ -n "$(git log origin/main..HEAD --oneline)" ]; then
+        SUCCESS=1
+        break
+      fi
+      log "Issue #${ISSUE_NUMBER}: verification passed but no changes were committed"
+    fi
 
-## Phase 4 — TEST
-1. Check /root/app/__tests__/ for existing tests — add to them, do not overwrite
-2. Write tests that verify your specific fix
-3. Run: cd /root/app && npm test
-4. If tests fail: read the error carefully, fix only what is needed, run again
-5. Keep going until all tests pass
-6. Run: /root/notify.sh \"#${ISSUE_NUMBER} tests passing\"
+    if [ $ATTEMPT -lt 2 ]; then
+      local FAIL_TAIL
+      FAIL_TAIL=$(tail -150 "$VERIFY_OUT" 2>/dev/null)
+      [ -z "$FAIL_TAIL" ] && FAIL_TAIL="(the claude run itself failed or timed out before verification; check your previous work for incomplete edits)"
+      PROMPT="Verification failed. The coordinator ran 'npm test && npm run build' after your changes and it did not pass, or no changes were committed.
 
-## Phase 5 — BUILD
-1. Run: cd /root/app && npm run build
-2. If build fails: read the error carefully, fix only what is needed, run build again
-3. Keep going until build passes
-4. Run: /root/notify.sh \"#${ISSUE_NUMBER} build passing\"
+Failing output (tail):
+${FAIL_TAIL}
 
-## Phase 6 — SUMMARIZE
-Write ${SUMMARY_FILE} in exactly this format:
-## What was fixed
-<one paragraph>
+Diagnose why this failed before changing anything else. Then fix it, re-run npm test and npm run build until green, and commit with message \"${COMMIT_TITLE}\"."
+      log "Issue #${ISSUE_NUMBER}: attempt ${ATTEMPT} failed verification, retrying with session resume"
+    fi
+    ATTEMPT=$((ATTEMPT + 1))
+  done
 
-## Changes made
-<bullet list with exact values, e.g. 'TARGET: 3 → 5'>
+  if [ $SUCCESS -eq 1 ]; then
+    local SUMMARY
+    SUMMARY=$(claude_json_field "$CLAUDE_OUT" "result")
+    [ -z "$SUMMARY" ] && SUMMARY="(agent produced no summary)"
 
-## Tests added
-<bullet list>
+    git push origin "$BRANCH" >> "$LOG_FILE" 2>&1
+    local PR_BODY="${SUMMARY}
 
-## Result: PASSED
+Closes #${ISSUE_NUMBER}"
+    local PR_URL
+    PR_URL=$(github_open_pr "$BRANCH" "$COMMIT_TITLE" "$PR_BODY")
 
-## Phase 7 — COMMIT
-Run: cd /root/app && git add -A && git commit -m \"fix: issue #${ISSUE_NUMBER} - ${ISSUE_TITLE}\""
+    if [ -n "$PR_URL" ]; then
+      github_comment "$ISSUE_NUMBER" "Agent opened a pull request for this issue: ${PR_URL}
 
-  ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" claude \
-    --print \
-    -p "$PROMPT" \
-    --allowedTools "Bash,Read,Write,Edit" \
-    2>&1 | tee "$OUTPUT_FILE" >> "$LOG_FILE"
-
-  # Check for success: summary file exists and contains Result: PASSED
-  if [ -f "$SUMMARY_FILE" ] && grep -q "Result: PASSED" "$SUMMARY_FILE"; then
-    local SUMMARY=$(cat "$SUMMARY_FILE")
-    rm -f "$SUMMARY_FILE"
-
-    git push origin "$BRANCH"
-    git checkout main
-    git merge "$BRANCH" --no-ff -m "fix: issue #${ISSUE_NUMBER} - ${ISSUE_TITLE}"
-    git push origin main
-    cd /root/app && npm run build >> "$LOG_FILE" 2>&1 && pm2 restart hs-navigator >> "$LOG_FILE" 2>&1
-
-    github_comment "$ISSUE_NUMBER" "$SUMMARY"
-    github_label "$ISSUE_NUMBER" "done"
-    github_remove_label "$ISSUE_NUMBER" "in-progress"
-    github_close "$ISSUE_NUMBER"
-    log "Issue #${ISSUE_NUMBER} done and deployed"
-    telegram "Done: issue #${ISSUE_NUMBER} - ${ISSUE_TITLE}"
+Tests and build verified green by the coordinator. Please review and merge."
+      github_label "$ISSUE_NUMBER" "pr-open"
+      github_remove_label "$ISSUE_NUMBER" "in-progress"
+      log "Issue #${ISSUE_NUMBER}: PR opened at ${PR_URL}"
+      telegram "PR ready for issue #${ISSUE_NUMBER}: ${ISSUE_TITLE} — ${PR_URL}"
+    else
+      github_label "$ISSUE_NUMBER" "needs-review"
+      github_remove_label "$ISSUE_NUMBER" "in-progress"
+      log "Issue #${ISSUE_NUMBER}: branch pushed but PR creation failed"
+      telegram "Issue #${ISSUE_NUMBER}: branch ${BRANCH} pushed but PR creation FAILED — needs manual attention"
+    fi
+    git checkout main >> "$LOG_FILE" 2>&1
   else
-    # Post partial summary + last 100 lines of agent output for context
-    local PARTIAL=""
-    if [ -f "$SUMMARY_FILE" ]; then
-      PARTIAL=$(cat "$SUMMARY_FILE")
-    fi
-    local AGENT_OUTPUT=""
-    if [ -f "$OUTPUT_FILE" ]; then
-      AGENT_OUTPUT=$(tail -100 "$OUTPUT_FILE")
-    fi
-    rm -f "$SUMMARY_FILE" "$OUTPUT_FILE"
-    local COMMENT="Agent could not fully resolve this issue.
+    local FAIL_OUTPUT
+    FAIL_OUTPUT=$(tail -100 "$VERIFY_OUT" 2>/dev/null)
+    [ -z "$FAIL_OUTPUT" ] && FAIL_OUTPUT="(no verification output — the claude run failed or timed out)"
+    github_comment "$ISSUE_NUMBER" "Agent could not resolve this issue after 2 attempts. Coordinator verification (npm test && npm run build) failed.
 
-${PARTIAL}
-
----
-
-<details><summary>Agent output (last 100 lines)</summary>
+<details><summary>Failure output (tail)</summary>
 
 \`\`\`
-${AGENT_OUTPUT}
+${FAIL_OUTPUT}
 \`\`\`
 
 </details>"
-    github_comment "$ISSUE_NUMBER" "$(printf '%b' "$COMMENT")"
     github_label "$ISSUE_NUMBER" "needs-review"
     github_remove_label "$ISSUE_NUMBER" "in-progress"
-    github_remove_label "$ISSUE_NUMBER" "todo"
-    git checkout main
+    cd "$APP_DIR"
+    git checkout main >> "$LOG_FILE" 2>&1
     git branch -D "$BRANCH" 2>/dev/null
-    log "Issue #${ISSUE_NUMBER} needs review"
-    local TAIL=$(tail -20 "$OUTPUT_FILE" 2>/dev/null | tr '\n' ' ' | cut -c1-500)
-    telegram "Stuck on #${ISSUE_NUMBER}: ${ISSUE_TITLE} | Last output: ${TAIL}"
+    log "Issue #${ISSUE_NUMBER}: failed after 2 attempts, labeled needs-review"
+    telegram "Failed after 2 attempts: issue #${ISSUE_NUMBER}: ${ISSUE_TITLE} — labeled needs-review, branch deleted"
   fi
+
+  rm -f "$CLAUDE_OUT" "$VERIFY_OUT"
 }
 
 log "Coordinator started"
 
-# Write a notify helper the agent can call to send Telegram updates
-cat > /root/notify.sh << 'NOTIFY'
+# Write a notify helper the inner agent can call to send Telegram updates
+cat > /home/agent/notify.sh << 'NOTIFY'
 #!/bin/bash
-source /root/.env.agents
+source /home/agent/.env.agents
 MSG=$(echo "$1" | tr '\n' ' ')
 curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
   -d chat_id="${TELEGRAM_CHAT_ID}" \
   -d "text=${MSG}" > /dev/null
 NOTIFY
-chmod +x /root/notify.sh
+chmod +x /home/agent/notify.sh
 
-# Sync any VPS-only test files into the repo so agents always have a baseline
-cd "$APP_DIR"
-if [[ -n $(git ls-files --others --exclude-standard __tests__/) ]]; then
-  log "Syncing untracked test files to repo"
-  git add __tests__/
-  git commit -m "chore: sync baseline tests to repo"
-  git push origin main
-fi
-
-telegram "Coordinator started, watching for todo issues"
+telegram "Coordinator started, watching for ${TRIGGER_LABEL} issues (PR flow — never pushes to main)"
 
 while true; do
   handle_telegram_commands
 
-  ISSUES_JSON=$(curl -s \
+  ISSUE_NUMBERS=$(curl -sL \
     -H "Authorization: token ${GITHUB_TOKEN}" \
     -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${GITHUB_REPO}/issues?labels=todo&state=open")
-
-  while IFS='|||' read -r NUMBER TITLE BODY; do
-    if [ -n "$NUMBER" ]; then
-      run_agent "$NUMBER" "$TITLE" "$BODY"
-    fi
-  done < <(echo "$ISSUES_JSON" | python3 -c "
+    "https://api.github.com/repos/${GITHUB_REPO}/issues?labels=${TRIGGER_LABEL}&state=open" \
+    | python3 -c "
 import json, sys
-issues = json.load(sys.stdin)
-for issue in issues:
-    t = issue['title'].replace('\n',' ').replace('|||',' ')
-    b = (issue.get('body') or '').replace('\n',' ').replace('|||',' ')
-    print(f\"{issue['number']}|||{t}|||{b}\")
+try:
+    issues = json.load(sys.stdin)
+    for i in issues:
+        if 'pull_request' not in i:
+            print(i['number'])
+except Exception:
+    pass
 ")
+
+  for NUMBER in $ISSUE_NUMBERS; do
+    run_agent "$NUMBER"
+  done
 
   sleep 60
 done

--- a/agent-coordinator.sh
+++ b/agent-coordinator.sh
@@ -2,7 +2,8 @@
 
 # AdmitDay autonomous coding agent coordinator.
 # Polls GitHub for open issues labeled "agent-ok", runs a Claude agent per issue
-# on a branch, verifies with npm test + npm run build, and opens a PR.
+# on a branch, verifies with npm test + npm run build, has an independent
+# reviewer approve the diff, and opens a PR.
 # This coordinator NEVER pushes to main and NEVER merges.
 
 # Load credentials
@@ -12,6 +13,7 @@ ANTHROPIC_API_KEY=$(grep ANTHROPIC_API_KEY /home/agent/app/.env.local | cut -d '
 APP_DIR="/home/agent/app"
 LOG_FILE="/home/agent/agent-coordinator.log"
 OFFSET_FILE="/home/agent/.tg_offset"
+LESSONS_FILE="/home/agent/app/LESSONS.md"
 TRIGGER_LABEL="agent-ok"
 CLAUDE_TIMEOUT=1800
 
@@ -79,6 +81,235 @@ github_open_pr() {
   echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('html_url',''))" 2>/dev/null
 }
 
+# Run one claude agent call with timeout, capturing the JSON result.
+# Reads the prompt from $PROMPT. run_claude OUT_FILE [RESUME_ID] [TOOLS]
+# Returns: 0 on success, 124 on timeout, 1 on any other error.
+run_claude() {
+  local OUT_FILE="$1"
+  local RESUME_ID="$2"
+  local TOOLS="${3:-Bash,Read,Write,Edit,Glob,Grep}"
+  local RESUME_ARGS=()
+  if [ -n "$RESUME_ID" ]; then
+    RESUME_ARGS=(--resume "$RESUME_ID")
+  fi
+  ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" timeout "$CLAUDE_TIMEOUT" claude \
+    -p "$PROMPT" \
+    --output-format json \
+    --allowedTools "$TOOLS" \
+    "${RESUME_ARGS[@]}" \
+    > "$OUT_FILE" 2>> "$LOG_FILE"
+  local RC=$?
+  if [ $RC -eq 124 ]; then
+    return 124
+  fi
+  python3 -c "
+import json,sys
+try:
+    d = json.load(open('$OUT_FILE'))
+    sys.exit(0 if not d.get('is_error') else 1)
+except Exception:
+    sys.exit(1)
+" && return 0 || return 1
+}
+
+claude_json_field() {
+  # claude_json_field FILE FIELD
+  python3 -c "
+import json,sys
+try:
+    d = json.load(open('$1'))
+    print(d.get('$2','') or '')
+except Exception:
+    pass
+"
+}
+
+# Coordinator-owned verification: the ONLY success signal.
+# This VPS has <600MB free disk and Next's webpack filesystem cache alone is
+# ~400MB, so: wipe .next before building and keep pruning .next/cache while
+# the build runs (webpack treats failed cache writes as non-fatal warnings).
+verify_app() {
+  local OUT="$1" RC=0
+  rm -rf "$APP_DIR/.next"
+  (cd "$APP_DIR" && npm test) > "$OUT" 2>&1 || RC=1
+  if [ $RC -eq 0 ]; then
+    ( while true; do rm -rf "$APP_DIR/.next/cache" 2>/dev/null; sleep 10; done ) &
+    local PRUNE_PID=$!
+    (cd "$APP_DIR" && npm run build) >> "$OUT" 2>&1 || RC=1
+    kill "$PRUNE_PID" 2>/dev/null
+    wait "$PRUNE_PID" 2>/dev/null
+    rm -rf "$APP_DIR/.next/cache"
+  fi
+  return $RC
+}
+
+# Independent reviewer with fresh context: given only the issue and the diff,
+# does this change actually resolve the issue? Echoes the review text.
+# Returns 0=approve, 1=reject, 2=reviewer unavailable (do not block on infra).
+review_change() {
+  local ISSUE_NUMBER="$1" ISSUE_TITLE="$2" ISSUE_BODY="$3"
+  local REVIEW_OUT="/tmp/review-issue-${ISSUE_NUMBER}.json"
+  local DIFF
+  DIFF=$(cd "$APP_DIR" && git diff origin/main...HEAD | head -c 60000)
+
+  local PROMPT="You are an independent code reviewer for the AdmitDay Next.js app. You have fresh context: judge only what is in front of you.
+
+The issue this change claims to resolve:
+Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+
+${ISSUE_BODY}
+
+The complete diff against main:
+\`\`\`diff
+${DIFF}
+\`\`\`
+
+Questions to answer:
+1. Does this diff actually resolve the issue?
+2. What did it break or put at risk? Look for scope creep (changes the issue did not ask for), modifications to data/schools.json (forbidden), deleted or weakened tests, and unrelated refactors.
+
+You may read files in /home/agent/app for context. Be strict about scope: if the diff contains significant changes beyond what the issue asked for, reject it.
+
+End your response with exactly one line:
+VERDICT: APPROVE
+or
+VERDICT: REJECT - <one-line reason>"
+
+  run_claude "$REVIEW_OUT" "" "Read,Glob,Grep"
+  local RC=$?
+  local REVIEW_TEXT
+  REVIEW_TEXT=$(claude_json_field "$REVIEW_OUT" "result")
+  rm -f "$REVIEW_OUT"
+  echo "$REVIEW_TEXT"
+  if [ $RC -ne 0 ] || [ -z "$REVIEW_TEXT" ]; then
+    return 2
+  fi
+  if echo "$REVIEW_TEXT" | grep -q "VERDICT: APPROVE"; then
+    return 0
+  fi
+  return 1
+}
+
+# Learning loop: after every completed task, distill 0-2 durable lessons into
+# LESSONS.md (deduped, hard cap 30 lines). Never fatal.
+run_retrospective() {
+  local ISSUE_NUMBER="$1" ISSUE_TITLE="$2" OUTCOME="$3" DIFF="$4"
+  local RETRO_OUT="/tmp/retro-issue-${ISSUE_NUMBER}.json"
+  local CURRENT_LESSONS="(file does not exist yet)"
+  [ -s "$LESSONS_FILE" ] && CURRENT_LESSONS=$(cat "$LESSONS_FILE")
+
+  local PROMPT="You maintain LESSONS.md, a list of durable lessons for an autonomous coding agent working on the AdmitDay Next.js app.
+
+A task just completed.
+Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+Outcome: ${OUTCOME}
+
+Diff (may be truncated):
+\`\`\`diff
+$(printf '%s' "$DIFF" | head -c 20000)
+\`\`\`
+
+Current LESSONS.md:
+---
+${CURRENT_LESSONS}
+---
+
+Write the complete new content of LESSONS.md and nothing else (no fences, no commentary):
+- Add 0-2 new lessons ONLY if this task taught something durable and reusable (a repo quirk, a recurring failure mode, a technique that worked). If nothing durable was learned, output the current content unchanged.
+- One lesson per line, as '- <lesson>'. A single '# Lessons' header line is allowed.
+- Deduplicate: never repeat an existing lesson in different words.
+- Hard cap 30 lines total: if adding would exceed it, drop the least useful existing line."
+
+  run_claude "$RETRO_OUT" "" "Read"
+  local RC=$?
+  if [ $RC -eq 0 ]; then
+    local NEW_LESSONS
+    NEW_LESSONS=$(claude_json_field "$RETRO_OUT" "result" | head -30)
+    if [ -n "$NEW_LESSONS" ]; then
+      printf '%s\n' "$NEW_LESSONS" > "$LESSONS_FILE"
+      log "Retrospective for #${ISSUE_NUMBER} updated LESSONS.md ($(wc -l < "$LESSONS_FILE") lines)"
+    fi
+  else
+    log "Retrospective for #${ISSUE_NUMBER} failed (non-fatal)"
+  fi
+  rm -f "$RETRO_OUT"
+}
+
+# Planner: break a Telegram /goal into <=5 small issues labeled agent-ok.
+# The planner claude call is READ-ONLY; the coordinator creates the issues.
+plan_goal() {
+  local GOAL="$1"
+  local PLAN_OUT="/tmp/plan-goal.json"
+
+  local PROMPT="You are a planning agent for the AdmitDay Next.js app at /home/agent/app. You have READ-ONLY access: explore the codebase with Read/Glob/Grep to ground your plan in reality.
+
+Owner's goal: ${GOAL}
+
+Break this goal into 1-5 SMALL, INDEPENDENT, individually testable GitHub issues. Each issue must be completable by one agent in one sitting, verifiable by 'npm test && npm run build', and must not depend on another issue in this batch being done first. Reference real file paths you verified exist. Never propose modifying data/schools.json.
+
+Output ONLY a JSON object, no markdown fences, in exactly this shape:
+{\"issues\": [{\"title\": \"...\", \"body\": \"...\"}]}
+Each body: what to change, where (file paths), and acceptance criteria."
+
+  run_claude "$PLAN_OUT" "" "Read,Glob,Grep"
+  local RC=$?
+  if [ $RC -ne 0 ]; then
+    telegram "Planner failed for goal: ${GOAL}"
+    log "Planner failed for goal: ${GOAL}"
+    rm -f "$PLAN_OUT"
+    return 1
+  fi
+
+  local CREATED
+  CREATED=$(GITHUB_TOKEN="$GITHUB_TOKEN" GITHUB_REPO="$GITHUB_REPO" TRIGGER_LABEL="$TRIGGER_LABEL" python3 - "$PLAN_OUT" << 'PYEOF'
+import json, sys, os, re, urllib.request
+
+try:
+    d = json.load(open(sys.argv[1]))
+    text = d.get('result', '') or ''
+except Exception:
+    sys.exit(1)
+
+m = re.search(r'\{.*\}', text, re.S)
+if not m:
+    sys.exit(1)
+try:
+    plan = json.loads(m.group(0))
+except Exception:
+    sys.exit(1)
+
+created = []
+for it in plan.get('issues', [])[:5]:
+    title = (it.get('title') or '').strip()
+    if not title:
+        continue
+    body = it.get('body') or ''
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{os.environ['GITHUB_REPO']}/issues",
+        data=json.dumps({'title': title, 'body': body,
+                         'labels': [os.environ['TRIGGER_LABEL']]}).encode(),
+        headers={'Authorization': f"token {os.environ['GITHUB_TOKEN']}",
+                 'Accept': 'application/vnd.github.v3+json'},
+        method='POST')
+    try:
+        with urllib.request.urlopen(req) as r:
+            num = json.load(r).get('number')
+            created.append(f"#{num} {title}")
+    except Exception:
+        created.append(f"FAILED to create: {title}")
+print('\n'.join(created))
+PYEOF
+)
+  rm -f "$PLAN_OUT"
+  if [ -n "$CREATED" ]; then
+    telegram "Planner created issues for goal '${GOAL}': ${CREATED}"
+    log "Planner created issues: ${CREATED}"
+  else
+    telegram "Planner produced no parseable issues for goal: ${GOAL}"
+    log "Planner produced no parseable issues for goal: ${GOAL}"
+  fi
+}
+
 handle_telegram_commands() {
   local OFFSET=0
   if [ -f "$OFFSET_FILE" ]; then
@@ -103,6 +334,11 @@ handle_telegram_commands() {
         telegram "Failed to create issue for: ${TITLE}"
         log "Failed to create issue via Telegram: ${TITLE}"
       fi
+    elif [[ "$TEXT" == /goal\ * ]]; then
+      local GOAL="${TEXT#/goal }"
+      log "Planning goal via Telegram: ${GOAL}"
+      telegram "Planning goal (read-only exploration, max 5 issues): ${GOAL}"
+      plan_goal "$GOAL"
     fi
   done < <(echo "$UPDATES" | python3 -c "
 import json, sys
@@ -112,62 +348,6 @@ for u in data.get('result', []):
     text = u.get('message', {}).get('text', '').replace('\t', ' ').replace('\n', ' ')
     print(f'{uid}\t{text}')
 ")
-}
-
-# Run one claude agent call with timeout, capturing session id and result text.
-# run_claude OUTPUT_JSON_FILE [RESUME_SESSION_ID] <<< prompt on stdin via $PROMPT env
-# Returns: 0 if claude ran and reported success, 1 on error, 124 on timeout.
-run_claude() {
-  local OUT_FILE="$1"
-  local RESUME_ID="$2"
-  local RESUME_ARGS=()
-  if [ -n "$RESUME_ID" ]; then
-    RESUME_ARGS=(--resume "$RESUME_ID")
-  fi
-  ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" timeout "$CLAUDE_TIMEOUT" claude \
-    -p "$PROMPT" \
-    --output-format json \
-    --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
-    "${RESUME_ARGS[@]}" \
-    > "$OUT_FILE" 2>> "$LOG_FILE"
-  local RC=$?
-  if [ $RC -eq 124 ]; then
-    return 124
-  fi
-  # Treat as success only if the JSON parses and is_error is false
-  python3 -c "
-import json,sys
-try:
-    d = json.load(open('$OUT_FILE'))
-    sys.exit(0 if not d.get('is_error') else 1)
-except Exception:
-    sys.exit(1)
-" && return 0 || return 1
-}
-
-claude_json_field() {
-  # claude_json_field FILE FIELD
-  python3 -c "
-import json,sys
-try:
-    d = json.load(open('$1'))
-    print(d.get('$2','') or '')
-except Exception:
-    pass
-"
-}
-
-# Coordinator-owned verification: the ONLY success signal.
-# Prunes the Next.js webpack cache afterwards — this VPS has very little free
-# disk and the cache alone is ~400MB.
-verify_app() {
-  local OUT="$1" RC=0
-  (cd "$APP_DIR" && npm test) > "$OUT" 2>&1 || RC=1
-  if [ $RC -eq 0 ]; then
-    (cd "$APP_DIR" && npm run build) >> "$OUT" 2>&1 || RC=1
-  fi
-  rm -rf "$APP_DIR/.next/cache"
-  return $RC
 }
 
 run_agent() {
@@ -214,6 +394,14 @@ except Exception:
   git checkout -b "$BRANCH" >> "$LOG_FILE" 2>&1
   rm -f "$CLAUDE_OUT" "$VERIFY_OUT"
 
+  local LESSONS_SECTION=""
+  if [ -s "$LESSONS_FILE" ]; then
+    LESSONS_SECTION="
+Lessons learned from previous tasks on this repo (follow them):
+$(cat "$LESSONS_FILE")
+"
+  fi
+
   local BRIEF="You are fixing a GitHub issue in the AdmitDay Next.js app.
 
 Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
@@ -222,13 +410,13 @@ ${ISSUE_BODY}
 
 Issue comments:
 ${ISSUE_COMMENTS}
-
+${LESSONS_SECTION}
 Instructions:
-- Work in /home/agent/app on branch ${BRANCH} (already checked out). Read /home/agent/app/CLAUDE.md first.
-- Fix the issue. Add tests for your change in __tests__/ (add, don't overwrite existing tests).
+- Work in /home/agent/app on branch ${BRANCH} (already checked out). If /home/agent/app/CLAUDE.md exists, read it first and follow its house rules.
+- Fix the issue. Stay strictly within its scope — an independent reviewer will reject scope creep. Add tests for your change in __tests__/ (add, don't overwrite existing tests).
 - Run 'cd /home/agent/app && npm test' and 'cd /home/agent/app && npm run build' and iterate until both are green.
-- Commit your work: cd /home/agent/app && git add -A && git commit -m \"${COMMIT_TITLE}\"
-- Never modify data/schools.json.
+- Commit your work: cd /home/agent/app && git add -A -- ':(exclude)LESSONS.md' && git commit -m \"${COMMIT_TITLE}\"
+- Never modify data/schools.json. Never commit LESSONS.md.
 - Never push, never merge, never switch branches.
 - You can send the owner a short progress update with: /home/agent/notify.sh \"message\"
 - End with a short summary of what you changed and why (it becomes the pull request description)."
@@ -236,6 +424,8 @@ Instructions:
   local ATTEMPT=1
   local SESSION_ID=""
   local SUCCESS=0
+  local FAIL_REASON=""
+  local REVIEW_TEXT=""
   local PROMPT="$BRIEF"
 
   while [ $ATTEMPT -le 2 ]; do
@@ -250,35 +440,57 @@ Instructions:
     fi
     [ -z "$SESSION_ID" ] && SESSION_ID=$(claude_json_field "$CLAUDE_OUT" "session_id")
 
+    FAIL_REASON=""
     # Objective verification by the coordinator — the only success signal.
-    # Also require that the branch actually differs from main.
     if [ $RC -eq 0 ] && verify_app "$VERIFY_OUT"; then
       cd "$APP_DIR"
-      # Fallback: commit anything the agent left uncommitted
-      if [ -n "$(git status --porcelain)" ]; then
-        git add -A && git commit -m "$COMMIT_TITLE" >> "$LOG_FILE" 2>&1
+      # Fallback: commit anything the agent left uncommitted (except LESSONS.md)
+      if [ -n "$(git status --porcelain -- ':(exclude)LESSONS.md')" ]; then
+        git add -A -- ':(exclude)LESSONS.md' && git commit -m "$COMMIT_TITLE" >> "$LOG_FILE" 2>&1
       fi
       if [ -n "$(git log origin/main..HEAD --oneline)" ]; then
-        SUCCESS=1
-        break
-      fi
-      log "Issue #${ISSUE_NUMBER}: verification passed but no changes were committed"
-    fi
+        # Independent reviewer pass (fresh context, issue + diff only)
+        log "Issue #${ISSUE_NUMBER}: verification green, running reviewer"
+        REVIEW_TEXT=$(review_change "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY")
+        local REVIEW_RC=$?
+        if [ $REVIEW_RC -eq 1 ]; then
+          FAIL_REASON="An independent reviewer examined your diff against the issue and REJECTED it:
 
-    if [ $ATTEMPT -lt 2 ]; then
+${REVIEW_TEXT}
+
+Address the reviewer's objections. Diagnose what is wrong before changing anything else."
+          log "Issue #${ISSUE_NUMBER}: reviewer rejected attempt ${ATTEMPT}"
+        else
+          [ $REVIEW_RC -eq 2 ] && log "Issue #${ISSUE_NUMBER}: reviewer unavailable, proceeding without review"
+          SUCCESS=1
+          break
+        fi
+      else
+        FAIL_REASON="Verification passed but no changes were committed on the branch. You must actually implement and commit the fix with: git add -A -- ':(exclude)LESSONS.md' && git commit -m \"${COMMIT_TITLE}\""
+        log "Issue #${ISSUE_NUMBER}: verification passed but no changes were committed"
+      fi
+    else
       local FAIL_TAIL
       FAIL_TAIL=$(tail -150 "$VERIFY_OUT" 2>/dev/null)
       [ -z "$FAIL_TAIL" ] && FAIL_TAIL="(the claude run itself failed or timed out before verification; check your previous work for incomplete edits)"
-      PROMPT="Verification failed. The coordinator ran 'npm test && npm run build' after your changes and it did not pass, or no changes were committed.
+      FAIL_REASON="The coordinator ran 'npm test && npm run build' after your changes and it did not pass.
 
 Failing output (tail):
 ${FAIL_TAIL}
 
 Diagnose why this failed before changing anything else. Then fix it, re-run npm test and npm run build until green, and commit with message \"${COMMIT_TITLE}\"."
-      log "Issue #${ISSUE_NUMBER}: attempt ${ATTEMPT} failed verification, retrying with session resume"
+    fi
+
+    if [ $ATTEMPT -lt 2 ]; then
+      PROMPT="$FAIL_REASON"
+      log "Issue #${ISSUE_NUMBER}: attempt ${ATTEMPT} failed, retrying with session resume"
     fi
     ATTEMPT=$((ATTEMPT + 1))
   done
+
+  # Capture the diff for the retrospective before any branch cleanup
+  local TASK_DIFF
+  TASK_DIFF=$(cd "$APP_DIR" && git diff origin/main...HEAD | head -c 20000)
 
   if [ $SUCCESS -eq 1 ]; then
     local SUMMARY
@@ -295,7 +507,7 @@ Closes #${ISSUE_NUMBER}"
     if [ -n "$PR_URL" ]; then
       github_comment "$ISSUE_NUMBER" "Agent opened a pull request for this issue: ${PR_URL}
 
-Tests and build verified green by the coordinator. Please review and merge."
+Tests and build verified green by the coordinator, and an independent reviewer approved the diff. Please review and merge."
       github_label "$ISSUE_NUMBER" "pr-open"
       github_remove_label "$ISSUE_NUMBER" "in-progress"
       log "Issue #${ISSUE_NUMBER}: PR opened at ${PR_URL}"
@@ -307,11 +519,16 @@ Tests and build verified green by the coordinator. Please review and merge."
       telegram "Issue #${ISSUE_NUMBER}: branch ${BRANCH} pushed but PR creation FAILED — needs manual attention"
     fi
     git checkout main >> "$LOG_FILE" 2>&1
+    run_retrospective "$ISSUE_NUMBER" "$ISSUE_TITLE" "SUCCESS — PR opened after ${ATTEMPT} attempt(s)" "$TASK_DIFF"
   else
     local FAIL_OUTPUT
     FAIL_OUTPUT=$(tail -100 "$VERIFY_OUT" 2>/dev/null)
     [ -z "$FAIL_OUTPUT" ] && FAIL_OUTPUT="(no verification output — the claude run failed or timed out)"
-    github_comment "$ISSUE_NUMBER" "Agent could not resolve this issue after 2 attempts. Coordinator verification (npm test && npm run build) failed.
+    [ -n "$REVIEW_TEXT" ] && FAIL_OUTPUT="${FAIL_OUTPUT}
+
+Reviewer feedback on the final attempt:
+${REVIEW_TEXT}"
+    github_comment "$ISSUE_NUMBER" "Agent could not resolve this issue after 2 attempts.
 
 <details><summary>Failure output (tail)</summary>
 
@@ -327,6 +544,7 @@ ${FAIL_OUTPUT}
     git branch -D "$BRANCH" 2>/dev/null
     log "Issue #${ISSUE_NUMBER}: failed after 2 attempts, labeled needs-review"
     telegram "Failed after 2 attempts: issue #${ISSUE_NUMBER}: ${ISSUE_TITLE} — labeled needs-review, branch deleted"
+    run_retrospective "$ISSUE_NUMBER" "$ISSUE_TITLE" "FAILURE — 2 attempts exhausted (verification or review failed)" "$TASK_DIFF"
   fi
 
   rm -f "$CLAUDE_OUT" "$VERIFY_OUT"
@@ -345,7 +563,7 @@ curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" 
 NOTIFY
 chmod +x /home/agent/notify.sh
 
-telegram "Coordinator started, watching for ${TRIGGER_LABEL} issues (PR flow — never pushes to main)"
+telegram "Coordinator started, watching for ${TRIGGER_LABEL} issues (PR flow — never pushes to main). Commands: /issue <title>, /goal <goal>"
 
 while true; do
   handle_telegram_commands


### PR DESCRIPTION
## Agent coordinator upgrade

Rewrites the autonomous coding agent coordinator:

- **PR flow, not merge-to-main**: on success the coordinator pushes the task branch and opens a PR for human review. It never merges and never pushes to main. Old deploy-build/pm2-restart steps removed (app deploys via Vercel).
- **Objective verification**: the coordinator itself runs `npm test && npm run build` after the agent finishes; both must exit 0. The agent-written summary is only used as PR body text.
- **Bounded retry with session resume**: each claude call runs under a 30-minute timeout with `--output-format json` to capture the session ID. One retry via `--resume` with the failing output; after 2 failures the issue is labeled `needs-review` with the failure output and the branch is deleted.
- **Trigger label** changed from `todo` to `agent-ok` — nothing is picked up unless deliberately labeled.
- **Better inner-agent context**: issue comments are fetched and included; the rigid 7-phase prompt is replaced by a short brief plus repo house rules in `CLAUDE.md`.
- All `/root` paths moved to `/home/agent`; GitHub API calls follow redirects (`-L`); repo rename to `neinna/AdmitDay` reflected in config.
- Coordinator prunes `.next/cache` after each verification (VPS disk is nearly full).

Do not merge without review — the running coordinator on the VPS is already the updated copy; this PR is for tracking and review.