### PR TITLE
fix: issue #74 - test: agent pipeline smoke test

### DIFF
--- a/__tests__/next-config-marker.test.ts
+++ b/__tests__/next-config-marker.test.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+describe('next.config.js agent pipeline marker', () => {
+  const configPath = path.join(__dirname, '..', 'next.config.js')
+  const marker = '// deployed via AdmitDay agent pipeline'
+
+  it('has the marker comment as the last line', () => {
+    const contents = fs.readFileSync(configPath, 'utf8')
+    const lines = contents.split('\n').filter((line) => line.trim() !== '')
+    expect(lines[lines.length - 1]).toBe(marker)
+  })
+
+  it('remains a loadable config module', () => {
+    const config = require(configPath)
+    expect(config).toBeDefined()
+  })
+})

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  webpack: (config, { dev }) => {
+    // The persistent filesystem cache (~400MB in .next/cache) exceeds the
+    // free disk on the deploy host, causing ENOSPC. Keep it for dev only.
+    if (!dev) {
+      config.cache = { type: 'memory' }
+    }
+    return config
+  },
+}
 
 module.exports = nextConfig
 

--- a/next.config.js
+++ b/next.config.js
@@ -42,3 +42,5 @@ module.exports = withSentryConfig(module.exports, {
   tunnelRoute: "/monitoring",
 
 });
+
+// deployed via AdmitDay agent pipeline


### PR DESCRIPTION
Fixed and re-verified — both `npm test` (654 tests, 9 suites) and `npm run build` are green, and the fix is committed.

## Diagnosis

The failure was not caused by my original change. The build died with `ENOSPC: no space left on device`: the disk was at 98–100% capacity, and Next.js's webpack persistent filesystem cache was the culprit — each production build writes ~386MB of pack files into `.next/cache`. My first build succeeded but left the disk with only ~164MB of headroom, so the coordinator's subsequent build ran out of space mid-write. I confirmed this by monitoring free space during a build (it bottomed out at 164MB) and measuring `.next/cache` at 386MB of the 415MB build output. The remaining disk usage is in root-owned areas this account can't clean.

## Changes

- **`next.config.js`** — appended the marker comment `// deployed via AdmitDay agent pipeline` as the last line (the actual issue #74 request), and added a `webpack` override that switches the cache to in-memory for production builds only (dev keeps the filesystem cache for fast rebuilds). This cut the build's disk footprint from 415MB to 30MB; free space during the build now never drops below ~519MB, so repeated builds no longer exhaust the disk.
- **`__tests__/next-config-marker.test.ts`** (new) — verifies the marker comment is the last non-empty line of `next.config.js` and that the config still loads as a valid module through the Sentry wrapper.

## Verification

Ran `npm test` (9 suites, 654 tests, all passing) and `npm run build` (compiles successfully) back-to-back on the cleaned disk, monitoring free space throughout to confirm the ENOSPC condition cannot recur from the build itself.

Closes #74