### PR TITLE
fix: issue #76 - test: agent pipeline smoke test 2 (phase 2)

### DIFF
--- a/__tests__/next-config-comment.test.ts
+++ b/__tests__/next-config-comment.test.ts
@@ -1,0 +1,13 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+// ── Issue #76: agent pipeline smoke test comment in next.config.js ──────────
+
+describe('next.config.js pipeline comment', () => {
+  const configSource = fs.readFileSync(path.join(__dirname, '../next.config.js'), 'utf-8')
+
+  it('ends with the AdmitDay agent pipeline comment as the last line', () => {
+    const lines = configSource.trimEnd().split('\n')
+    expect(lines[lines.length - 1]).toBe('// deployed via AdmitDay agent pipeline')
+  })
+})

--- a/next.config.js
+++ b/next.config.js
@@ -42,3 +42,4 @@ module.exports = withSentryConfig(module.exports, {
   tunnelRoute: "/monitoring",
 
 });
+// deployed via AdmitDay agent pipeline


### PR DESCRIPTION
Done. Both `npm test` (653 tests, 9 suites) and `npm run build` are green, and the work is committed on `task-76-test-agent-pipeline-smoke-test`.

## Summary

Issue #76 asked for a single change: append the comment `// deployed via AdmitDay agent pipeline` as the last line of `next.config.js`.

- **`next.config.js`** — added the comment as the final line, after the Sentry `withSentryConfig` block. No other changes to the config.
- **`__tests__/next-config-comment.test.ts`** — new test file (existing tests untouched) that reads `next.config.js` and asserts its last non-empty line is exactly the pipeline comment, following the same source-file-assertion pattern used by other tests in the suite.

Closes #76