### PR TITLE
fix: in-memory webpack cache for production builds (avoid ENOSPC)

### DIFF
--- a/__tests__/next-config.test.ts
+++ b/__tests__/next-config.test.ts
@@ -1,0 +1,21 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+// ── next.config.js: in-memory webpack cache for production builds ────────────
+// The VPS agent verification host has limited free disk; Next.js's default
+// ~400MB filesystem cache in .next/cache caused ENOSPC during production
+// builds. Production builds use an in-memory cache instead. These tests pin
+// that fix (source-level, to avoid invoking the Sentry-wrapped webpack fn).
+
+describe('next.config.js production build cache', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../next.config.js'), 'utf8')
+
+  it('loads as a config module', () => {
+    expect(require('../next.config.js')).toBeDefined()
+  })
+
+  it('uses an in-memory webpack cache for production builds (avoids ENOSPC)', () => {
+    expect(source).toContain("config.cache = { type: 'memory' }")
+    expect(source).toMatch(/if \(!dev\)/)
+  })
+})

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,16 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  webpack: (config, { dev }) => {
+    // The persistent filesystem cache (~400MB in .next/cache) can exceed the
+    // free disk on the VPS build host, causing ENOSPC during agent verification
+    // builds. Use an in-memory cache for production builds; keep the fast disk
+    // cache for local dev.
+    if (!dev) {
+      config.cache = { type: 'memory' }
+    }
+    return config
+  },
+}
 
 module.exports = nextConfig
 


### PR DESCRIPTION
## What

Production builds now use an in-memory webpack cache instead of the default ~400MB filesystem cache in `.next/cache`.

## Why

The VPS agent-verification host has limited free disk; the persistent cache caused `ENOSPC` during production builds. Dev keeps the fast disk cache. Harmless on Vercel (ephemeral build containers).

## Provenance

This is the one real change from the #74 agent-pipeline smoke test ([#75](https://github.com/neinna/AdmitDay/pull/75)), extracted into a clean commit. The smoke PRs ([#75](https://github.com/neinna/AdmitDay/pull/75), [#77](https://github.com/neinna/AdmitDay/pull/77)) also added a cosmetic `// deployed via AdmitDay agent pipeline` marker and a test pinning that comment — dropped here as pipeline-test cruft. The smoke tests validated the pipeline end-to-end and are being closed.

Test: `__tests__/next-config.test.ts` pins the fix (source-level, to avoid invoking the Sentry-wrapped webpack fn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)