### PR TITLE
fix: issue #80 - Migrate school data to Postgres (fixes production /list showing 0 schools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The filter page and the chat page do not share state or hand off to each other. 
 - **Frontend:** Next.js, Tailwind CSS
 - **AI:** Claude API (Anthropic) for generation, grounding prompts to prevent hallucination
 - **RAG pipeline:** Built from scratch. Data ingestion, semantic chunking (identity/academics/activities splits per school), in-memory vector search, chat API route
-- **Data:** 457 NYC public high schools scraped and structured from DOE sources
+- **Data:** 457 NYC public high schools scraped and structured from DOE sources. After re-scraping, run the seed script (`npx ts-node scripts/seed-schools.ts`) to push `data/schools.json` into Postgres.
 - **Observability:** Sentry (error tracking), PostHog (product analytics)
 - **Deployment:** DigitalOcean VPS, PM2 process manager, GitHub Actions CI/CD
 - **Coding agent:** Autonomous agent (agent-coordinator.sh) watches GitHub Issues labeled `todo`, runs Claude Code, commits on success, notifies via Telegram

--- a/__tests__/load-schools.test.ts
+++ b/__tests__/load-schools.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for lib/load-schools.ts — getAllSchools().
+ *
+ * @vercel/postgres is mocked: these tests (and CI) run with no live database
+ * and no POSTGRES_URL.
+ */
+
+import { School } from '@/types'
+
+const mockSql = jest.fn()
+
+jest.mock('@vercel/postgres', () => ({
+  sql: (...args: unknown[]) => mockSql(...args),
+}))
+
+const schoolA = { dbn: '02M475', name: 'Stuyvesant High School' } as School
+const schoolB = { dbn: '13K430', name: 'Brooklyn Technical High School' } as School
+
+// getAllSchools caches in module state, so each test gets a fresh module copy.
+async function freshGetAllSchools() {
+  jest.resetModules()
+  const mod = await import('@/lib/load-schools')
+  return mod.getAllSchools
+}
+
+// The mocked sql is a tagged template: first arg is the template strings array.
+function queryText(callArgs: unknown[]): string {
+  return (callArgs[0] as string[]).join('')
+}
+
+beforeEach(() => {
+  mockSql.mockReset()
+})
+
+describe('getAllSchools', () => {
+  it('returns the parsed data column of every row', async () => {
+    mockSql.mockImplementation((strings: string[]) =>
+      strings.join('').includes('SELECT data FROM schools')
+        ? Promise.resolve({ rows: [{ data: schoolA }, { data: schoolB }] })
+        : Promise.resolve({ rows: [] })
+    )
+    const getAllSchools = await freshGetAllSchools()
+
+    const schools = await getAllSchools()
+    expect(schools).toEqual([schoolA, schoolB])
+
+    // Schema was created before querying
+    const queries = mockSql.mock.calls.map((c) => queryText(c))
+    expect(queries.some((q) => q.includes('CREATE TABLE IF NOT EXISTS schools'))).toBe(true)
+  })
+
+  it('returns [] when the table is empty', async () => {
+    mockSql.mockResolvedValue({ rows: [] })
+    const getAllSchools = await freshGetAllSchools()
+
+    await expect(getAllSchools()).resolves.toEqual([])
+  })
+
+  it('returns [] instead of throwing when the DB is unreachable', async () => {
+    mockSql.mockRejectedValue(new Error('missing_connection_string'))
+    const getAllSchools = await freshGetAllSchools()
+
+    await expect(getAllSchools()).resolves.toEqual([])
+  })
+
+  it('caches a non-empty result so repeated calls do not re-query', async () => {
+    mockSql.mockResolvedValue({ rows: [{ data: schoolA }] })
+    const getAllSchools = await freshGetAllSchools()
+
+    await getAllSchools()
+    const callsAfterFirst = mockSql.mock.calls.length
+    const again = await getAllSchools()
+
+    expect(again).toEqual([schoolA])
+    expect(mockSql.mock.calls.length).toBe(callsAfterFirst)
+  })
+
+  it('retries after a failure instead of pinning the error state', async () => {
+    mockSql.mockRejectedValueOnce(new Error('connection refused'))
+    mockSql.mockResolvedValue({ rows: [{ data: schoolA }] })
+    const getAllSchools = await freshGetAllSchools()
+
+    await expect(getAllSchools()).resolves.toEqual([])
+    await expect(getAllSchools()).resolves.toEqual([schoolA])
+  })
+})

--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -1379,8 +1379,9 @@ describe('Issue #39: requirements page.tsx is a server component', () => {
     expect(pageSource).not.toContain("'use client'")
   })
 
-  it('imports fs for server-side file reading', () => {
-    expect(pageSource).toContain("import fs from 'fs'")
+  it('loads school data server-side via getAllSchools (issue #80: Postgres, not fs)', () => {
+    expect(pageSource).toContain("import { getAllSchools } from '@/lib/load-schools'")
+    expect(pageSource).not.toContain("import fs from 'fs'")
   })
 
   it('exports ReqSection type for client component', () => {

--- a/app/list/page.tsx
+++ b/app/list/page.tsx
@@ -1,5 +1,3 @@
-import fs from 'fs'
-import path from 'path'
 import Link from 'next/link'
 import SchoolList from '@/components/SchoolList'
 import ViewRequirementsLink from '@/components/ViewRequirementsLink'
@@ -11,6 +9,7 @@ import {
   selectSHSATSchools,
   groupSchools,
 } from '@/lib/school-list-utils'
+import { getAllSchools } from '@/lib/load-schools'
 
 // ── Input parsing ────────────────────────────────────────────────────────────
 
@@ -53,14 +52,7 @@ export default async function ListPage({
 }) {
   const inputs = parseInputs(searchParams)
 
-  let allSchools: School[] = []
-  try {
-    const filePath = path.join(process.cwd(), 'data', 'schools.json')
-    const raw = fs.readFileSync(filePath, 'utf-8')
-    allSchools = JSON.parse(raw)
-  } catch {
-    // schools.json not yet present
-  }
+  const allSchools = await getAllSchools()
 
   const { results: baseResults } = getResults(allSchools, inputs)
 

--- a/app/requirements/page.tsx
+++ b/app/requirements/page.tsx
@@ -1,5 +1,3 @@
-import fs from 'fs'
-import path from 'path'
 import { School, UserInputs, SectionType } from '@/types'
 import RequirementsContent from './RequirementsContent'
 import {
@@ -12,6 +10,7 @@ import {
   sortBySize,
   groupSchools,
 } from '@/lib/school-list-utils'
+import { getAllSchools } from '@/lib/load-schools'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -131,14 +130,7 @@ export default async function RequirementsPage({
 }) {
   const inputs = parseInputs(searchParams)
 
-  let allSchools: School[] = []
-  try {
-    const filePath = path.join(process.cwd(), 'data', 'schools.json')
-    const raw = fs.readFileSync(filePath, 'utf-8')
-    allSchools = JSON.parse(raw)
-  } catch {
-    // schools.json not yet present
-  }
+  const allSchools = await getAllSchools()
 
   // SHSAT: use same selectSHSATSchools logic as list page
   let shsatSelected: School[] = []

--- a/lib/load-schools.ts
+++ b/lib/load-schools.ts
@@ -1,0 +1,48 @@
+import { sql } from '@vercel/postgres'
+import { School } from '@/types'
+
+// School data lives in Vercel Postgres (same Neon store as SHSAT results in
+// lib/shsat-db.ts). data/schools.json is gitignored scraped output, so it never
+// reaches Vercel deploys — the schools table is seeded manually from it via
+// scripts/seed-schools.ts after each scrape.
+
+// Create the table once per cold start. The guard promise dedupes concurrent
+// calls; on failure it resets so the next request can retry.
+let schemaReady: Promise<void> | null = null
+
+function ensureSchema(): Promise<void> {
+  if (!schemaReady) {
+    schemaReady = (async () => {
+      await sql`
+        CREATE TABLE IF NOT EXISTS schools (
+          dbn   TEXT PRIMARY KEY,
+          data  JSONB
+        )
+      `
+    })().catch((err) => {
+      schemaReady = null
+      throw err
+    })
+  }
+  return schemaReady
+}
+
+// Cached per lambda so repeated calls in the same instance don't re-query.
+// Only non-empty results are cached, so an empty table or a transient DB
+// failure doesn't pin [] for the lifetime of the lambda.
+let cachedSchools: School[] | null = null
+
+export async function getAllSchools(): Promise<School[]> {
+  if (cachedSchools) return cachedSchools
+  try {
+    await ensureSchema()
+    const { rows } = await sql<{ data: School }>`SELECT data FROM schools`
+    const schools = rows.map((row) => row.data)
+    if (schools.length > 0) cachedSchools = schools
+    return schools
+  } catch {
+    // No DB / connection hiccup: return [] so the pages render their
+    // "School data not yet loaded on the server" banner instead of crashing.
+    return []
+  }
+}

--- a/scripts/seed-schools.ts
+++ b/scripts/seed-schools.ts
@@ -1,0 +1,71 @@
+/**
+ * seed-schools.ts
+ *
+ * Seeds the Vercel Postgres (Neon) `schools` table from local scraped data.
+ * Reads data/schools.json and upserts every record keyed by DBN, so the
+ * production /list and /requirements pages can load school data from the
+ * database instead of the gitignored JSON file.
+ *
+ * Run manually after each scrape (requires production DB credentials):
+ *   npx ts-node scripts/seed-schools.ts
+ *
+ * Requires: POSTGRES_URL in .env.local
+ */
+
+import fs from "fs";
+import path from "path";
+import dotenv from "dotenv";
+
+// Load env vars from .env.local
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+
+import { sql } from "@vercel/postgres";
+
+interface School {
+  dbn: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+async function main() {
+  // Load schools
+  const schoolsPath = path.resolve(process.cwd(), "data", "schools.json");
+  if (!fs.existsSync(schoolsPath)) {
+    console.error("data/schools.json not found.");
+    process.exit(1);
+  }
+
+  const schools: School[] = JSON.parse(fs.readFileSync(schoolsPath, "utf-8"));
+  console.log(`Loaded ${schools.length} schools from ${schoolsPath}.`);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS schools (
+      dbn   TEXT PRIMARY KEY,
+      data  JSONB
+    )
+  `;
+
+  let upserted = 0;
+  for (const school of schools) {
+    if (!school.dbn) {
+      console.warn(`Skipping record with no dbn: ${school.name ?? "(unnamed)"}`);
+      continue;
+    }
+    await sql`
+      INSERT INTO schools (dbn, data)
+      VALUES (${school.dbn}, ${JSON.stringify(school)})
+      ON CONFLICT (dbn) DO UPDATE SET data = EXCLUDED.data
+    `;
+    upserted++;
+    if (upserted % 50 === 0) {
+      console.log(`Upserted ${upserted}/${schools.length}...`);
+    }
+  }
+
+  console.log(`Done. Upserted ${upserted} schools into the schools table.`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Issue #80 is complete and committed on `task-80-migrate-school-data-to-postgre`. All 662 tests pass and `npm run build` succeeds with no `POSTGRES_URL` set.

## Summary

Production `/list` and `/requirements` showed 0 schools because `data/schools.json` is gitignored and never reaches Vercel. School data now loads from Vercel Postgres (the same Neon store as SHSAT results).

**What changed:**

- **`lib/load-schools.ts` (new)** — exports `getAllSchools(): Promise<School[]>`. Mirrors the `ensureSchema()` guard-promise pattern from `lib/shsat-db.ts` (creates `schools (dbn TEXT PRIMARY KEY, data JSONB)` once per cold start, resetting on failure so the next request retries). Runs `SELECT data FROM schools` and caches non-empty results in a module-level variable so repeated calls in the same lambda don't re-query; an empty table or transient DB failure is deliberately not cached, so it can recover. On empty table or any DB error it returns `[]` — never throws — preserving the existing "School data not yet loaded on the server" banner instead of white-screening.
- **`scripts/seed-schools.ts` (new)** — structured like `scripts/embed-schools.ts` (dotenv from `.env.local`, `npx ts-node`). Reads `data/schools.json` and upserts each record via `INSERT ... ON CONFLICT (dbn) DO UPDATE SET data = EXCLUDED.data`. Not run by the agent — a human runs it against Neon after each scrape.
- **`app/list/page.tsx` / `app/requirements/page.tsx`** — replaced the `fs.readFileSync('data/schools.json')` block with `const allSchools = await getAllSchools()` and removed the now-unused `fs`/`path` imports. Both pages stay dynamic (they read `searchParams`), so the query runs at request time. No filtering logic touched.
- **`README.md`** — one-line note: after re-scraping, run the seed script to push `data/schools.json` into Postgres.
- **`__tests__/load-schools.test.ts` (new)** — 5 tests with `@vercel/postgres` fully mocked (no DB/`POSTGRES_URL` needed in CI): returns row data, empty-table → `[]`, DB error → `[]` without throwing, non-empty result cached (no re-query), and retry-after-failure works.
- **`__tests__/schools.test.ts`** — one necessary assertion update: an issue #39 test asserted the requirements page contains `import fs from 'fs'`, which directly contradicts this issue's requirement to remove that import — both couldn't stay true. I updated that single test (kept, not deleted) to assert the equivalent new behavior: the page loads data server-side via `getAllSchools` and no longer imports `fs`. Everything else in the file, including the root-`schools.json` data assertions, is untouched.

**Post-merge (human step):** run `npx ts-node scripts/seed-schools.ts` with production `POSTGRES_URL` in `.env.local`, then verify `admitday.com/list` returns schools.

Closes #80