### PR TITLE
fix: issue #82 - Rate-limit /api/chat and /api/rationale (per-IP, in-memory stopgap)

### DIFF
--- a/__tests__/rate-limit.test.ts
+++ b/__tests__/rate-limit.test.ts
@@ -1,0 +1,93 @@
+/**
+ * __tests__/rate-limit.test.ts
+ *
+ * Unit tests for the in-memory per-IP rate limiter (issue #82).
+ * Uses fake timers so window resets need no real waiting, and a minimal
+ * fake NextRequest (headers.get shim) — no real server.
+ */
+
+import type { NextRequest } from 'next/server'
+import { checkRateLimit, MAX_REQUESTS, WINDOW_MS } from '@/lib/rate-limit'
+
+function fakeRequest(ip?: string): NextRequest {
+  return {
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'x-forwarded-for' && ip ? ip : null,
+    },
+  } as unknown as NextRequest
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+describe('checkRateLimit (issue #82)', () => {
+  it('allows up to MAX_REQUESTS requests from one IP within the window', () => {
+    jest.setSystemTime(1_000_000)
+    const req = fakeRequest('1.2.3.4')
+    for (let i = 0; i < MAX_REQUESTS; i++) {
+      expect(checkRateLimit(req)).toEqual({ ok: true })
+    }
+  })
+
+  it('blocks the request after the limit with a positive retryAfterSec', () => {
+    jest.setSystemTime(2_000_000)
+    const req = fakeRequest('2.3.4.5')
+    for (let i = 0; i < MAX_REQUESTS; i++) {
+      checkRateLimit(req)
+    }
+    const result = checkRateLimit(req)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.retryAfterSec).toBeGreaterThan(0)
+      expect(result.retryAfterSec).toBeLessThanOrEqual(WINDOW_MS / 1000)
+    }
+  })
+
+  it('allows requests again after the window elapses', () => {
+    jest.setSystemTime(3_000_000)
+    const req = fakeRequest('3.4.5.6')
+    for (let i = 0; i < MAX_REQUESTS; i++) {
+      checkRateLimit(req)
+    }
+    expect(checkRateLimit(req).ok).toBe(false)
+
+    jest.setSystemTime(3_000_000 + WINDOW_MS)
+    expect(checkRateLimit(req)).toEqual({ ok: true })
+  })
+
+  it('tracks limits per IP — a different x-forwarded-for is independent', () => {
+    jest.setSystemTime(4_000_000)
+    const first = fakeRequest('4.5.6.7')
+    for (let i = 0; i < MAX_REQUESTS; i++) {
+      checkRateLimit(first)
+    }
+    expect(checkRateLimit(first).ok).toBe(false)
+
+    const second = fakeRequest('5.6.7.8')
+    expect(checkRateLimit(second)).toEqual({ ok: true })
+  })
+
+  it('uses the first entry of a multi-hop x-forwarded-for header', () => {
+    jest.setSystemTime(5_000_000)
+    const direct = fakeRequest('6.7.8.9')
+    const proxied = fakeRequest('6.7.8.9, 10.0.0.1')
+    for (let i = 0; i < MAX_REQUESTS; i++) {
+      checkRateLimit(direct)
+    }
+    expect(checkRateLimit(proxied).ok).toBe(false)
+  })
+
+  it('falls back to a shared "unknown" bucket when the header is missing', () => {
+    jest.setSystemTime(6_000_000)
+    for (let i = 0; i < MAX_REQUESTS; i++) {
+      checkRateLimit(fakeRequest())
+    }
+    expect(checkRateLimit(fakeRequest()).ok).toBe(false)
+  })
+})

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -10,10 +10,19 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { NextRequest } from "next/server";
 import { searchSchools } from "@/lib/rag";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 export async function POST(request: NextRequest) {
+  const rl = checkRateLimit(request);
+  if (!rl.ok) {
+    return Response.json(
+      { error: "You're sending requests too quickly — please wait a moment and try again." },
+      { status: 429, headers: { "Retry-After": String(rl.retryAfterSec) } },
+    );
+  }
+
   const { question } = await request.json();
 
   if (!question || typeof question !== "string") {

--- a/app/api/rationale/route.ts
+++ b/app/api/rationale/route.ts
@@ -1,9 +1,18 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { NextRequest } from 'next/server'
+import { checkRateLimit } from '@/lib/rate-limit'
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
 
 export async function POST(request: NextRequest) {
+  const rl = checkRateLimit(request)
+  if (!rl.ok) {
+    return Response.json(
+      { error: "You're sending requests too quickly — please wait a moment and try again." },
+      { status: 429, headers: { 'Retry-After': String(rl.retryAfterSec) } },
+    )
+  }
+
   const { school, userInputs } = await request.json()
 
   const schoolCtx = [

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -38,6 +38,15 @@ export default function ChatPage() {
         body: JSON.stringify({ question: trimmed }),
       })
 
+      if (res.status === 429) {
+        const data = await res.json().catch(() => null)
+        setError(
+          data?.error ??
+            "You're sending requests too quickly — please wait a moment and try again."
+        )
+        return
+      }
+
       if (!res.ok) {
         throw new Error(`Request failed (${res.status})`)
       }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,65 @@
+/**
+ * lib/rate-limit.ts
+ *
+ * In-memory, per-IP fixed-window rate limiter for the unauthenticated
+ * LLM-backed API routes (/api/chat, /api/rationale).
+ *
+ * NOTE: This is a deliberate stopgap. Vercel lambdas do not share memory,
+ * so the limit is per-instance rather than global — it caps runaway loops
+ * against a warm instance but is not a hard global cap. The future upgrade
+ * is a durable KV-backed limiter (Upstash / Vercel KV), which needs
+ * provisioning and secrets we don't add here.
+ */
+
+import type { NextRequest } from 'next/server'
+
+export const MAX_REQUESTS = 15
+export const WINDOW_MS = 60_000
+
+interface WindowEntry {
+  count: number
+  windowStart: number
+}
+
+const buckets = new Map<string, WindowEntry>()
+
+function getClientIp(request: NextRequest): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown'
+  )
+}
+
+/** Drop entries whose window has already elapsed so the Map stays bounded. */
+function pruneExpired(now: number): void {
+  buckets.forEach((entry, ip) => {
+    if (now - entry.windowStart >= WINDOW_MS) {
+      buckets.delete(ip)
+    }
+  })
+}
+
+export function checkRateLimit(
+  request: NextRequest
+): { ok: true } | { ok: false; retryAfterSec: number } {
+  const now = Date.now()
+  pruneExpired(now)
+
+  const ip = getClientIp(request)
+  const entry = buckets.get(ip)
+
+  if (!entry || now - entry.windowStart >= WINDOW_MS) {
+    buckets.set(ip, { count: 1, windowStart: now })
+    return { ok: true }
+  }
+
+  if (entry.count < MAX_REQUESTS) {
+    entry.count++
+    return { ok: true }
+  }
+
+  const retryAfterSec = Math.max(
+    1,
+    Math.ceil((entry.windowStart + WINDOW_MS - now) / 1000)
+  )
+  return { ok: false, retryAfterSec }
+}


### PR DESCRIPTION
Done — committed as `ede4893` on `task-82-rate-limit-apichat-and-apirati`, with `npm test` (668 tests, 11 suites) and `npm run build` both passing.

## Summary

`POST /api/chat` and `POST /api/rationale` are unauthenticated and trigger paid LLM calls (OpenAI embedding + Anthropic completion for chat, Anthropic completion for rationale), so a bot loop was direct cost exposure. This adds a per-IP rate limit as an in-memory stopgap, per the issue's no-new-infrastructure constraint.

**`lib/rate-limit.ts` (new)** — exports `checkRateLimit(request)` returning `{ ok: true }` or `{ ok: false, retryAfterSec }`. Fixed-window limiter (`MAX_REQUESTS = 15`, `WINDOW_MS = 60_000`) keyed by the first `x-forwarded-for` entry (falls back to `'unknown'`), stored in a module-level `Map` that prunes expired windows on every call so it stays bounded. Reads the clock via `Date.now()` so tests can use fake timers. A code comment documents that this is per-instance on Vercel (lambdas don't share memory) and that a KV-backed limiter (Upstash / Vercel KV) is the future upgrade.

**Route wiring** — both `POST` handlers call `checkRateLimit` as their first statement, before parsing the body or any LLM call, and return a 429 with a friendly error message and a `Retry-After` header when blocked.

**Chat UI** — `handleSubmit` in `app/chat/page.tsx` now handles `res.status === 429` explicitly: it reads the server's `error` message (with a fallback if the body isn't JSON) into the existing error banner and returns, instead of throwing the generic "Request failed" error. All other statuses behave as before.

**Tests** — new `__tests__/rate-limit.test.ts` (no existing tests touched) uses a minimal fake `NextRequest` (`headers.get` shim) and `jest.useFakeTimers()` to cover: allows up to the limit, blocks the 16th request with a positive bounded `retryAfterSec`, allows again once the window elapses, per-IP independence, first-hop parsing of multi-hop `x-forwarded-for`, and the shared `'unknown'` bucket when the header is missing.

One iteration was needed: the repo's ES5 TypeScript target rejects `for...of` over a `Map`, so the prune loop uses `Map.forEach` instead.

Closes #82