### PR TITLE
fix: issue #84 - Hide the unbuilt "Full Access" paid-tier UI (UI-only, no accounts)

### DIFF
--- a/__tests__/requirements-hydration.test.ts
+++ b/__tests__/requirements-hydration.test.ts
@@ -37,7 +37,8 @@ describe('RequirementsContent hydration guard', () => {
   it('uses displayChecked for SVG checkmark in renderItems', () => {
     // All 4 uses of item.id lookup in renderItems should use displayChecked
     const renderItemsStart = src.indexOf('function renderItems(')
-    const renderItemsEnd = src.indexOf('\n  function LockBanner', renderItemsStart)
+    // renderItems is the last helper before the component's return (LockBanner removed in #84)
+    const renderItemsEnd = src.indexOf('\n  return (', renderItemsStart)
     const renderItemsBody = src.slice(renderItemsStart, renderItemsEnd)
 
     const displayCheckedUses = (renderItemsBody.match(/displayChecked\[item\.id\]/g) ?? []).length

--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -318,17 +318,17 @@ describe('Issue #9: Jest setup in package.json', () => {
   })
 })
 
-// ── Issue #12: Locked paid tier placeholders ─────────────────────────────────
+// ── Issue #12/#84: Locked paid tier placeholders (removed in #84) ────────────
 
-describe('Issue #12: SchoolList locked expand placeholder', () => {
+describe('Issue #12/#84: SchoolList locked expand placeholder removed', () => {
   const schoolListSource = fs.readFileSync(path.join(__dirname, '../components/SchoolList.tsx'), 'utf-8')
 
-  it('shows a lock icon SVG when more schools exist beyond visible count', () => {
-    expect(schoolListSource).toContain('M12 15v2m-6 4h12')
+  it('does NOT show a lock icon SVG (locked UI removed in #84)', () => {
+    expect(schoolListSource).not.toContain('M12 15v2m-6 4h12')
   })
 
-  it('shows "Full Access" label in the expand area', () => {
-    expect(schoolListSource).toContain('Full Access')
+  it('does NOT show "Full Access" label (locked UI removed in #84)', () => {
+    expect(schoolListSource).not.toContain('Full Access')
   })
 
   it('does NOT show "coming soon" label in the expand area', () => {
@@ -339,31 +339,26 @@ describe('Issue #12: SchoolList locked expand placeholder', () => {
     expect(schoolListSource).not.toContain('>Load 15 more<')
     expect(schoolListSource).not.toContain('Load 15 more\n')
   })
-
-  it('shows remaining school count in the lock placeholder using PAID_TIER_CAP - FREE_TIER_CAP', () => {
-    // Issue #40: lock banner now always shows a fixed count (PAID_TIER_CAP - FREE_TIER_CAP = 15)
-    expect(schoolListSource).toContain('PAID_TIER_CAP - FREE_TIER_CAP')
-  })
 })
 
-describe('Issue #12: List page locked save button', () => {
+describe('Issue #12/#84: List page locked save button removed', () => {
   const listSource = fs.readFileSync(path.join(__dirname, '../app/list/page.tsx'), 'utf-8')
 
-  it('contains a Save list label', () => {
-    expect(listSource).toContain('Save list')
+  it('does NOT contain a Save list label (locked UI removed in #84)', () => {
+    expect(listSource).not.toContain('Save list')
   })
 
-  it('aria-label reflects Full Access save list text', () => {
-    expect(listSource).toContain('Save list — Full Access')
+  it('does NOT contain the Full Access save aria-label (locked UI removed in #84)', () => {
+    expect(listSource).not.toContain('Save list — Full Access')
     expect(listSource).not.toContain('Download school list — Season Pass coming soon')
   })
 
-  it('save button is not a real link or button (cursor-not-allowed)', () => {
-    expect(listSource).toContain('cursor-not-allowed')
+  it('does NOT contain a locked cursor-not-allowed button (locked UI removed in #84)', () => {
+    expect(listSource).not.toContain('cursor-not-allowed')
   })
 
-  it('save area shows Full Access label', () => {
-    expect(listSource).toContain('Full Access')
+  it('does NOT show Full Access label anywhere (locked UI removed in #84)', () => {
+    expect(listSource).not.toContain('Full Access')
   })
 })
 
@@ -455,16 +450,16 @@ describe('Issue #12/#39: Requirements page — locked deadline tracking section 
 
 // ── Issue #16: Season Pass banners + last verified fix ───────────────────────
 
-describe('Issue #16: List page save banner rename', () => {
+describe('Issue #16/#84: List page save banner removed', () => {
   const listSource = fs.readFileSync(path.join(__dirname, '../app/list/page.tsx'), 'utf-8')
 
-  it('uses "Save list" label (not "Download list")', () => {
-    expect(listSource).toContain('Save list')
+  it('does NOT contain a save banner label (locked UI removed in #84)', () => {
+    expect(listSource).not.toContain('Save list')
     expect(listSource).not.toContain('Download list')
   })
 
-  it('aria-label reflects Full Access save list text', () => {
-    expect(listSource).toContain('Save list — Full Access')
+  it('does NOT contain the Full Access save aria-label (locked UI removed in #84)', () => {
+    expect(listSource).not.toContain('Save list — Full Access')
     expect(listSource).not.toContain('Download school list — Season Pass coming soon')
   })
 })
@@ -503,25 +498,23 @@ describe('Issue #16: Requirements page deadlines last verified', () => {
   })
 })
 
-describe('Issue #16: Home page locked save banner', () => {
+describe('Issue #16/#84: Home page locked save banner removed', () => {
   const homeSource = fs.readFileSync(path.join(__dirname, '../app/page.tsx'), 'utf-8')
 
-  it('has a locked save banner after the form', () => {
-    expect(homeSource).toContain('Save your HS guardrails')
+  it('does NOT have a locked save banner (locked UI removed in #84)', () => {
+    expect(homeSource).not.toContain('Save your HS guardrails')
   })
 
-  it('save banner shows Full Access label', () => {
-    expect(homeSource).toContain('Save your HS guardrails — Full Access')
+  it('does NOT show a Full Access label (locked UI removed in #84)', () => {
+    expect(homeSource).not.toContain('Full Access')
   })
 
-  it('save banner is cursor-not-allowed (locked)', () => {
-    expect(homeSource).toContain('cursor-not-allowed')
+  it('does NOT contain a locked cursor-not-allowed element (locked UI removed in #84)', () => {
+    expect(homeSource).not.toContain('cursor-not-allowed')
   })
 
-  it('save banner appears after the submit button', () => {
-    const submitIdx = homeSource.indexOf('Find schools')
-    const bannerIdx = homeSource.indexOf('Save your HS guardrails')
-    expect(bannerIdx).toBeGreaterThan(submitIdx)
+  it('still has the submit button', () => {
+    expect(homeSource).toContain('Find schools')
   })
 })
 
@@ -844,11 +837,9 @@ describe('Issue #23: FeedbackRow placed in SummaryBar (SchoolList)', () => {
   })
 
   it('FeedbackRow is NOT rendered standalone at the bottom of SchoolList', () => {
-    // The standalone usage after the locked-rows section should be gone
-    const afterLockedRows = schoolListSource.slice(
-      schoolListSource.indexOf('Lock badge'),
-    )
-    expect(afterLockedRows).not.toContain('<FeedbackRow')
+    // The only usage is inside SummaryBar (the standalone bottom usage is gone)
+    const feedbackRowUses = schoolListSource.match(/<FeedbackRow/g) ?? []
+    expect(feedbackRowUses.length).toBe(1)
   })
 
   it('globals.css contains feedback-pop keyframe', () => {
@@ -1475,22 +1466,22 @@ describe('Issue #39: RequirementsContent.tsx is a client component', () => {
   })
 })
 
-describe('Issue #39: Season Pass → Full Access across all files', () => {
-  it('list page uses "Full Access" not "Season Pass"', () => {
+describe('Issue #39/#84: no Season Pass or Full Access across all files', () => {
+  it('list page has neither "Full Access" nor "Season Pass" (locked UI removed in #84)', () => {
     const listSource = fs.readFileSync(path.join(__dirname, '../app/list/page.tsx'), 'utf-8')
-    expect(listSource).toContain('Full Access')
+    expect(listSource).not.toContain('Full Access')
     expect(listSource).not.toContain('Season Pass')
   })
 
-  it('home page uses "Full Access" not "Season Pass"', () => {
+  it('home page has neither "Full Access" nor "Season Pass" (locked UI removed in #84)', () => {
     const homeSource = fs.readFileSync(path.join(__dirname, '../app/page.tsx'), 'utf-8')
-    expect(homeSource).toContain('Full Access')
+    expect(homeSource).not.toContain('Full Access')
     expect(homeSource).not.toContain('Season Pass')
   })
 
-  it('SchoolList uses "Full Access" not "Season Pass"', () => {
+  it('SchoolList has neither "Full Access" nor "Season Pass" (locked UI removed in #84)', () => {
     const schoolListSource = fs.readFileSync(path.join(__dirname, '../components/SchoolList.tsx'), 'utf-8')
-    expect(schoolListSource).toContain('Full Access')
+    expect(schoolListSource).not.toContain('Full Access')
     expect(schoolListSource).not.toContain('Season Pass')
   })
 
@@ -1641,16 +1632,17 @@ describe('Issue #40: capSchoolsByCategory', () => {
   })
 })
 
-describe('Issue #40: SchoolList lock banner', () => {
-  it('SchoolList always shows lock banner (no conditional on totalCount)', () => {
+describe('Issue #40/#84: SchoolList lock banner removed', () => {
+  it('SchoolList has no lock banner (locked UI removed in #84)', () => {
     const schoolListSource = fs.readFileSync(path.join(__dirname, '../components/SchoolList.tsx'), 'utf-8')
     // Must NOT use the old "visibleCount < totalCount" guard
     expect(schoolListSource).not.toContain('visibleCount < totalCount')
-    // Must reference PAID_TIER_CAP and FREE_TIER_CAP for the count
-    expect(schoolListSource).toContain('PAID_TIER_CAP - FREE_TIER_CAP')
+    // The lock banner count (and its PAID_TIER_CAP import) is gone
+    expect(schoolListSource).not.toContain('PAID_TIER_CAP - FREE_TIER_CAP')
+    expect(schoolListSource).not.toContain('PAID_TIER_CAP')
   })
 
-  it('lock banner shows "15 more schools" (PAID_TIER_CAP 30 minus FREE_TIER_CAP 15)', () => {
+  it('tier cap constants are unchanged in lib (PAID_TIER_CAP 30 minus FREE_TIER_CAP 15)', () => {
     expect(PAID_TIER_CAP - FREE_TIER_CAP).toBe(15)
   })
 })
@@ -1678,11 +1670,11 @@ describe('Issue #40: requirements page uses capped results and lock banner', () 
     expect(pageSource).toContain('cappedSchools')
   })
 
-  it('RequirementsContent renders lock banners', () => {
+  it('RequirementsContent does NOT render lock banners (locked UI removed in #84)', () => {
     const contentSource = fs.readFileSync(path.join(__dirname, '../app/requirements/RequirementsContent.tsx'), 'utf-8')
-    expect(contentSource).toContain('lockedCount')
-    expect(contentSource).toContain('Full Access')
-    expect(contentSource).toContain('LockBanner')
+    expect(contentSource).not.toContain('lockedCount')
+    expect(contentSource).not.toContain('Full Access')
+    expect(contentSource).not.toContain('LockBanner')
   })
 })
 
@@ -1942,12 +1934,10 @@ describe('Issue #45: Disclaimer and verified line moved to bottom', () => {
     expect(disclaimerIdx).toBeGreaterThan(sectionsLoopIdx)
   })
 
-  it('disclaimer appears BEFORE the bottom Lock banner', () => {
+  it('has no bottom Lock banner (locked UI removed in #84)', () => {
     const disclaimerIdx = reqContentSource.indexOf('Every effort was made to keep this data current')
-    const lockBannerBottomIdx = reqContentSource.indexOf('Lock banner — bottom')
     expect(disclaimerIdx).toBeGreaterThan(-1)
-    expect(lockBannerBottomIdx).toBeGreaterThan(-1)
-    expect(disclaimerIdx).toBeLessThan(lockBannerBottomIdx)
+    expect(reqContentSource).not.toContain('Lock banner — bottom')
   })
 })
 
@@ -2822,5 +2812,40 @@ describe('Issue #60: school size filter disabled on filter page', () => {
 
   it('does not restore size from localStorage', () => {
     expect(pageSource).not.toContain("includes(saved.size)")
+  })
+})
+
+// ── Issue #84: Hide the unbuilt "Full Access" paid-tier UI ────────────────────
+
+describe('Issue #84: no Full Access paid-tier chrome remains in the UI', () => {
+  const uiFiles = [
+    '../app/page.tsx',
+    '../app/list/page.tsx',
+    '../components/SchoolList.tsx',
+    '../app/requirements/RequirementsContent.tsx',
+  ]
+
+  it.each(uiFiles)('%s does NOT contain "Full Access"', (file) => {
+    const source = fs.readFileSync(path.join(__dirname, file), 'utf-8')
+    expect(source).not.toContain('Full Access')
+  })
+
+  it('requirements page.tsx no longer computes or passes lockedCount', () => {
+    const pageSource = fs.readFileSync(path.join(__dirname, '../app/requirements/page.tsx'), 'utf-8')
+    expect(pageSource).not.toContain('lockedCount')
+    expect(pageSource).not.toContain('PAID_TIER_CAP')
+  })
+
+  it('SchoolList no longer imports the tier cap constants', () => {
+    const schoolListSource = fs.readFileSync(path.join(__dirname, '../components/SchoolList.tsx'), 'utf-8')
+    expect(schoolListSource).not.toContain('FREE_TIER_CAP')
+    expect(schoolListSource).not.toContain('PAID_TIER_CAP')
+  })
+
+  it('free-tier cap logic in lib is untouched (FREE_TIER_CAP still 15)', () => {
+    expect(FREE_TIER_CAP).toBe(15)
+    const libSource = fs.readFileSync(path.join(__dirname, '../lib/school-list-utils.ts'), 'utf-8')
+    expect(libSource).toContain('FREE_TIER_CAP')
+    expect(libSource).toContain('PAID_TIER_CAP')
   })
 })

--- a/app/list/page.tsx
+++ b/app/list/page.tsx
@@ -121,17 +121,6 @@ export default async function ListPage({
             </p>
           </div>
           <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2">
-            {/* Locked save button */}
-            <span
-              aria-label="Save list — Full Access"
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 border border-gray-200 bg-gray-50 rounded-md cursor-not-allowed select-none"
-            >
-              <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-              <span>Save list</span>
-              <span className="text-xs text-gray-400 font-normal">— Full Access</span>
-            </span>
             <ViewRequirementsLink href={`/requirements?${reqParams.toString()}`} />
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -344,20 +344,6 @@ export default function HomePage() {
             Find schools &rarr;
           </button>
         </form>
-
-        {/* Locked save banner */}
-        <div className="mt-4">
-          <span
-            aria-label="Save your HS guardrails — Full Access"
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 border border-gray-200 bg-gray-50 rounded-md cursor-not-allowed select-none"
-          >
-            <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-            </svg>
-            <span>Save your HS guardrails</span>
-            <span className="text-xs text-gray-400 font-normal">— Full Access</span>
-          </span>
-        </div>
       </div>
       <Footer />
     </main>

--- a/app/requirements/RequirementsContent.tsx
+++ b/app/requirements/RequirementsContent.tsx
@@ -92,10 +92,9 @@ function inferAuditionLabel(info: string): string {
 interface Props {
   sections: ReqSection[]
   listHref: string
-  lockedCount: number
 }
 
-export default function RequirementsContent({ sections, listHref, lockedCount }: Props) {
+export default function RequirementsContent({ sections, listHref }: Props) {
   const posthog = usePostHog()
   const [checked, setChecked] = useState<Record<string, boolean>>({})
   const [hydrated, setHydrated] = useState(false)
@@ -178,28 +177,9 @@ export default function RequirementsContent({ sections, listHref, lockedCount }:
     )
   }
 
-  function LockBanner() {
-    return (
-      <div className="flex items-center justify-center gap-2 py-3 px-4 bg-gray-50 border border-gray-200 rounded-md">
-        <svg className="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-        </svg>
-        <span className="text-sm text-gray-500">
-          {lockedCount} more school{lockedCount !== 1 ? 's' : ''} —{' '}
-          <span className="font-medium text-gray-600">Full Access</span>
-        </span>
-      </div>
-    )
-  }
-
   return (
     <main className="min-h-screen bg-white">
       <div className="max-w-2xl mx-auto px-4 py-10">
-        {/* Lock banner — top */}
-        <div className="mb-4">
-          <LockBanner />
-        </div>
-
         {/* Header */}
         <div className="mb-6">
           <Link href={listHref} className="text-sm text-gray-500 hover:text-gray-700">
@@ -349,11 +329,6 @@ export default function RequirementsContent({ sections, listHref, lockedCount }:
             myschools.nyc
           </a>
         </p>
-
-        {/* Lock banner — bottom */}
-        <div className="mt-2">
-          <LockBanner />
-        </div>
       </div>
       <Footer />
     </main>

--- a/app/requirements/page.tsx
+++ b/app/requirements/page.tsx
@@ -2,8 +2,6 @@ import { School, UserInputs, SectionType } from '@/types'
 import RequirementsContent from './RequirementsContent'
 import {
   capSchoolsByCategory,
-  FREE_TIER_CAP,
-  PAID_TIER_CAP,
   applyFilters,
   selectSHSATSchools,
   sortByHomeBorough,
@@ -157,7 +155,6 @@ export default async function RequirementsPage({
   // Cap at FREE_TIER_CAP with per-category limits (same as list page)
   const cappedSchools = capSchoolsByCategory(matchedSchools)
   const sections = buildReqSections(cappedSchools)
-  const lockedCount = PAID_TIER_CAP - FREE_TIER_CAP
 
   // Compute SHSAT cutoff info for the matched schools in the SHSAT section
   if (inputs.shsat) {
@@ -185,5 +182,5 @@ export default async function RequirementsPage({
   )
   const listHref = `/list?${reqParams.toString()}`
 
-  return <RequirementsContent sections={sections} listHref={listHref} lockedCount={lockedCount} />
+  return <RequirementsContent sections={sections} listHref={listHref} />
 }

--- a/components/SchoolList.tsx
+++ b/components/SchoolList.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { usePostHog } from 'posthog-js/react'
 import { SectionGroup, SectionType, UserInputs } from '@/types'
 import SchoolRow from './SchoolRow'
-import { PAGE_SIZE, getVisibleGroups, FREE_TIER_CAP, PAID_TIER_CAP } from '@/lib/school-list-utils'
+import { PAGE_SIZE, getVisibleGroups } from '@/lib/school-list-utils'
 import FeedbackRow from './FeedbackRow'
 
 // ── Section visual config ────────────────────────────────────────────────────
@@ -186,33 +186,6 @@ export default function SchoolList({ groups, userInputs, totalCount }: Props) {
             </div>
           )
         })}
-      </div>
-
-      {/* Lock banner — paid tier (always shown; paid tier adds PAID_TIER_CAP - FREE_TIER_CAP more) */}
-      <div className="mt-4">
-        {/* Locked rows preview */}
-        <div className="border border-gray-200 rounded-md overflow-hidden opacity-50 pointer-events-none select-none" aria-hidden="true">
-          {[0, 1, 2].map((i) => (
-            <div key={i} className="grid grid-cols-[2rem_1fr_6rem_1rem] sm:grid-cols-[2rem_1fr_5rem_2.5rem_6rem_1rem] items-center gap-2 px-3 py-3 border-b border-gray-100 bg-gray-50">
-              <span className="text-xs text-gray-300 text-right">{FREE_TIER_CAP + i + 1}</span>
-              <span className="h-3 bg-gray-200 rounded w-3/4" />
-              <span className="hidden sm:block h-3 bg-gray-200 rounded w-full" />
-              <span className="hidden sm:block h-3 bg-gray-200 rounded w-full" />
-              <span className="h-3 bg-gray-200 rounded w-8 ml-auto" />
-              <span />
-            </div>
-          ))}
-        </div>
-        {/* Lock badge */}
-        <div className="mt-3 flex items-center justify-center gap-2 py-3 px-4 bg-gray-50 border border-gray-200 rounded-md">
-          <svg className="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-          </svg>
-          <span className="text-sm text-gray-500">
-            {PAID_TIER_CAP - FREE_TIER_CAP} more school{PAID_TIER_CAP - FREE_TIER_CAP !== 1 ? 's' : ''} —{' '}
-            <span className="font-medium text-gray-600">Full Access</span>
-          </span>
-        </div>
       </div>
 
     </div>


### PR DESCRIPTION
Done. Issue #84 is fixed and committed as `1aef643` on `task-84-hide-the-unbuilt-full-access-p`, with `npm test` (674 tests, 11 suites) and `npm run build` both green.

## Summary

**Why:** The UI advertised a "Full Access" paid tier that has nothing behind it (no accounts, no payments). This change hides all of that chrome so users being onboarded aren't shown misleading locked buttons and paywall teasers. UI-only — the free-tier cap of 15 schools and all logic in `lib/school-list-utils.ts` are untouched.

**Removed the four locked/teaser UI elements:**
- `app/page.tsx` — the disabled "Save your HS guardrails — Full Access" banner after the form.
- `app/list/page.tsx` — the disabled "Save list — Full Access" button (the "View requirements" link remains).
- `components/SchoolList.tsx` — the entire lock banner: the three greyed skeleton rows numbered past `FREE_TIER_CAP` and the "15 more schools — Full Access" badge.
- `app/requirements/RequirementsContent.tsx` — the `LockBanner` component and both its usages (top and bottom of the page).

**Cleaned up what those removals orphaned:**
- Dropped `FREE_TIER_CAP`/`PAID_TIER_CAP` from `SchoolList.tsx`'s import (kept `PAGE_SIZE`, `getVisibleGroups`).
- Removed the `lockedCount` prop from `RequirementsContent`'s `Props` and signature, its computation in `app/requirements/page.tsx`, the pass-through in JSX, and the now-unused `FREE_TIER_CAP`/`PAID_TIER_CAP` imports there.

**Tests:**
- Flipped the assertions in `__tests__/schools.test.ts` that pinned the locked UI's existence (Issues #12, #16, #39, #40 blocks) to assert the locked UI is absent; kept still-true assertions (no "Season Pass", no "coming soon", no working "Load 15 more").
- Fixed two source-boundary markers the removals made stale: the "FeedbackRow not standalone" check now counts `<FeedbackRow` occurrences instead of slicing from the deleted "Lock badge" comment, and the hydration test's `renderItems` end marker now uses the component's `return (` instead of the deleted `function LockBanner`.
- Added an Issue #84 block asserting no "Full Access" remains in any of the four UI files, no `lockedCount`/orphaned cap imports remain, and `FREE_TIER_CAP` is still 15 in the untouched lib.

**Acceptance verified:** `grep -rn "Full Access" app/ components/` returns nothing; `lib/school-list-utils.ts` and `data/schools.json` unmodified; list still caps at 15.

Closes #84