### PR TITLE
docs: correct README (Vercel deploy, agent-ok label, PR-only flow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The filter page and the chat page do not share state or hand off to each other. 
 - **RAG pipeline:** Built from scratch. Data ingestion, semantic chunking (identity/academics/activities splits per school), in-memory vector search, chat API route
 - **Data:** 457 NYC public high schools scraped and structured from DOE sources. After re-scraping, run the seed script (`npx ts-node scripts/seed-schools.ts`) to push `data/schools.json` into Postgres.
 - **Observability:** Sentry (error tracking), PostHog (product analytics)
-- **Deployment:** DigitalOcean VPS, PM2 process manager, GitHub Actions CI/CD
-- **Coding agent:** Autonomous agent (agent-coordinator.sh) watches GitHub Issues labeled `todo`, runs Claude Code, commits on success, notifies via Telegram
+- **Deployment:** Vercel (auto-deploys from `main`), GitHub Actions CI, Vercel Postgres (Neon)
+- **Coding agent:** Autonomous agent (agent-coordinator.sh) watches GitHub Issues labeled `agent-ok`, runs Claude Code on a task branch, verifies with `npm test` + `npm run build`, then opens a PR for review — it never merges or pushes to `main`; notifies via Telegram
   
 ## Lessons Learned Building This So Far
  


### PR DESCRIPTION
Fixes stale README lines from roadmap #72 item 8: deployment is Vercel (not DigitalOcean/PM2), the coding agent's trigger label is `agent-ok` with a PR-only flow. The item-8 delete targets (lib/route.ts, schools copy.json, create-parent-dashboard-issue.sh) are already absent from the repo, so this closes out item 8.