### PR TITLE
test: guard against non-allowlisted markdown in the public repo

### DIFF
--- a/__tests__/md-allowlist.test.ts
+++ b/__tests__/md-allowlist.test.ts
@@ -1,0 +1,23 @@
+import { execSync } from 'child_process'
+
+// ── Public-repo privacy guard ────────────────────────────────────────────────
+// This repo is PUBLIC. Planning/strategy/PRD docs must never be committed here
+// (a strategy PRD leaked for months before being purged from history — see the
+// md-privacy-guard change). Only the two markdown files below may be tracked.
+//
+// To intentionally add another markdown file, add its exact repo-relative path
+// to ALLOWED in the SAME pull request — that makes the decision explicit and
+// reviewable rather than accidental.
+const ALLOWED = ['README.md', 'CLAUDE.md']
+
+describe('markdown allowlist (public-repo privacy guard)', () => {
+  it('only the allowlisted markdown files are tracked in the repo', () => {
+    const tracked = execSync('git ls-files', { encoding: 'utf-8' })
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+    const markdown = tracked.filter((f) => f.toLowerCase().endsWith('.md'))
+    const unexpected = markdown.filter((f) => !ALLOWED.includes(f))
+    expect(unexpected).toEqual([])
+  })
+})


### PR DESCRIPTION
## Public-repo privacy guard for markdown

Adds `__tests__/md-allowlist.test.ts`: a CI test that fails if any tracked `.md` file exists outside the allowlist (`README.md`, `CLAUDE.md`). Because the `test` check is required by branch protection, this **blocks any future PR** that adds a stray markdown file (planning docs, strategy, PRDs) to this public repo.

To intentionally add another markdown file, add its path to `ALLOWED` in the same PR — an explicit, reviewable decision.

### Context
A strategy PRD (`HS_Navigator_Strategy_PRD.md`) had been committed to this public repo since March and was purged from history separately. This guard prevents a recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
