### PR TITLE
diag: log DB host on empty schools query

### DIFF
--- a/lib/load-schools.ts
+++ b/lib/load-schools.ts
@@ -40,8 +40,10 @@ export async function getAllSchools(): Promise<School[]> {
     const schools = rows.map((row) => row.data)
     if (schools.length === 0) {
       // Connected fine but the table is empty (or points at the wrong DB) —
-      // surface it so an empty /list isn't a silent mystery in production.
-      console.warn('[load-schools] SELECT returned 0 rows from the schools table')
+      // surface it (host only, never credentials) so an empty /list isn't a
+      // silent mystery in production.
+      const host = (process.env.POSTGRES_URL || '(unset)').replace(/^.*@/, '').split('/')[0]
+      console.warn('[load-schools] SELECT returned 0 rows; db host=' + host)
     }
     if (schools.length > 0) cachedSchools = schools
     return schools


### PR DESCRIPTION
Temporary diagnostic: when the schools query returns 0 rows, log the DB host (host only, never credentials) to confirm which database the production runtime actually connects to vs the one that was seeded. Will be reverted once the mismatch is identified.