### PR TITLE
fix: bump chat generation to Sonnet 5 (Sonnet 4 retired)

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest) {
 
   // Step 3: Send to Claude with the retrieved context
   const message = await client.messages.create({
-    model: "claude-sonnet-4-20250514",
+    model: "claude-sonnet-5",
     max_tokens: 600,
     system:
       "You are an experienced NYC high school admissions consultant. Answer the parent's question using ONLY the school information provided below.\n\nFor each school provided, state the school name, then 1-2 sentences about why it is relevant to the parent's question. Mention concrete details and numbers when available. Describe every school provided. Do not skip any.\n\nUse only facts from the provided context. Never say 'appears to', 'seems to', or other hedging language. If a specific detail is not stated in the context, say it is not listed. Do not make up information about schools.\n\nAfter describing all schools, provide a 1-2 sentence summary.",

--- a/app/api/rationale/route.ts
+++ b/app/api/rationale/route.ts
@@ -72,7 +72,7 @@ export async function POST(request: NextRequest) {
     .join('\n')
 
   const message = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-5',
     max_tokens: 150,
     system:
       'You are a helpful NYC high school admissions assistant. Respond with only a valid JSON object — no markdown, no explanation, no code fences. The JSON must have exactly two fields:\n' +


### PR DESCRIPTION
`claude-sonnet-4-20250514` was retired 2026-06-15, so `/api/chat` and `/api/rationale` fail against it. Bumps both to `claude-sonnet-5`. Same tier, live model.