### PR TITLE
fix: issue #92 - Hybrid search for chat: deterministic pre-filter + semantic rank (roadmap #72 item 6)

### DIFF
--- a/__tests__/query-filters.test.ts
+++ b/__tests__/query-filters.test.ts
@@ -1,0 +1,50 @@
+import { extractFilters, hasFilters } from '@/lib/query-filters'
+
+describe('extractFilters (issue #92: hybrid search deterministic pre-filter)', () => {
+  it('detects a borough mentioned in the question', () => {
+    const filters = extractFilters('What are some good schools in Brooklyn?')
+    expect(filters.borough).toBe('Brooklyn')
+  })
+
+  it('does not false-match a borough name inside another word', () => {
+    const filters = extractFilters('Is Bronxville a good place to live?')
+    expect(filters.borough).toBeUndefined()
+  })
+
+  it('detects a sport mentioned in the question', () => {
+    const filters = extractFilters('Which schools have a strong soccer team?')
+    expect(filters.sports).toContain('Soccer')
+  })
+
+  it('detects an interest/subject keyword', () => {
+    const filters = extractFilters('I want a school with a good CS program')
+    expect(filters.interests).toContain('Computer Science')
+  })
+
+  it('handles the compound "CS + soccer + Brooklyn" case with all three signals', () => {
+    const filters = extractFilters('Looking for CS + soccer + Brooklyn schools')
+    expect(filters.borough).toBe('Brooklyn')
+    expect(filters.sports).toContain('Soccer')
+    expect(filters.interests).toContain('Computer Science')
+    expect(hasFilters(filters)).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    const filters = extractFilters('schools in BROOKLYN with basketball')
+    expect(filters.borough).toBe('Brooklyn')
+    expect(filters.sports).toContain('Basketball')
+  })
+
+  it('returns empty filters and hasFilters=false for a plain question with no signals', () => {
+    const filters = extractFilters('What is the best school for my kid?')
+    expect(filters.borough).toBeUndefined()
+    expect(filters.sports).toEqual([])
+    expect(filters.interests).toEqual([])
+    expect(hasFilters(filters)).toBe(false)
+  })
+
+  it('does not duplicate a sport matched by multiple aliases', () => {
+    const filters = extractFilters('Any schools with track and field or track?')
+    expect(filters.sports.filter((s) => s === 'Track')).toHaveLength(1)
+  })
+})

--- a/lib/query-filters.ts
+++ b/lib/query-filters.ts
@@ -1,0 +1,123 @@
+/**
+ * query-filters.ts
+ *
+ * Deterministic pre-filter extraction for chat retrieval (roadmap #72 item 6).
+ *
+ * Compound questions like "CS + soccer + Brooklyn" mix signals that are
+ * unambiguous in text (a borough name, a sport, a subject) with signals that
+ * genuinely need semantic search (school "vibe", size, rigor). This module
+ * only pulls out the deterministic part; anything not clearly recognized is
+ * left for the embedding-based ranker in lib/rag.ts to handle.
+ *
+ * Place at: lib/query-filters.ts
+ */
+
+// Same five boroughs used throughout the app (see BOROUGH_ORDER in
+// lib/school-list-utils.ts and the school data's `borough` field).
+const BOROUGHS = ["Manhattan", "Brooklyn", "Queens", "Bronx", "Staten Island"];
+
+// PSAL sports as they appear in the school data's activities text, plus
+// common aliases students use when asking about them.
+const SPORT_ALIASES: Record<string, string> = {
+  badminton: "Badminton",
+  baseball: "Baseball",
+  basketball: "Basketball",
+  bowling: "Bowling",
+  cricket: "Cricket",
+  "cross country": "Cross Country",
+  "double dutch": "Double Dutch",
+  fencing: "Fencing",
+  "flag football": "Flag Football",
+  football: "Football",
+  golf: "Golf",
+  gymnastics: "Gymnastics",
+  handball: "Handball",
+  "indoor track": "Indoor Track",
+  "outdoor track": "Outdoor Track",
+  "track & field": "Track",
+  "track and field": "Track",
+  track: "Track",
+  lacrosse: "Lacrosse",
+  rugby: "Rugby",
+  soccer: "Soccer",
+  softball: "Softball",
+  stunt: "Stunt",
+  swimming: "Swimming",
+  "table tennis": "Table Tennis",
+  tennis: "Tennis",
+  volleyball: "Volleyball",
+  wrestling: "Wrestling",
+};
+
+// Deterministic keyword -> interest-category aliases. Matched against the
+// `interests` strings in each school's metadata (e.g. "Computer Science &
+// Technology"), so we only need the distinctive part of the phrase. Only
+// keywords that map unambiguously to a single real category are included —
+// broad terms like "arts" or "STEM" span multiple categories in the data and
+// are left for semantic ranking instead of a deterministic filter.
+const INTEREST_ALIASES: Record<string, string> = {
+  cs: "Computer Science",
+  "computer science": "Computer Science",
+  coding: "Computer Science",
+  programming: "Computer Science",
+  engineering: "Engineering",
+  robotics: "Engineering",
+  business: "Business",
+  government: "Law & Government",
+  medicine: "Health Professions",
+  nursing: "Health Professions",
+  culinary: "Culinary Arts",
+  cosmetology: "Cosmetology",
+  architecture: "Architecture",
+  "environmental science": "Environmental Science",
+  film: "Film/Video",
+  "visual art": "Visual Art & Design",
+  "performing art": "Performing Arts",
+  theater: "Performing Arts",
+  theatre: "Performing Arts",
+  humanities: "Humanities & Interdisciplinary",
+  jrotc: "JROTC",
+};
+
+export interface QueryFilters {
+  borough?: string;
+  sports: string[];
+  interests: string[];
+}
+
+function findWord(question: string, word: string): boolean {
+  const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`, "i").test(question);
+}
+
+/**
+ * Pulls out deterministic borough / sport / interest signals from a free-text
+ * question. Returns empty arrays and an undefined borough when nothing
+ * matches, so callers can treat that as "no filters, behave as before".
+ */
+export function extractFilters(question: string): QueryFilters {
+  const borough = BOROUGHS.find((b) => findWord(question, b));
+
+  const sports = Array.from(
+    new Set(
+      Object.entries(SPORT_ALIASES)
+        .filter(([alias]) => findWord(question, alias))
+        .map(([, canonical]) => canonical)
+    )
+  );
+
+  const interests = Array.from(
+    new Set(
+      Object.entries(INTEREST_ALIASES)
+        .filter(([alias]) => findWord(question, alias))
+        .map(([, canonical]) => canonical)
+    )
+  );
+
+  return { borough, sports, interests };
+}
+
+/** True when extractFilters found at least one deterministic signal. */
+export function hasFilters(filters: QueryFilters): boolean {
+  return Boolean(filters.borough) || filters.sports.length > 0 || filters.interests.length > 0;
+}

--- a/lib/rag.ts
+++ b/lib/rag.ts
@@ -18,6 +18,7 @@
 import fs from "fs";
 import path from "path";
 import OpenAI from "openai";
+import { extractFilters, hasFilters, QueryFilters } from "./query-filters";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -106,6 +107,76 @@ function loadEmbeddings(): SchoolEmbedding[] {
 }
 
 // ---------------------------------------------------------------------------
+// Deterministic pre-filter (roadmap #72 item 6): restrict the candidate pool
+// by borough/sport/interest signals extracted from the question, before the
+// existing semantic ranking runs within that pool.
+// ---------------------------------------------------------------------------
+
+function includesWord(haystack: string, needle: string): boolean {
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`, "i").test(haystack);
+}
+
+function schoolMatchesFilters(entries: SchoolEmbedding[], filters: QueryFilters): boolean {
+  const { borough, metadata } = entries[0];
+
+  if (filters.borough && borough !== filters.borough) return false;
+
+  if (filters.sports.length > 0 || filters.interests.length > 0) {
+    const combinedText = entries.map((e) => e.chunk).join(" ");
+    const interestsList = metadata.interests ?? [];
+
+    if (
+      filters.sports.length > 0 &&
+      !filters.sports.some((sport) => includesWord(combinedText, sport))
+    ) {
+      return false;
+    }
+
+    if (
+      filters.interests.length > 0 &&
+      !filters.interests.some(
+        (interest) =>
+          includesWord(combinedText, interest) ||
+          interestsList.some((i) => includesWord(i, interest))
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Restricts chunks to schools matching the deterministic filters. Falls back
+ * to the full candidate pool if the filters match zero schools, so an
+ * overly-specific extraction can't zero out retrieval entirely.
+ */
+function applyDeterministicFilters(
+  chunks: SchoolEmbedding[],
+  filters: QueryFilters
+): SchoolEmbedding[] {
+  if (!hasFilters(filters)) return chunks;
+
+  const byDbn = new Map<string, SchoolEmbedding[]>();
+  for (const entry of chunks) {
+    const group = byDbn.get(entry.dbn);
+    if (group) group.push(entry);
+    else byDbn.set(entry.dbn, [entry]);
+  }
+
+  const matchingDbns = new Set(
+    Array.from(byDbn.entries())
+      .filter(([, entries]) => schoolMatchesFilters(entries, filters))
+      .map(([dbn]) => dbn)
+  );
+
+  if (matchingDbns.size === 0) return chunks;
+  return chunks.filter((entry) => matchingDbns.has(entry.dbn));
+}
+
+// ---------------------------------------------------------------------------
 // Search: embed query, find top matches, deduplicate by school
 // ---------------------------------------------------------------------------
 
@@ -122,11 +193,14 @@ export async function searchSchools(
   });
   const queryEmbedding = response.data[0].embedding;
 
-  // Load all chunk embeddings
+  // Load all chunk embeddings, then restrict to schools matching any
+  // deterministic filters (borough/sport/interest) extracted from the query.
   const allChunks = loadEmbeddings();
+  const filters = extractFilters(query);
+  const candidateChunks = applyDeterministicFilters(allChunks, filters);
 
-  // Score every chunk against the query
-  const scored = allChunks.map((entry) => ({
+  // Score every candidate chunk against the query
+  const scored = candidateChunks.map((entry) => ({
     ...entry,
     score: cosineSimilarity(queryEmbedding, entry.embedding),
   }));


### PR DESCRIPTION
## Summary

Implemented hybrid search for chat retrieval (roadmap #72, item 6):

- **`lib/query-filters.ts`** (new): pure `extractFilters(question)` that deterministically pulls out borough (Manhattan/Brooklyn/Queens/Bronx/Staten Island, using word-boundary matching so "Bronxville" doesn't false-match "Bronx"), sports (matched against the PSAL sport vocabulary found in the school data's activities text, e.g. Soccer, Basketball, Track), and interests (unambiguous keyword aliases like "CS"/"coding"/"programming" → "Computer Science", mapped against the real per-school `interests` categories — deliberately excluding broad/ambiguous terms like "STEM" or "arts" that span multiple categories). Returns empty arrays/undefined when nothing matches; `hasFilters()` reports whether any signal was found.
- **`lib/rag.ts`**: `searchSchools()` now calls `extractFilters()` on the query and, when signals are present, restricts the candidate chunk pool to matching schools (`applyDeterministicFilters`) before running the existing embedding-based scoring/ranking/dedup/top-5 pipeline unchanged. If a filter combination matches zero schools, it safely falls back to the full pool rather than returning nothing. When no filters are found, behavior is byte-for-byte identical to before.
- **`__tests__/query-filters.test.ts`** (new): covers borough detection, borough false-positive avoidance, sport detection, interest detection, the compound "CS + soccer + Brooklyn" case, case-insensitivity, the no-signal empty case, and alias dedup.

`npm test` (683 tests, 14 suites) and `npm run build` both pass. Diff is scoped only to the three files above — no unrelated changes bundled in this time (prior attempts were rejected for bundling an unrelated DB-targeting fix).

As noted in the issue, retrieval-quality validation against the golden dataset (`listready_eval.py`) requires live API calls and can't run in CI — a human should run that eval post-merge to confirm no regressions.

Closes #92