### PR TITLE
chore: purge stale product names (ListReady / HSNavigator) from tooling

### DIFF
--- a/admitday_eval.py
+++ b/admitday_eval.py
@@ -5,7 +5,7 @@ Sends each golden dataset test case to Claude for automated scoring,
 then compares against manual human scores.
 
 Usage:
-    ANTHROPIC_API_KEY="sk-ant-..." python listready_eval.py
+    ANTHROPIC_API_KEY="sk-ant-..." python admitday_eval.py
 
 Output:
     - Per-case comparison table (human score vs judge score)
@@ -244,7 +244,7 @@ GOLDEN_DATASET = [
 # ---------------------------------------------------------------------------
 # Judge prompt
 # ---------------------------------------------------------------------------
-JUDGE_SYSTEM_PROMPT = """You are an eval judge for a NYC high school recommendation app called ListReady.
+JUDGE_SYSTEM_PROMPT = """You are an eval judge for a NYC high school recommendation app called AdmitDay.
 
 You will receive:
 - The user's filter selections (what they were looking for)
@@ -386,9 +386,9 @@ def run_eval():
         "agreement_rate_pct": round(agreement_rate, 1),
         "results": results,
     }
-    with open("listready_eval_results.json", "w") as f:
+    with open("admitday_eval_results.json", "w") as f:
         json.dump(output, f, indent=2)
-    print(f"\nFull results written to listready_eval_results.json")
+    print(f"\nFull results written to admitday_eval_results.json")
 
 
 if __name__ == "__main__":

--- a/build_school_data.py
+++ b/build_school_data.py
@@ -19,7 +19,7 @@ import re
 from bs4 import BeautifulSoup
 
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (compatible; HSNavigator/1.0; research tool)"
+    "User-Agent": "Mozilla/5.0 (compatible; AdmitDay/1.0; research tool)"
 }
 
 # Minimum SHSAT score that received a specialized high school offer.

--- a/fix_parser.py
+++ b/fix_parser.py
@@ -3,7 +3,7 @@ import json
 import time
 from bs4 import BeautifulSoup
 
-HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; HSNavigator/1.0; research tool)"}
+HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; AdmitDay/1.0; research tool)"}
 
 def classify_admissions(text):
     text = text.lower().strip()


### PR DESCRIPTION
Purges stale former product names from tooling scripts. The repo was renamed **ListReady → hs-navigator → AdmitDay**; "ListReady" should not appear anywhere.

**Changed:**
- Renamed `listready_eval.py` → `admitday_eval.py`; updated its internal references (output file, usage comment) and fixed the eval-judge system prompt that described the app as "ListReady" → "AdmitDay".
- Scraper User-Agent `HSNavigator/1.0` → `AdmitDay/1.0` in `build_school_data.py` and `fix_parser.py`.

**Deliberately NOT touched** (load-bearing external identifiers — changing the code alone would break things):
- `next.config.js` Sentry project slug `"listready"` (and its assertion in `__tests__/schools.test.ts`). Renaming this requires renaming the Sentry project first, or error reporting silently breaks. Tracked as a separate decision.
- `.github/workflows/deploy.yml`'s `pm2 restart hs-navigator` step — a separate legacy-deploy question.
- `CLAUDE.md`'s historical note about the rename (correct as written).

Tooling-only; does not touch the Next.js app, so `npm test` / `npm run build` are unaffected.
