### PR TITLE
docs: house rule to keep README current as changes ship

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 - Run `npm test` and `npm run build` before considering any change done; both must exit 0.
 - The app deploys to Vercel automatically from `main`. Do not add local deploy or pm2 steps.
 - The product name in UI copy is **"AdmitDay"** (the repo was renamed from hs-navigator; don't reintroduce the old name).
+- If a change alters user-facing behavior, the data model, or the architecture, update `README.md` in the same PR so the README never drifts from reality (`README.md` is on the markdown allowlist, so editing it is always allowed).
 - Never push, never merge, never switch branches — the coordinator owns git remotes.
 - `LESSONS.md` is coordinator-owned runtime state — read it for context, but never commit it (use `git add -A -- ':(exclude)LESSONS.md'`).
 - Stay strictly within the scope of the issue you were given; an independent reviewer rejects scope creep.


### PR DESCRIPTION
Adds one CLAUDE.md house rule: if a change alters user-facing behavior, the data model, or the architecture, update README.md in the same PR. Makes 'keep the README current as we go' structural — the agent applies it and the independent reviewer enforces it, instead of it being manually chased. Docs-only.