### PR TITLE
fix: issue #110 - /find: wire the ask box to the conversational RAG (grounded answer + sources), keeping hard filters + soft annotations — #99 step 2

### DIFF
--- a/__tests__/find-ask-rag.test.ts
+++ b/__tests__/find-ask-rag.test.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const srcPath = path.join(__dirname, '../app/find/FindClient.tsx')
+let src: string
+
+beforeAll(() => {
+  src = fs.readFileSync(srcPath, 'utf-8')
+})
+
+describe('/find ask box wired to conversational RAG (issue #110)', () => {
+  it('still runs the deterministic soft-annotation pass (unchanged from #108)', () => {
+    expect(src).toContain('extractFilters(askText)')
+    expect(src).toContain('getUnmetCriteria')
+  })
+
+  it('POSTs the question to the existing /api/chat route', () => {
+    expect(src).toContain("'/api/chat'")
+    expect(src).toContain("method: 'POST'")
+    expect(src).toMatch(/JSON\.stringify\(\s*\{\s*question/)
+  })
+
+  it('does not introduce a new LLM/RAG route', () => {
+    expect(src).not.toMatch(/fetch\(\s*['"]\/api\/(?!chat)/)
+  })
+
+  it('tracks loading state for the grounded answer', () => {
+    expect(src).toMatch(/askLoading/)
+  })
+
+  it('tracks an error state for the grounded answer and handles 429', () => {
+    expect(src).toMatch(/askAnswerError/)
+    expect(src).toContain('429')
+  })
+
+  it('renders the grounded answer and its sources', () => {
+    expect(src).toMatch(/askAnswer/)
+    expect(src).toMatch(/askSources/)
+    expect(src).toContain('Sources')
+  })
+
+  it('never removes schools based on the ask box (hard filters stay separate)', () => {
+    expect(src).toContain('hardFiltered')
+    // The ranked list is still built from hardFiltered, not from the RAG answer.
+    expect(src).toMatch(/hardFiltered\.map/)
+  })
+})
+
+describe('/find page and other surfaces remain untouched (issue #110 scope)', () => {
+  it('does not add a nav link to /find', () => {
+    const layoutFiles = ['../components/Footer.tsx', '../app/layout.tsx']
+      .map((p) => path.join(__dirname, p))
+      .filter((p) => fs.existsSync(p))
+    for (const file of layoutFiles) {
+      const content = fs.readFileSync(file, 'utf-8')
+      expect(content).not.toMatch(/href=["']\/find["']/)
+    }
+  })
+})

--- a/app/find/FindClient.tsx
+++ b/app/find/FindClient.tsx
@@ -6,6 +6,13 @@ import { BOROUGH_ORDER } from '@/lib/school-list-utils'
 import { extractFilters, QueryFilters } from '@/lib/query-filters'
 import { getUnmetCriteria } from '@/lib/soft-match'
 
+interface AskSource {
+  name: string
+  dbn: string
+  borough: string
+  score: number
+}
+
 const BOROUGHS = Object.keys(BOROUGH_ORDER)
 const SIZES: { value: School['size']; label: string }[] = [
   { value: 'small', label: 'Small (<400)' },
@@ -33,6 +40,10 @@ export default function FindClient({ schools }: Props) {
 
   const [askText, setAskText] = useState('')
   const [askFilters, setAskFilters] = useState<QueryFilters | null>(null)
+  const [askAnswer, setAskAnswer] = useState('')
+  const [askSources, setAskSources] = useState<AskSource[]>([])
+  const [askLoading, setAskLoading] = useState(false)
+  const [askAnswerError, setAskAnswerError] = useState('')
 
   const admissionsTrackOptions = useMemo(
     () => uniqueSorted(schools.flatMap((s) => s.admissions_types ?? [])),
@@ -69,9 +80,47 @@ export default function FindClient({ schools }: Props) {
     return rows.sort((a, b) => a.missing.length - b.missing.length)
   }, [hardFiltered, askFilters])
 
-  function handleAskSubmit(e: React.FormEvent) {
+  async function handleAskSubmit(e: React.FormEvent) {
     e.preventDefault()
+    const trimmed = askText.trim()
+
+    // Soft annotation pass — deterministic, unchanged from #108.
     setAskFilters(extractFilters(askText))
+
+    if (!trimmed) return
+
+    setAskLoading(true)
+    setAskAnswerError('')
+    setAskAnswer('')
+    setAskSources([])
+
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: trimmed }),
+      })
+
+      if (res.status === 429) {
+        const data = await res.json().catch(() => null)
+        setAskAnswerError(
+          data?.error ?? "You're sending requests too quickly — please wait a moment and try again."
+        )
+        return
+      }
+
+      if (!res.ok) {
+        throw new Error(`Request failed (${res.status})`)
+      }
+
+      const data = await res.json()
+      setAskAnswer(typeof data.answer === 'string' ? data.answer : '')
+      setAskSources(Array.isArray(data.sources) ? data.sources : [])
+    } catch {
+      setAskAnswerError('Something went wrong getting an answer. Please try again.')
+    } finally {
+      setAskLoading(false)
+    }
   }
 
   return (
@@ -183,6 +232,39 @@ export default function FindClient({ schools }: Props) {
           Ask
         </button>
       </form>
+
+      {/* Grounded answer panel (RAG via /api/chat) — sits above the results
+          list. The question below never removes schools from that list. */}
+      {(askLoading || askAnswerError || askAnswer) && (
+        <div className="mb-5 border border-gray-200 rounded-md p-4">
+          {askLoading && <p className="text-sm text-gray-500">Searching schools and generating an answer…</p>}
+          {!askLoading && askAnswerError && (
+            <p role="alert" className="text-sm text-red-700">
+              {askAnswerError}
+            </p>
+          )}
+          {!askLoading && !askAnswerError && askAnswer && (
+            <div>
+              <p className="text-sm text-gray-900 whitespace-pre-wrap leading-relaxed">{askAnswer}</p>
+              {askSources.length > 0 && (
+                <div className="mt-3">
+                  <h2 className="text-xs font-medium text-gray-500 mb-1.5">Sources</h2>
+                  <ul className="flex flex-wrap gap-2">
+                    {askSources.map((s) => (
+                      <li
+                        key={s.dbn}
+                        className="text-xs px-2 py-1 rounded-full bg-gray-50 text-gray-700 border border-gray-200"
+                      >
+                        {s.name} &middot; {s.borough}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* One shared, ranked results list */}
       <div>


### PR DESCRIPTION
## Summary

Implemented issue #110: `/find`'s ask box is now conversational, in addition to its existing deterministic soft-annotation behavior.

**Changes (`app/find/FindClient.tsx` only):**
- On submit, still runs `extractFilters()` → soft "missing: X" annotations exactly as before (unchanged, never removes schools).
- Additionally POSTs the trimmed question to the existing `/api/chat` route (same rate-limited, grounded Sonnet 5 backend used by `/chat` — no new LLM route or retrieval logic).
- New state (`askAnswer`, `askSources`, `askLoading`, `askAnswerError`) drives an answer panel rendered above the results list: a loading message while the request is in flight, a friendly message on 429/other errors, or the grounded answer with a row of source chips (name + borough) on success.
- The results list still comes from `hardFiltered` and is unaffected by the RAG call — hard filters and soft annotations behave exactly as in #108/#109.

**Tests:** added `__tests__/find-ask-rag.test.ts` (static source checks, matching this repo's existing `chat-page.test.ts` style) verifying the annotation pass is untouched, the `/api/chat` POST/JSON-body wiring, no new API route is introduced, loading/error/429 handling exists, answer+sources are rendered, and that no nav link to `/find` was added.

`npm test` (666 tests) and `npm run build` both pass. No changes to `/list`, `/requirements`, `/chat`, `data/schools.json`, or the `/api/chat` backend.

Closes #110