### PR TITLE
design: add approved /find screen visual reference

### DIFF
--- a/design/find-screen.html
+++ b/design/find-screen.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Admit Day — /find (approved direction)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Libre+Franklin:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@1,6..72,400;1,6..72,500&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>body{margin:0;background:#B9B9B5;font-family:'Libre Franklin',sans-serif;}</style>
+</head>
+<body>
+<div style="width: 1120px; margin: 40px auto; font-family: 'Libre Franklin', sans-serif; background: #FFFFFF; border: 1px solid #DEDEDA; box-shadow: 0 24px 60px -30px rgba(0,0,0,0.45);">
+        <div style="display: flex; align-items: center; justify-content: space-between; padding: 20px 36px; border-bottom: 1px solid #E8E8E4;">
+          <div style="display: flex; align-items: baseline; gap: 3px;">
+            <span style="font-family: 'Space Grotesk', sans-serif; font-size: 21px; font-weight: 700; color: #0B0B0C; letter-spacing: -0.035em;">Admit</span><span style="font-family: 'Newsreader', serif; font-style: italic; font-size: 24px; font-weight: 500; color: #1D4ED8; letter-spacing: -0.01em; margin-left: 3px;">Day</span>
+          </div>
+          <div style="display: flex; gap: 30px; font-size: 14px; color: #55555A;">
+            <span style="color: #0B0B0C; font-weight: 500; padding-bottom: 3px; border-bottom: 2px solid #1D4ED8;">Find</span>
+            <span>My schools</span>
+            <span>Readiness</span>
+          </div>
+        </div>
+
+        <div style="display: grid; grid-template-columns: 316px 1fr;">
+          <div style="border-right: 1px solid #E8E8E4; padding: 32px 28px; display: flex; flex-direction: column; gap: 30px;">
+            <div style="display: flex; flex-direction: column; gap: 12px;">
+              <div style="display: flex; align-items: baseline; justify-content: space-between;"><div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">Borough</div><div style="font-size: 12px; color: #1D4ED8;">2 selected</div></div>
+              <div style="display: flex; flex-wrap: wrap; gap: 8px;">
+                <span style="font-size: 13.5px; padding: 7px 13px; border: 1px solid #0B0B0C; background: #0B0B0C; color: #fff;">Brooklyn ✓</span>
+                <span style="font-size: 13.5px; padding: 7px 13px; border: 1px solid #DEDEDA; color: #3A3A3F;">Manhattan</span>
+                <span style="font-size: 13.5px; padding: 7px 13px; border: 1px solid #0B0B0C; background: #0B0B0C; color: #fff;">Queens ✓</span>
+                <span style="font-size: 13.5px; padding: 7px 13px; border: 1px solid #DEDEDA; color: #3A3A3F;">Bronx</span>
+                <span style="font-size: 13.5px; padding: 7px 13px; border: 1px solid #DEDEDA; color: #3A3A3F;">Staten Is.</span>
+              </div>
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 12px;">
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">Admissions track</div>
+              <div style="display: flex; flex-direction: column; gap: 1px;">
+                <div style="display: flex; align-items: center; justify-content: space-between; padding: 9px 0; border-bottom: 1px solid #F0F0EC; font-size: 14px; color: #0B0B0C;"><span>Screened</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 12px; color: #1D4ED8;">✓ 62</span></div>
+                <div style="display: flex; align-items: center; justify-content: space-between; padding: 9px 0; border-bottom: 1px solid #F0F0EC; font-size: 14px; color: #0B0B0C;"><span>Screened w/ assessment</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 12px; color: #1D4ED8;">✓ 24</span></div>
+                <div style="display: flex; align-items: center; justify-content: space-between; padding: 9px 0; border-bottom: 1px solid #F0F0EC; font-size: 14px; color: #8A8A90;"><span>SHSAT</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 12px;">8</span></div>
+                <div style="display: flex; align-items: center; justify-content: space-between; padding: 9px 0; border-bottom: 1px solid #F0F0EC; font-size: 14px; color: #8A8A90;"><span>Audition</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 12px;">21</span></div>
+                <div style="display: flex; align-items: center; justify-content: space-between; padding: 9px 0; border-bottom: 1px solid #F0F0EC; font-size: 14px; color: #8A8A90;"><span>Educational Option</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 12px;">203</span></div>
+                <div style="display: flex; align-items: center; justify-content: space-between; padding: 9px 0; font-size: 14px; color: #8A8A90;"><span>Open</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 12px;">58</span></div>
+              </div>
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 12px;">
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">Size</div>
+              <div style="display: flex; border: 1px solid #DEDEDA;">
+                <span style="flex: 1; text-align: center; font-size: 13px; padding: 8px 0; color: #3A3A3F;">Any</span>
+                <span style="flex: 1; text-align: center; font-size: 13px; padding: 8px 0; color: #3A3A3F; border-left: 1px solid #DEDEDA;">Small</span>
+                <span style="flex: 1; text-align: center; font-size: 13px; padding: 8px 0; background: #0B0B0C; color: #fff; border-left: 1px solid #0B0B0C;">Medium</span>
+                <span style="flex: 1; text-align: center; font-size: 13px; padding: 8px 0; color: #3A3A3F; border-left: 1px solid #DEDEDA;">Large</span>
+              </div>
+            </div>
+            
+            <div style="display: flex; flex-direction: column; gap: 10px; padding-top: 6px; border-top: 1px solid #E8E8E4;">
+              <div style="font-size: 13px; color: #8A8A90;">Boroughs and tracks are multi-select. Cleared filters return all 457 schools.</div>
+              <div style="font-size: 13.5px; color: #1D4ED8; text-decoration: underline; text-underline-offset: 3px;">Reset</div>
+            </div>
+          </div>
+
+          <div style="display: flex; flex-direction: column;">
+            <div style="padding: 34px 36px 26px; border-bottom: 1px solid #E8E8E4; display: flex; flex-direction: column; gap: 18px;">
+              <div style="display: flex; flex-direction: column; gap: 8px;">
+                <div style="font-family: 'Space Grotesk', sans-serif; font-size: 44px; font-weight: 700; line-height: 1.02; color: #0B0B0C; letter-spacing: -0.038em;">Find schools</div>
+                <div style="font-size: 15.5px; color: #55555A; max-width: 560px; text-wrap: pretty;">Filters set the floor. The ask box adds the things a filter can't: “strong CS, a real soccer team, walkable from Sunset Park.”</div>
+              </div>
+              <div style="display: flex; gap: 10px;">
+                <div style="flex: 1; display: flex; align-items: center; gap: 10px; border: 1px solid #C9C9C4; padding: 13px 15px;">
+                  <span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #1D4ED8;">›</span>
+                  <span style="font-size: 15px; color: #0B0B0C;">strong CS and a soccer team, small classes</span>
+                </div>
+                <div style="background: #1D4ED8; color: #fff; font-size: 15px; font-weight: 500; padding: 13px 26px;">Ask</div>
+              </div>
+              <div style="display: flex; gap: 8px; align-items: center;">
+                <span style="font-family: 'JetBrains Mono', monospace; font-size: 11px; color: #8A8A90; letter-spacing: 0.1em; text-transform: uppercase;">Applied</span>
+                <span style="font-size: 13px; padding: 5px 10px; background: #EEF2FF; color: #1D4ED8; border: 1px solid #C7D2FE;">computer science ×</span>
+                <span style="font-size: 13px; padding: 5px 10px; background: #EEF2FF; color: #1D4ED8; border: 1px solid #C7D2FE;">PSAL soccer ×</span>
+              </div>
+            </div>
+
+            <div style="display: flex; align-items: baseline; justify-content: space-between; padding: 16px 36px; border-bottom: 1px solid #E8E8E4; background: #FAFAF8;">
+              <div style="display: flex; align-items: baseline; gap: 8px;">
+                <span style="font-family: 'JetBrains Mono', monospace; font-size: 22px; font-weight: 500; color: #0B0B0C; letter-spacing: -0.02em;">31</span>
+                <span style="font-size: 14px; color: #55555A;">matches in Brooklyn + Queens</span>
+              </div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 11.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90;">Sorted by fit</div>
+            </div>
+
+            <div style="display: flex; flex-direction: column;">
+              <div style="display: grid; grid-template-columns: 34px 1fr 128px 96px; gap: 16px; align-items: start; padding: 22px 36px; border-bottom: 1px solid #F0F0EC;">
+                <div style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #B8B8B4; padding-top: 5px;">01</div>
+                <div style="display: flex; flex-direction: column; gap: 5px;">
+                  <div style="font-size: 18px; font-weight: 700; color: #0B0B0C; letter-spacing: -0.015em;">Brooklyn Technical High School</div>
+                  <div style="font-size: 13.5px; color: #55555A;">Fort Greene · SHSAT · 5,900 students</div>
+                  <div style="font-size: 14px; color: #2A2A2F; max-width: 430px; text-wrap: pretty;">Nine majors including software engineering; PSAL soccer. Entry is the exam only.</div>
+                </div>
+                <div style="display: flex; flex-direction: column; gap: 3px;">
+                  <div style="font-family: 'JetBrains Mono', monospace; font-size: 18px; color: #0B0B0C;">4.1</div>
+                  <div style="font-size: 11.5px; color: #8A8A90; letter-spacing: 0.06em; text-transform: uppercase;">Apps / seat</div>
+                </div>
+                <div style="border: 1px solid #0B0B0C; text-align: center; font-size: 13.5px; padding: 8px 0; color: #0B0B0C;">Add</div>
+              </div>
+              <div style="display: grid; grid-template-columns: 34px 1fr 128px 96px; gap: 16px; align-items: start; padding: 22px 36px; border-bottom: 1px solid #F0F0EC;">
+                <div style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #B8B8B4; padding-top: 5px;">02</div>
+                <div style="display: flex; flex-direction: column; gap: 5px;">
+                  <div style="font-size: 18px; font-weight: 700; color: #0B0B0C; letter-spacing: -0.015em;">Millennium Brooklyn High School</div>
+                  <div style="font-size: 13.5px; color: #55555A;">Park Slope · Screened · 680 students</div>
+                  <div style="font-size: 14px; color: #2A2A2F; max-width: 430px; text-wrap: pretty;">Small and screened on 7th-grade grades. CS electives, no soccer team.</div>
+                </div>
+                <div style="display: flex; flex-direction: column; gap: 3px;">
+                  <div style="font-family: 'JetBrains Mono', monospace; font-size: 18px; color: #0B0B0C;">9.6</div>
+                  <div style="font-size: 11.5px; color: #8A8A90; letter-spacing: 0.06em; text-transform: uppercase;">Apps / seat</div>
+                </div>
+                <div style="border: 1px solid #0B0B0C; text-align: center; font-size: 13.5px; padding: 8px 0; color: #0B0B0C;">Add</div>
+              </div>
+              <div style="display: grid; grid-template-columns: 34px 1fr 128px 96px; gap: 16px; align-items: start; padding: 22px 36px; border-bottom: 1px solid #F0F0EC;">
+                <div style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #B8B8B4; padding-top: 5px;">03</div>
+                <div style="display: flex; flex-direction: column; gap: 5px;">
+                  <div style="font-size: 18px; font-weight: 700; color: #0B0B0C; letter-spacing: -0.015em;">Leon M. Goldstein High School for the Sciences</div>
+                  <div style="font-size: 13.5px; color: #55555A;">Manhattan Beach · Screened · 1,080 students</div>
+                  <div style="font-size: 14px; color: #2A2A2F; max-width: 430px; text-wrap: pretty;">Strong science and AP load; boys' and girls' PSAL soccer.</div>
+                </div>
+                <div style="display: flex; flex-direction: column; gap: 3px;">
+                  <div style="font-family: 'JetBrains Mono', monospace; font-size: 18px; color: #0B0B0C;">7.2</div>
+                  <div style="font-size: 11.5px; color: #8A8A90; letter-spacing: 0.06em; text-transform: uppercase;">Apps / seat</div>
+                </div>
+                <div style="border: 1px solid #0B0B0C; text-align: center; font-size: 13.5px; padding: 8px 0; color: #0B0B0C;">Add</div>
+              </div>
+              <div style="display: grid; grid-template-columns: 34px 1fr 128px 96px; gap: 16px; align-items: start; padding: 22px 36px; border-bottom: 1px solid #F0F0EC;">
+                <div style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #B8B8B4; padding-top: 5px;">04</div>
+                <div style="display: flex; flex-direction: column; gap: 5px;">
+                  <div style="display: flex; align-items: center; gap: 10px;">
+                    <div style="font-size: 18px; font-weight: 700; color: #0B0B0C; letter-spacing: -0.015em;">Pathways in Technology Early College</div>
+                    <div style="font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: #1D4ED8; border: 1px solid #C7D2FE; background: #EEF2FF; padding: 3px 7px;">Hidden gem</div>
+                  </div>
+                  <div style="font-size: 13.5px; color: #55555A;">Crown Heights · Ed. Opt · 570 students</div>
+                  <div style="font-size: 14px; color: #2A2A2F; max-width: 430px; text-wrap: pretty;">Six-year software track with an associate degree. Lottery-weighted, not screened.</div>
+                </div>
+                <div style="display: flex; flex-direction: column; gap: 3px;">
+                  <div style="font-family: 'JetBrains Mono', monospace; font-size: 18px; color: #0B0B0C;">2.8</div>
+                  <div style="font-size: 11.5px; color: #8A8A90; letter-spacing: 0.06em; text-transform: uppercase;">Apps / seat</div>
+                </div>
+                <div style="border: 1px solid #0B0B0C; text-align: center; font-size: 13.5px; padding: 8px 0; color: #0B0B0C;">Add</div>
+              </div>
+              <div style="display: grid; grid-template-columns: 34px 1fr 128px 96px; gap: 16px; align-items: start; padding: 22px 36px;">
+                <div style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #B8B8B4; padding-top: 5px;">05</div>
+                <div style="display: flex; flex-direction: column; gap: 5px;">
+                  <div style="font-size: 18px; font-weight: 700; color: #0B0B0C; letter-spacing: -0.015em;">Edward R. Murrow High School</div>
+                  <div style="font-size: 13.5px; color: #55555A;">Midwood · Audition, Ed. Opt · 3,900 students</div>
+                  <div style="font-size: 14px; color: #2A2A2F; max-width: 430px; text-wrap: pretty;">Large, wide course catalog, competitive soccer. CS is an elective, not a major.</div>
+                </div>
+                <div style="display: flex; flex-direction: column; gap: 3px;">
+                  <div style="font-family: 'JetBrains Mono', monospace; font-size: 18px; color: #0B0B0C;">5.4</div>
+                  <div style="font-size: 11.5px; color: #8A8A90; letter-spacing: 0.06em; text-transform: uppercase;">Apps / seat</div>
+                </div>
+                <div style="border: 1px solid #0B0B0C; text-align: center; font-size: 13.5px; padding: 8px 0; color: #0B0B0C;">Add</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+</body>
+</html>


### PR DESCRIPTION
Adds the approved high-fidelity design mock for the unified /find screen as `design/find-screen.html`, so the build issues can reference a concrete visual source of truth. Static reference only, not wired into the app; contains placeholder school data. No app code touched.