### PR TITLE
docs: document agent issue sequencing in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,4 @@
 - Never push, never merge, never switch branches — the coordinator owns git remotes.
 - `LESSONS.md` is coordinator-owned runtime state — read it for context, but never commit it (use `git add -A -- ':(exclude)LESSONS.md'`).
 - Stay strictly within the scope of the issue you were given; an independent reviewer rejects scope creep.
+- **Issue sequencing:** the coordinator picks up `agent-ok` issues in **ascending issue-number order** (file them in the order they should be built). An issue whose body contains a line `Blocked by #N` is skipped while issue #N is still open.


### PR DESCRIPTION
Documents the coordinator's new sequencing behavior so it isn't tribal knowledge: agent-ok issues are picked up in ascending issue-number order, and an issue whose body says 'Blocked by #N' is skipped while #N is open. Docs-only.