### PR TITLE
fix: issue #113 - Design foundation: token layer + fonts + five UI primitives (for the /find redesign)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The filter page and the chat page are still two separate surfaces that don't sha
 ## Architecture
 
 - **Frontend:** Next.js 14 (App Router), Tailwind CSS.
+- **Design system:** a token layer + five primitives (`Chip`, `SegmentedControl`, `Button`, `StatBlock`, `SchoolRow`) in `components/ui/`, backing the approved `/find` redesign (see `design/find-screen.html`). Named color tokens and four `next/font/google` families (Space Grotesk, Newsreader, Libre Franklin, JetBrains Mono) live in `tailwind.config.ts` / `lib/fonts.ts`. No existing page consumes these yet — landing them is a separate, later change.
 - **Generation:** Claude **Sonnet 5** (Anthropic), grounded prompts to prevent hallucination.
 - **Retrieval (RAG):** built from scratch — OpenAI `text-embedding-3-small` (1536-dim), semantic chunking (identity / academics / activities per school), hybrid deterministic-plus-semantic search, grounded chat API route.
 - **Data:** 457 NYC public high schools in Vercel Postgres (`dbn TEXT PRIMARY KEY, data JSONB`), read through a cached loader (`lib/load-schools.ts` → `getAllSchools()`) that degrades gracefully to an empty-state banner on any DB error. After a re-scrape, run `npx ts-node scripts/seed-schools.ts` to upsert `data/schools.json` into Postgres (the JSON is gitignored and never ships in the repo).

--- a/__tests__/ui-primitives.test.ts
+++ b/__tests__/ui-primitives.test.ts
@@ -1,0 +1,271 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+// Issue #113 — design foundation: token layer + fonts + five UI primitives.
+// This repo's jest setup runs in the `node` test environment (see
+// jest.config.js) with no jsdom/testing-library, and no existing test
+// imports/renders a .tsx component module directly — every component test
+// in this suite (see chat-page.test.ts, schools.test.ts) asserts against the
+// component's source text instead. These tests follow that same convention.
+
+function readSource(relPath: string): string {
+  return fs.readFileSync(path.join(__dirname, '..', relPath), 'utf-8')
+}
+
+const HEX_COLOR_RE = /#[0-9a-fA-F]{3,8}\b/g
+
+describe('tailwind.config.ts — design tokens (issue #113)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('tailwind.config.ts')
+  })
+
+  const TOKENS: Record<string, string> = {
+    ink: '#0B0B0C',
+    'ink-2': '#2A2A2F',
+    muted: '#55555A',
+    faint: '#8A8A90',
+    rule: '#E8E8E4',
+    'rule-light': '#F0F0EC',
+    border: '#DEDEDA',
+    'border-strong': '#C9C9C4',
+    accent: '#1D4ED8',
+    'accent-bg': '#EEF2FF',
+    'accent-border': '#C7D2FE',
+    gem: '#0F7B5A',
+    'gem-bg': '#F0F8F5',
+    'gem-border': '#BFE3D5',
+    surface: '#FFFFFF',
+    'surface-2': '#FAFAF8',
+  }
+
+  it.each(Object.entries(TOKENS))('defines the %s token as %s', (token, hex) => {
+    const re = new RegExp(`['"]?${token}['"]?:\\s*['"]${hex}['"]`, 'i')
+    expect(src).toMatch(re)
+  })
+
+  it('only defines one accent color (no second accent-* hue introduced)', () => {
+    // accent / accent-bg / accent-border must all share the same blue hue family (#1D4ED8, #EEF2FF, #C7D2FE)
+    const accentLines = src.split('\n').filter((l) => /accent/i.test(l))
+    expect(accentLines.length).toBeGreaterThanOrEqual(3)
+    expect(accentLines.some((l) => l.includes('#1D4ED8'))).toBe(true)
+  })
+
+  it('exposes font-display, font-wordmark, font-sans, font-mono families', () => {
+    expect(src).toMatch(/display:\s*\[[^\]]*var\(--font-display\)/)
+    expect(src).toMatch(/wordmark:\s*\[[^\]]*var\(--font-wordmark\)/)
+    expect(src).toMatch(/sans:\s*\[[^\]]*var\(--font-sans\)/)
+    expect(src).toMatch(/mono:\s*\[[^\]]*var\(--font-mono\)/)
+  })
+})
+
+describe('lib/fonts.ts — next/font/google loaders (issue #113)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('lib/fonts.ts')
+  })
+
+  it("imports the four fonts from 'next/font/google'", () => {
+    expect(src).toMatch(
+      /import\s*{\s*Space_Grotesk,\s*Newsreader,\s*Libre_Franklin,\s*JetBrains_Mono\s*}\s*from\s*'next\/font\/google'/
+    )
+  })
+
+  it('every font loader uses display: swap', () => {
+    const swapCount = (src.match(/display:\s*'swap'/g) || []).length
+    expect(swapCount).toBe(4)
+  })
+
+  it('Space Grotesk is weight 700 and exposed as --font-display', () => {
+    const block = src.slice(src.indexOf('Space_Grotesk('), src.indexOf('fontWordmark ='))
+    expect(block).toContain("'700'")
+    expect(block).toContain('--font-display')
+  })
+
+  it('Newsreader is italic weight 500 and exposed as --font-wordmark', () => {
+    const block = src.slice(src.indexOf('Newsreader('), src.indexOf('fontSans ='))
+    expect(block).toContain("'500'")
+    expect(block).toContain("'italic'")
+    expect(block).toContain('--font-wordmark')
+  })
+
+  it('Libre Franklin loads 400/500/700 and is exposed as --font-sans', () => {
+    const block = src.slice(src.indexOf('Libre_Franklin('), src.indexOf('fontMono ='))
+    expect(block).toContain("'400'")
+    expect(block).toContain("'500'")
+    expect(block).toContain("'700'")
+    expect(block).toContain('--font-sans')
+  })
+
+  it('JetBrains Mono loads 400/500 and is exposed as --font-mono', () => {
+    const block = src.slice(src.indexOf('JetBrains_Mono('))
+    expect(block).toContain("'400'")
+    expect(block).toContain("'500'")
+    expect(block).toContain('--font-mono')
+  })
+})
+
+describe('app/layout.tsx — fonts wired without changing the default body typeface (issue #113)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('app/layout.tsx')
+  })
+
+  it('still applies inter.className to <body> (no default-page-font change)', () => {
+    expect(src).toContain('<body className={inter.className}>')
+  })
+
+  it('attaches the new font CSS variables on <html>, not <body>', () => {
+    expect(src).toMatch(/<html[^>]*className=\{fontVariables\}/)
+  })
+
+  it('imports the font loaders from lib/fonts', () => {
+    expect(src).toContain("from '@/lib/fonts'")
+  })
+})
+
+describe.each([
+  ['Chip', 'components/ui/Chip.tsx'],
+  ['SegmentedControl', 'components/ui/SegmentedControl.tsx'],
+  ['Button', 'components/ui/Button.tsx'],
+  ['StatBlock', 'components/ui/StatBlock.tsx'],
+  ['SchoolRow (ui primitive)', 'components/ui/SchoolRow.tsx'],
+])('%s — no hardcoded hex colors (issue #113)', (_name, relPath) => {
+  it('contains no raw hex color literals (must reference named tokens)', () => {
+    const src = readSource(relPath)
+    // Strip out any stray comments that might mention a hex for context.
+    const codeOnly = src.replace(/\/\/.*$/gm, '')
+    expect(codeOnly.match(HEX_COLOR_RE)).toBeNull()
+  })
+})
+
+describe('Chip primitive (issue #113)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('components/ui/Chip.tsx')
+  })
+
+  it('exports a ChipVariant type covering set | inferred | unselected | add', () => {
+    expect(src).toMatch(/set['"]?\s*\|\s*['"]?inferred['"]?\s*\|\s*['"]?unselected['"]?\s*\|\s*['"]?add/)
+  })
+
+  it('"set" variant is a solid ink fill with white text and a check suffix', () => {
+    expect(src).toMatch(/set:\s*'bg-ink[^']*text-white/)
+    expect(src).toContain("'set' && <span className=\"ml-1.5\">✓</span>")
+  })
+
+  it('"inferred" variant uses accent-bg fill, accent-border, accent text, and a trailing ×', () => {
+    expect(src).toMatch(/inferred:\s*'bg-accent-bg[^']*border-accent-border[^']*text-accent'/)
+    expect(src).toContain("'inferred' && <span className=\"ml-1.5\">×</span>")
+  })
+
+  it('"unselected" variant is just a 1px border (no fill)', () => {
+    expect(src).toMatch(/unselected:\s*'bg-transparent border border-border/)
+  })
+
+  it('"add" variant uses a dashed border-strong border', () => {
+    expect(src).toMatch(/add:\s*'bg-transparent border border-dashed border-border-strong/)
+  })
+})
+
+describe('SegmentedControl primitive (issue #113)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('components/ui/SegmentedControl.tsx')
+  })
+
+  it('wraps cells in a 1px border box', () => {
+    expect(src).toContain('border border-border')
+  })
+
+  it('marks the selected cell with ink fill + white text, others with ink-3 text', () => {
+    expect(src).toMatch(/selected\s*\?\s*'bg-ink text-white[^']*'\s*:\s*'text-ink-3'/)
+  })
+
+  it('divides non-first cells with a 1px left border', () => {
+    expect(src).toMatch(/i > 0 \? 'border-l border-border' : ''/)
+  })
+})
+
+describe('Button primitive (issue #113)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('components/ui/Button.tsx')
+  })
+
+  it('"primary" variant is an accent fill with white, medium-weight text', () => {
+    expect(src).toMatch(/primary:\s*'bg-accent text-white font-medium/)
+  })
+
+  it('"outline" variant is a 1px ink border', () => {
+    expect(src).toMatch(/outline:\s*'bg-transparent text-ink border border-ink'/)
+  })
+
+  it('defaults to the primary variant', () => {
+    expect(src).toContain("variant = 'primary'")
+  })
+})
+
+describe('StatBlock primitive (issue #113)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('components/ui/StatBlock.tsx')
+  })
+
+  it('renders a mono value at 16px in ink over an uppercase faint label', () => {
+    expect(src).toContain('font-mono text-[16px] text-ink')
+    expect(src).toMatch(/font-mono text-\[10\.5px\] tracking-\[0\.06em\] uppercase text-faint/)
+  })
+})
+
+describe('SchoolRow ui primitive (issue #113)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('components/ui/SchoolRow.tsx')
+  })
+
+  it('uses the 34px/1fr/128px/96px grid with 16px gap', () => {
+    expect(src).toContain('grid-cols-[34px_1fr_128px_96px]')
+    expect(src).toContain('gap-4')
+  })
+
+  it('uses 22px/36px padding, items-start, and a rule-light bottom border', () => {
+    expect(src).toContain('px-9 py-[22px]')
+    expect(src).toContain('items-start')
+    expect(src).toContain('border-b border-rule-light')
+  })
+
+  it('hovers to surface-2 with a 120ms ease-out transition and no transform', () => {
+    expect(src).toContain('hover:bg-surface-2')
+    expect(src).toContain('transition-colors duration-[120ms] ease-out')
+    expect(src).not.toMatch(/hover:(scale|translate)/)
+  })
+
+  it('puts the name and hidden-gem badge in a gapped flex row (badge cannot land mid-wrap)', () => {
+    expect(src).toMatch(/flex items-center gap-2\.5[\s\S]{0,200}isHiddenGem/)
+  })
+
+  it('is a distinct module from the existing components/SchoolRow.tsx (no collision)', () => {
+    const existing = readSource('components/SchoolRow.tsx')
+    expect(existing).not.toContain('grid-cols-[34px_1fr_128px_96px]')
+  })
+})
+
+describe('components/ui barrel exports (issue #113)', () => {
+  it('re-exports all five primitives', () => {
+    const src = readSource('components/ui/index.ts')
+    expect(src).toContain("from './Chip'")
+    expect(src).toContain("from './SegmentedControl'")
+    expect(src).toContain("from './Button'")
+    expect(src).toContain("from './StatBlock'")
+    expect(src).toContain("from './SchoolRow'")
+  })
+})

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,9 +3,16 @@ import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import NavBar from '@/components/NavBar'
 import PHProvider from '@/components/PosthogProvider'
+import { fontDisplay, fontWordmark, fontSans, fontMono } from '@/lib/fonts'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
+
+// Design foundation (issue #113): only defines the --font-* CSS variables
+// used by the new font-display/font-wordmark/font-sans/font-mono Tailwind
+// utilities. Body keeps inter.className below, so no existing page's
+// default typeface changes.
+const fontVariables = `${fontDisplay.variable} ${fontWordmark.variable} ${fontSans.variable} ${fontMono.variable}`
 
 export function generateMetadata(): Metadata {
   return {
@@ -19,7 +26,7 @@ export function generateMetadata(): Metadata {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className={fontVariables}>
       <body className={inter.className}>
         <PHProvider>
           <NavBar />

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,18 @@
+import { ButtonHTMLAttributes } from 'react'
+
+export type ButtonVariant = 'primary' | 'outline'
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+}
+
+const BASE = 'font-sans text-[15px] px-[26px] py-[13px] transition-colors duration-[120ms] ease-out'
+
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  primary: 'bg-accent text-white font-medium border border-accent',
+  outline: 'bg-transparent text-ink border border-ink',
+}
+
+export default function Button({ variant = 'primary', className = '', ...rest }: Props) {
+  return <button className={`${BASE} ${VARIANT_CLASSES[variant]} ${className}`} {...rest} />
+}

--- a/components/ui/Chip.tsx
+++ b/components/ui/Chip.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react'
+
+export type ChipVariant = 'set' | 'inferred' | 'unselected' | 'add'
+
+interface Props {
+  variant: ChipVariant
+  children: ReactNode
+  onClick?: () => void
+  className?: string
+}
+
+const BASE = 'inline-flex items-center font-sans text-[13.5px] px-[13px] py-[7px] leading-none'
+
+const VARIANT_CLASSES: Record<ChipVariant, string> = {
+  set: 'bg-ink border border-ink text-white',
+  inferred: 'bg-accent-bg border border-accent-border text-accent',
+  unselected: 'bg-transparent border border-border text-ink-3',
+  add: 'bg-transparent border border-dashed border-border-strong text-muted',
+}
+
+export default function Chip({ variant, children, onClick, className = '' }: Props) {
+  return (
+    <span
+      onClick={onClick}
+      className={`${BASE} ${VARIANT_CLASSES[variant]} ${onClick ? 'cursor-pointer' : ''} ${className}`}
+    >
+      {children}
+      {variant === 'set' && <span className="ml-1.5">✓</span>}
+      {variant === 'inferred' && <span className="ml-1.5">×</span>}
+    </span>
+  )
+}

--- a/components/ui/SchoolRow.tsx
+++ b/components/ui/SchoolRow.tsx
@@ -1,0 +1,55 @@
+import { ReactNode } from 'react'
+
+interface Props {
+  rowNumber: number
+  name: string
+  isHiddenGem?: boolean
+  metadata: string
+  rationale: string
+  statValue: string | number
+  statLabel: string
+  action: ReactNode
+}
+
+export default function SchoolRow({
+  rowNumber,
+  name,
+  isHiddenGem = false,
+  metadata,
+  rationale,
+  statValue,
+  statLabel,
+  action,
+}: Props) {
+  return (
+    <div
+      className="grid grid-cols-[34px_1fr_128px_96px] gap-4 items-start px-9 py-[22px] border-b border-rule-light hover:bg-surface-2 transition-colors duration-[120ms] ease-out"
+    >
+      <div className="font-mono text-[13px] text-row-index pt-[5px]">
+        {String(rowNumber).padStart(2, '0')}
+      </div>
+
+      <div className="flex flex-col gap-[5px]">
+        <div className="flex items-center gap-2.5">
+          <div className="font-sans font-bold text-[18px] text-ink">{name}</div>
+          {isHiddenGem && (
+            <span className="font-mono text-[10.5px] tracking-[0.08em] uppercase text-gem bg-gem-bg border border-gem-border px-[7px] py-[3px]">
+              Hidden gem
+            </span>
+          )}
+        </div>
+        <div className="font-sans text-[13.5px] text-faint">{metadata}</div>
+        <div className="font-sans text-[14.5px] leading-[1.5] text-ink-2 max-w-[430px]" style={{ textWrap: 'pretty' }}>
+          {rationale}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-[3px]">
+        <div className="font-mono text-[18px] text-ink">{statValue}</div>
+        <div className="font-mono text-[11.5px] tracking-[0.06em] uppercase text-faint">{statLabel}</div>
+      </div>
+
+      <div>{action}</div>
+    </div>
+  )
+}

--- a/components/ui/SegmentedControl.tsx
+++ b/components/ui/SegmentedControl.tsx
@@ -1,0 +1,34 @@
+export interface SegmentedControlOption {
+  label: string
+  value: string
+}
+
+interface Props {
+  options: SegmentedControlOption[]
+  value: string
+  onChange?: (value: string) => void
+  className?: string
+}
+
+export default function SegmentedControl({ options, value, onChange, className = '' }: Props) {
+  return (
+    <div className={`flex border border-border font-sans ${className}`}>
+      {options.map((option, i) => {
+        const selected = option.value === value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange?.(option.value)}
+            aria-pressed={selected}
+            className={`flex-1 text-center text-[13px] py-2 transition-colors duration-[120ms] ease-out ${
+              i > 0 ? 'border-l border-border' : ''
+            } ${selected ? 'bg-ink text-white border-ink' : 'text-ink-3'}`}
+          >
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/ui/StatBlock.tsx
+++ b/components/ui/StatBlock.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  value: string | number
+  label: string
+  className?: string
+}
+
+export default function StatBlock({ value, label, className = '' }: Props) {
+  return (
+    <div className={`flex flex-col gap-[3px] ${className}`}>
+      <div className="font-mono text-[16px] text-ink">{value}</div>
+      <div className="font-mono text-[10.5px] tracking-[0.06em] uppercase text-faint">{label}</div>
+    </div>
+  )
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,0 +1,8 @@
+export { default as Chip } from './Chip'
+export type { ChipVariant } from './Chip'
+export { default as SegmentedControl } from './SegmentedControl'
+export type { SegmentedControlOption } from './SegmentedControl'
+export { default as Button } from './Button'
+export type { ButtonVariant } from './Button'
+export { default as StatBlock } from './StatBlock'
+export { default as SchoolRow } from './SchoolRow'

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,0 +1,34 @@
+import { Space_Grotesk, Newsreader, Libre_Franklin, JetBrains_Mono } from 'next/font/google'
+
+// Design foundation (issue #113) — one font per Tailwind family, each exposed
+// as a CSS variable so tailwind.config.ts can map font-display/font-wordmark/
+// font-sans/font-mono to them. Attached on <html> in app/layout.tsx.
+
+export const fontDisplay = Space_Grotesk({
+  subsets: ['latin'],
+  weight: ['700'],
+  display: 'swap',
+  variable: '--font-display',
+})
+
+export const fontWordmark = Newsreader({
+  subsets: ['latin'],
+  weight: ['500'],
+  style: ['italic'],
+  display: 'swap',
+  variable: '--font-wordmark',
+})
+
+export const fontSans = Libre_Franklin({
+  subsets: ['latin'],
+  weight: ['400', '500', '700'],
+  display: 'swap',
+  variable: '--font-sans',
+})
+
+export const fontMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  display: 'swap',
+  variable: '--font-mono',
+})

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,8 +8,49 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        // Design foundation tokens (issue #113) — components must reference
+        // these names, never hardcode a hex.
+        ink: '#0B0B0C',
+        'ink-2': '#2A2A2F',
+        // Not in the original token table, but the approved reference
+        // (design/find-screen.html) uses this exact shade for unselected
+        // chip / segmented-control text, so it's named rather than hardcoded.
+        'ink-3': '#3A3A3F',
+        muted: '#55555A',
+        faint: '#8A8A90',
+        rule: '#E8E8E4',
+        'rule-light': '#F0F0EC',
+        border: '#DEDEDA',
+        'border-strong': '#C9C9C4',
+        accent: '#1D4ED8',
+        'accent-bg': '#EEF2FF',
+        'accent-border': '#C7D2FE',
+        gem: '#0F7B5A',
+        'gem-bg': '#F0F8F5',
+        'gem-border': '#BFE3D5',
+        surface: '#FFFFFF',
+        'surface-2': '#FAFAF8',
+        // Also not in the original table: the approved reference uses this
+        // exact shade for the SchoolRow mono row numeral (e.g. "01").
+        'row-index': '#B8B8B4',
+      },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        // Libre Franklin is the workhorse for all reading text.
+        sans: ['var(--font-sans)', 'Libre Franklin', 'system-ui', 'sans-serif'],
+        // Space Grotesk 700 — page titles + "Admit" in the wordmark only.
+        display: ['var(--font-display)', 'Space Grotesk', 'sans-serif'],
+        // Newsreader italic 500 — "Day" in the wordmark only.
+        wordmark: ['var(--font-wordmark)', 'Newsreader', 'serif'],
+        // JetBrains Mono — numbers/codes only (stat values, counts, DBNs, eyebrows).
+        mono: [
+          'var(--font-mono)',
+          'JetBrains Mono',
+          'ui-monospace',
+          'SFMono-Regular',
+          'Menlo',
+          'monospace',
+        ],
       },
     },
   },


### PR DESCRIPTION
## Summary

Implemented the design foundation for the `/find` redesign (issue #113), purely additive — no existing page's behavior or rendered markup changed.

**Token layer** (`tailwind.config.ts`): all 16 named color tokens from the issue table (`ink`, `muted`, `accent`, `gem`, `surface`, etc.), plus three extra tokens (`ink-3`, `row-index`) for hexes the approved HTML reference uses that weren't in the written table — added as named tokens rather than hardcoded, per the "never hardcode a hex" rule.

**Fonts** (`lib/fonts.ts`, `app/layout.tsx`): Space Grotesk, Newsreader (italic), Libre Franklin, and JetBrains Mono via `next/font/google`, all `display: 'swap'`, exposed as `font-display`/`font-wordmark`/`font-sans`/`font-mono`. The font CSS variables are attached on `<html>`; `<body>` keeps its existing `inter.className` unchanged, so no page's default typeface shifts.

One disclosed exception worth flagging: `components/SchoolRow.tsx` (existing, rendered on `/list`) already uses Tailwind's built-in `font-mono` utility for its row-number badge. Since the issue requires `font-mono` to resolve to JetBrains Mono, that single numeral's typeface will now render in JetBrains Mono instead of the browser-default monospace stack — a subtle font substitution, not a layout/behavior change, and unavoidable while satisfying the token spec as written.

**Five primitives** (`components/ui/`): `Chip` (set/inferred/unselected/add), `SegmentedControl`, `Button` (primary/outline), `StatBlock`, and a new presentational `SchoolRow` (distinct module from the existing one) — all exported from `components/ui/index.ts`.

**Tests** (`__tests__/ui-primitives.test.ts`, 50 cases): follows this repo's existing convention (no jsdom/testing-library is installed; jest runs in `node` env) of asserting against component source text rather than rendering — covers token values, font config, variant class strings, and confirms no hex literals leak into the primitive files.

`npm test` (716 passed) and `npm run build` both exit 0. Committed on `task-113-design-foundation-token-layer-`.

Closes #113