### PR TITLE
design: saved list (/my-schools) + refreshed find/detail references

### DIFF
--- a/design/find-screen-diff.html
+++ b/design/find-screen-diff.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Admit Day — /find: live build vs design</title><style>body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:900px;margin:40px auto;padding:0 20px;line-height:1.6;color:#222}table{border-collapse:collapse;width:100%}th,td{border:1px solid #ddd;padding:6px 10px;text-align:left}th{background:#f5f5f5}code{background:#f0f0f0;padding:2px 5px}pre{background:#f6f6f6;padding:14px;overflow-x:auto}h1,h2,h3{line-height:1.25}</style></head><body><h1><code>/find</code> — live build vs. design, and what has to change</h1>
+<p>Written against <code>https://www.admitday.com/find</code> as of Jul 30, 2026, read as content (structure and copy, not pixels). Read with <code>design_handoff_find_screen/README.md</code>; this file only lists deltas and the decisions made after that handoff shipped.</p>
+<p>Two of these are <strong>blocking</strong> — <code>/my-schools</code> cannot be reached or populated without them.</p>
+<hr />
+<h2>1. Rows have no <code>Add to list</code> control — BLOCKING</h2>
+<p>The design's row grid is <code>34px 1fr 128px 96px</code>, where the last 96px column is an <code>Add</code> button (1px <code>ink</code> outline; filled + <code>Remove</code> when already saved). The live rows end at the metadata line.</p>
+<p>Without it there is no way into <code>/my-schools</code> from the list, and the whole saved-list screen is unreachable.</p>
+<p><strong>Fix:</strong> add the fourth column. Optimistic toggle, <code>localStorage</code> until auth, header count increments in the same tick. Same two states as the button on <code>/school</code>, so the control is recognisable across screens.</p>
+<h2>2. The header carries no saved count, and nav item three is stale — BLOCKING</h2>
+<p>Live: <code>Home</code> / <code>My Schools</code> / <code>Readiness</code>.<br />
+Design: <code>Find</code> / <code>My Schools</code> + mono saved count in <code>accent</code> / <code>Checklist</code>.</p>
+<p>Three separate changes:</p>
+<ul>
+<li><strong><code>Home</code> → <code>Find</code>.</strong> The route is the product's core screen, not a homepage. If a marketing landing page needs a nav slot, it goes on the wordmark, which already links to <code>/</code>.</li>
+<li><strong>Mono saved count</strong> on <code>My Schools</code>, in <code>accent</code>, at 12.5px. This is the only feedback that <code>Add</code> worked, and it's the entry point to <code>/my-schools</code>.</li>
+<li><strong><code>Readiness</code> → <code>Checklist</code>.</strong> Decided while designing <code>/my-schools</code>: requirements and deadlines live on that screen, and "Readiness" implied a score, which the product does not produce. Rename everywhere.</li>
+</ul>
+<h2>3. Rows are missing the two fields the saved list compares on</h2>
+<p>Live rows show <code>Borough · Track</code>. The design shows <code>Neighborhood · Track · N students</code> (or DBN) plus a <strong>stat column: applicants per seat</strong> in mono.</p>
+<p><code>/my-schools</code> puts applicants-per-seat and neighborhood side by side on every saved school, because that is how a family tells its list apart. If <code>/find</code> doesn't surface the ratio, the only selectivity signal in the product is two clicks deep — the specific trust failure the <code>/school</code> stats grid was built to fix. A parent should not be able to add twelve schools without once seeing how selective any of them are.</p>
+<p><strong>Fix:</strong> add the stat column (<code>applicants_per_seat</code>, mono 16px over a 10.5px uppercase <code>faint</code> label) and put neighborhood in the metadata line. Omit the stat cell entirely when the DOE didn't publish it — never <code>—</code>, never <code>0</code>. Same rule as <code>/school</code> and <code>/my-schools</code>.</p>
+<h2>4. Rows don't appear to link to <code>/school/[dbn]</code></h2>
+<p>School names read as plain text. They are the primary navigation into the detail view, which is designed and handed off.</p>
+<p><strong>Fix:</strong> name is a link; whole row is hoverable (<code>surface-2</code>), name and <code>Add</code> are the only click targets.</p>
+<h2>5. All 457 schools render as one flat list</h2>
+<p>No result-count band, no active-filter summary, no paging.</p>
+<p>The design has a <strong>results count band</strong> (<code>16px 36px</code>, <code>surface-2</code>, <code>border-bottom: 1px rule</code>): left, mono count + the active filters named in plain language (<code>31 matches in Brooklyn + Queens, Screened</code>); right, mono uppercase <code>SORTED BY FIT</code>. And a <strong>footer band</strong> with <code>26 more matches</code> — paginate or lazy-load.</p>
+<p>Naming the filters is load-bearing in two places downstream: <code>/school</code>'s back band echoes that exact string (<code>‹ Back to 31 matches · Brooklyn + Queens, Screened</code>), and <code>/my-schools</code> shows the same criteria as chips. All three read one source.</p>
+<p><strong>Fix:</strong> add both bands. Cap the initial render (~25 rows).</p>
+<h2>6. The ask box is a separate field below the filters, with no chip mechanic</h2>
+<p>Live: <code>Interests</code>, then <code>Ask</code>, as two more fields in the filter stack, with the note <em>"Filters narrow the list. The ask box below just annotates it — nothing gets removed."</em></p>
+<p>The design puts the ask in the right column as a command bar with a mono <code>›</code> prompt and a square accent submit, and — the important part — renders every signal it extracts as an <strong>individually removable accent chip</strong> under an <code>APPLIED</code> eyebrow.</p>
+<p>That copy line is honest about the current behavior, but it's describing a workaround: if the ask only annotates, the system has inferred something it won't show and can't be corrected. The chips are the trust mechanic, and they're also the input for two downstream screens: <code>/school</code>'s <code>MATCHED YOUR ASK</code> accent chips, and <code>/my-schools</code>' <code>SELECTION CRITERIA</code> strip. <strong>Neither has an input until the ask returns structured signals.</strong></p>
+<p><strong>Fix, in order:</strong><br />
+1. The ask endpoint returns the extracted signals as structured data (<code>{ id, label, kind }</code>), not just prose. If this needs API work, it is the first thing to do — everything else here is layout.<br />
+2. Render them as chips with a trailing <code>×</code>. Removing one re-runs matching locally, <strong>without</strong> re-calling the model.<br />
+3. Move the ask out of the filter stack into the right column above the results.<br />
+4. Fold <code>Interests</code> into it — a free-text interest is an ask signal, not a fourth filter group.</p>
+<h2>7. Filter rail — mostly right, two gaps</h2>
+<p>Borough, Admissions track and Size are all present with the right options, and <code>Reset filters</code> exists. Missing from the content:</p>
+<ul>
+<li><strong>Per-track match counts</strong> — the design shows a mono count of matching schools on each track row, and <code>N selected</code> in <code>accent</code> on the Borough group label. Counts are what make a deterministic filter feel deterministic.</li>
+<li><strong>Size as a segmented control</strong> — 4 equal cells in one 1px <code>border</code> box, selected cell <code>ink</code>-filled. Live it reads as a list of four options. Behaviorally the same, visually a different primitive.</li>
+<li>Confirm the rail is 316px with <code>border-right: 1px solid rule</code>. That measure is now shared by <code>/school</code>'s info rail and <code>/my-schools</code>' composition rail — it's the product's spine.</li>
+</ul>
+<p><code>Zoned</code> and <code>Educational Option</code> are in the live data, so keep both in the track list.</p>
+<h2>8. Filter state must be in the URL</h2>
+<p>Can't be confirmed from content, so flagging it: the design requires filter state as query params. <code>/school</code>'s back band and <code>/my-schools</code>' <code>Edit criteria</code> link both serialize back to a filtered <code>/find</code>. If state is component-only, both break on refresh or share.</p>
+<h2>9. Footer disclaimer — keep, and reword slightly</h2>
+<p>The live footer is doing the right job and says more than the design asked for. Two notes:</p>
+<ul>
+<li>Keep the MySchools link and the "no tool can guarantee an offer" framing. That is the trust story.</li>
+<li>The DOE-randomness sentence is good but long for a persistent band. The design's version — <em>"Requirements and deadlines from DOE data · confirm at MySchools before you submit"</em> — is the standing line; the fuller paragraph belongs on an About or methodology page, or in the sign-up flow. <code>/my-schools</code> follows the short pattern (two 13px <code>faint</code> lines).</li>
+</ul>
+<hr />
+<h2>Order of work</h2>
+<ol>
+<li><code>Add to list</code> on rows + live saved count in the header. <em>(Unblocks <code>/my-schools</code>.)</em></li>
+<li><code>Readiness</code> → <code>Checklist</code>; <code>Home</code> → <code>Find</code>.</li>
+<li>Row links to <code>/school/[dbn]</code>; applicants-per-seat stat column; neighborhood in the metadata line.</li>
+<li>Filter state in the URL.</li>
+<li>Ask returns structured signals → chip bar → move the ask into the right column, absorb <code>Interests</code>.</li>
+<li>Results count band with named filters, footer paging.</li>
+<li>Rail polish: per-track counts, <code>N selected</code>, segmented Size control.</li>
+</ol>
+<p>1–3 are enough to make <code>/my-schools</code> real. 5 is what makes <code>/school</code> and <code>/my-schools</code> show the family their own words back.</p>
+<h2>Not a delta, but worth stating</h2>
+<p>Nothing in the live content suggests a derived score, rating, or admissions prediction anywhere. That's the hardest constraint in this product to hold, and it's being held. Keep it that way: no "reach/target/likely", no fit percentage, no selectivity rating — only DOE values, published as given.</p></body></html>

--- a/design/saved-list-handoff.html
+++ b/design/saved-list-handoff.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Admit Day — Saved List Design Handoff</title><style>body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:900px;margin:40px auto;padding:0 20px;line-height:1.6;color:#222}table{border-collapse:collapse;width:100%}th,td{border:1px solid #ddd;padding:6px 10px;text-align:left}th{background:#f5f5f5}code{background:#f0f0f0;padding:2px 5px}pre{background:#f6f6f6;padding:14px;overflow-x:auto}h1,h2,h3{line-height:1.25}</style></head><body><h1>Handoff: Admit Day — saved list (<code>/my-schools</code>)</h1>
+<h2>Overview</h2>
+<p>The screen behind the saved count in the header. A family lands here after adding schools from <code>/find</code> or a school detail page, and it answers three questions and only three:</p>
+<ol>
+<li><strong>What's on my list, and in what order?</strong></li>
+<li><strong>What does that list look like as a whole?</strong></li>
+<li><strong>Can I get it out of here?</strong></li>
+</ol>
+<p>Everything else was deliberately removed. Requirements and deadlines live on <code>/checklist</code>, not here — this page is about the list itself.</p>
+<p><strong>Rank order is the product.</strong> NYC families submit an ordered list of programs in MySchools; the ranking on this page is a draft of that submission. So the ranking table is the page's spine, and the reorder control is treated as a primary control, not a nicety.</p>
+<p><strong>The list is generated, not just collected.</strong> Schools arrive here because they matched the family's selection criteria on <code>/find</code>. There is no cap on length — counselors advise ranking twelve or more, but the design never counts down to a target or nags. No "3 of 12 slots used", no progress bar, no completion badge.</p>
+<p>Target codebase: Next.js 14 App Router + React + Tailwind, tokens already in <code>tailwind.config.ts</code> from the <code>/find</code> handoff.</p>
+<h2>About the design files</h2>
+<p><code>saved-list.html</code> is a <strong>design reference created in HTML</strong> — intended look and layout, not production code. Recreate it with the codebase's Tailwind tokens and App Router patterns; don't paste the markup in. All schools, ratios and dates are <strong>placeholder</strong>.</p>
+<p><strong>Fidelity: high.</strong> Colors, type, spacing and layout are final. Interactions are indicated, not implemented.</p>
+<p><strong><code>6b</code> is the approved direction.</strong> <code>6a</code> and <code>6c</code> are the same layout in two other data conditions — build one component that produces all three.</p>
+<h2>Inherited system — unchanged</h2>
+<p>Radius <code>0</code> everywhere. No shadows. Separation by 1px rules, never cards. One accent: <code>#1D4ED8</code>.</p>
+<p>Tokens: <code>ink #0B0B0C</code>, <code>ink-2 #2A2A2F</code>, <code>muted #55555A</code>, <code>faint #8A8A90</code>, <code>rule #E8E8E4</code>, <code>rule-light #F0F0EC</code>, <code>border #DEDEDA</code>, <code>surface #FFFFFF</code>, <code>surface-2 #FAFAF8</code>, <code>accent #1D4ED8</code>, <code>accent-bg #EEF2FF</code>, <code>accent-border #C7D2FE</code>.</p>
+<p>Three faces, three jobs — <strong>Space Grotesk 700</strong> for the page title (<code>My Schools</code>) and the <code>Admit</code> wordmark only; <strong>Libre Franklin</strong> for everything read; <strong>JetBrains Mono</strong> for every number, code, date and uppercase eyebrow; <strong>Newsreader italic 500</strong> for the <code>Day</code> in the wordmark only.</p>
+<p>1120px max width. Same header. Nav is <code>Find</code> / <code>My Schools</code> + mono saved count in accent / <strong><code>Checklist</code></strong> — note the rename from <code>Readiness</code>; it applies across all screens.</p>
+<h2>Design decisions (and why)</h2>
+<h3>Reordering is explicit controls, with drag as a shortcut</h3>
+<p>Each row carries a mono rank numeral and a pair of 26px <code>↑</code> / <code>↓</code> buttons; the whole row is also draggable via a <code>⠿</code> handle. Drag alone was rejected for three reasons: this list can run to 14+ rows so drag means scroll-drag, the audience skews toward parents on phones and shared/older machines, and rank order is the one thing on the page that must be verifiable — a parent needs to see <code>07</code> and know it is seventh, then move it one place with certainty.</p>
+<p>The <code>↑</code> on the first row and <code>↓</code> on the last are rendered in <code>border</code> grey (disabled), never hidden — the control's shape stays constant down the column.</p>
+<p><strong>Rank numerals are positional, not stored.</strong> They re-render <code>01…N</code> after every move. Never show a stale number.</p>
+<h3>Composition is a proportion band plus counts. It is never a score.</h3>
+<p>A 12px-tall band of <code>flex</code>-weighted segments in four greys (<code>ink</code> → <code>ink-2</code> → <code>muted</code> → <code>faint</code>), followed by a legend of <code>swatch · label · mono count</code>. Greyscale is deliberate: color would encode good/bad. Nothing is ordered by desirability, nothing is labelled "risky", "safe", "reach" or "balanced", and no percentage is shown — a percentage invites a target.</p>
+<p><strong>The segment weights must be derived from the same counts as the legend.</strong> They encoded a different set in an early build and it read as three open/zoned schools where there were two — precisely the misread this section exists to prevent. One function, one source.</p>
+<p><strong>Track buckets are mutually exclusive and priority-ordered</strong>, because DOE programs carry several methods at once (<code>Screened, Audition</code>). Resolve in this order: <code>SHSAT</code> → <code>Audition / Portfolio</code> → <code>Screened</code> → <code>Open / Zoned</code>. A program is counted once, in its most selective bucket. The buckets must sum to the saved total — assert this in a test.</p>
+<p>A zero-count bucket stays in the legend with a hollow swatch (1px <code>border</code> on <code>surface</code>) and <code>faint</code> text. <strong>This is the point of the section</strong>: a family with no open or zoned option needs to see <code>Open / Zoned 0</code>, and it cannot be seen if the row is dropped.</p>
+<p>Below the legend, one factual sentence under a mono <code>READING THE SHAPE</code> eyebrow — generated from the counts, describing only what is there ("Every school on the list screens or tests. No open or zoned program is on it yet."). Never advisory, never predictive. The page footer carries the standing disclaimer: <em>"Counts only — we don't score a list or predict an outcome."</em></p>
+<p>Boroughs and applicants-per-seat get the same treatment as <code>/school</code>'s stats grid: a 3-up cell grid, <code>gap: 1px</code> on a <code>rule</code> background, mono number over an uppercase label. Number first, label second — the digit is the content.</p>
+<h3>Requirements are not on this page</h3>
+<p>They were designed here and cut. Deadlines belong to <code>/checklist</code>, and a family looking at both saw the same three dates twice. Nothing on <code>/my-schools</code> links to it except the nav item. When <code>/checklist</code> is designed, it reads the same saved set.</p>
+<h3>Export is one primary button in the header</h3>
+<p>Labelled just <strong><code>Export</code></strong> — <code>ink</code> fill, white, <code>11px 20px</code>, top right of the title band. It was originally a rail card with explanatory copy and a PDF label; both were removed. Export is the growth mechanic, so it gets the page's only filled button and no competition. Share-link is deliberately deferred — the design has room for it as a second button in the same cluster.</p>
+<p>The export itself is the ranked list in order with each program's DBN: the sheet a parent keeps open while typing into MySchools. Rules-and-rows on white prints cleanly, which is why the layout was built this way.</p>
+<h3>The match strip is borrowed content and is labelled as such</h3>
+<p><code>6a</code> carries a 3-up strip under the eyebrow <strong><code>FROM YOUR 31 MATCHES ON FIND</code></strong>, with an <code>Open in Find ↗</code> link. It is the <code>/find</code> result set for the saved criteria, re-run and de-duplicated against the list — nothing new is computed here, and <code>/find</code> stays the source of truth. Each card names <em>why</em> it matched in accent text.</p>
+<p><strong>Show it below 6 saved; drop it above.</strong> Once the list is long, re-showing search results competes with the ranking, and the nav handles it from there.</p>
+<h2>Layout</h2>
+<h3>1. Header — <code>18px 36px</code>, <code>border-bottom: 1px rule</code></h3>
+<p>As <code>/find</code>, with <code>Checklist</code> as the third nav item and the mono saved count on <code>My Schools</code>.</p>
+<h3>2. Title band — grid <code>1fr auto</code>, <code>align-items: end</code>, <code>30px 36px 24px</code>, <code>border-bottom: 1px rule</code></h3>
+<p>Left: <code>My Schools</code> (Space Grotesk 700, 40px, lh 1.04, ls −0.038em). Right: the <code>Export</code> button. No subtitle, no count line — the nav count and the table's own numerals carry that.</p>
+<h3>3. Selection criteria strip — <code>11px 36px</code>, <code>surface-2</code>, <code>border-bottom: 1px rule</code></h3>
+<p>Mono uppercase <code>SELECTION CRITERIA</code> label, then one accent chip per criterion (12.5px, <code>accent-bg</code>, 1px <code>accent-border</code>, <code>5px 9px</code>), then a right-aligned <code>Edit criteria</code> link back to <code>/find</code> with those filters applied. Same chip treatment as the ask chips on <code>/find</code> — same mechanic, so the same styling. Omit the strip when a list was built without criteria.</p>
+<h3>4. Body — grid <code>1fr 316px</code>, main column <code>border-right: 1px solid rule</code></h3>
+<p>316px matches the <code>/find</code> filter rail and the <code>/school</code> info rail, so all three screens share a spine.</p>
+<p><strong>Main column — the ranking</strong> (<code>26px 36px 30px</code>). Eyebrow row: <code>YOUR RANKING</code> left, and right, 12.5px <code>faint</code>: <em>"Drag a row, or use ↑ ↓"</em> — on the wider single-column states the sentence extends to <em>"— this order is the one you'll enter in MySchools."</em></p>
+<p>Table is a set of grid rows, not a <code>&lt;table&gt;</code>. Column template at 14 rows (<code>1fr</code> main column): <code>46px 1fr 132px 62px 74px</code>, gap 12px, <code>11px 0</code>, <code>border-bottom: 1px rule-light</code>. At full width (<code>6a</code>, <code>6c</code>, single-column states) it opens up to <code>54px 1fr 156px 112px 96px</code>, gap 16px, <code>15px 0</code>, and the remove control becomes the word <code>Remove</code> instead of <code>×</code>.</p>
+<p>Header row: mono 10px uppercase, ls .1em, <code>faint</code> — <code>Rank</code> / <code>School &amp; Program</code> / <code>Track</code> / <code>A/Seat</code>, plus an empty cell for controls. <code>border-bottom: 1px rule</code>.</p>
+<p>Each row:<br />
+1. <code>⠿</code> drag handle (13px, <code>border</code> grey; <code>faint</code> on hover) + mono rank numeral (16px, weight 500, <code>ink</code>).<br />
+2. School name as a link to <code>/school/[dbn]</code> (15px/600 <code>ink</code>) over a 12.5px <code>muted</code> line: <code>Program · Neighborhood, Borough</code>. At full width the DBN sits in that line in mono.<br />
+3. Track (13.5px <code>ink-2</code>) — the program's methods as published, comma-separated. This is the raw string; the composition buckets are a separate derivation.<br />
+4. Applicants per seat, mono 14px <code>ink</code>.<br />
+5. <code>↑</code> <code>↓</code> (23px square at 14 rows, 26px at full width, 1px <code>border</code>) + remove.</p>
+<p>Hovered/dragging row takes <code>surface-2</code> and its controls darken to <code>1px muted</code>.</p>
+<p><strong>Rail</strong> — two stacked sections divided by <code>border-bottom: 1px rule</code>:</p>
+<ul>
+<li><strong>Composition</strong> (<code>26px 28px</code>) — eyebrow with a right-aligned mono <code>14 SAVED</code>; the band; the legend as full-width rows (<code>swatch · label · flex:1 · mono count</code>); then the Boroughs and Applicants-Per-Seat cell grids, each under its own mono label, separated by <code>border-top: 1px rule-light</code> and <code>14px</code> padding.</li>
+<li><strong>Last edited</strong> (<code>20px 28px</code>) — mono <code>LAST EDITED</code> label + a 13px line naming the change (<code>Jul 28, 2026 · moved Beacon to 3</code>). Small, but it is the only confirmation that a reorder persisted.</li>
+</ul>
+<h3>5. Footer band — <code>16px 36px</code>, <code>surface-2</code>, <code>border-top: 1px rule</code></h3>
+<p>Two 13px <code>faint</code> lines, spread apart: left <em>"DOE-published data for the 2026–27 cycle · confirm each program on the official listing before you apply"</em>; right, right-aligned, <em>"Counts only — we don't score a list or predict an outcome."</em></p>
+<h2>Type scale (as built)</h2>
+<table>
+<thead>
+<tr>
+<th>Element</th>
+<th>Face / size</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Page title</td>
+<td>Space Grotesk 700, 40px, lh 1.04, ls −0.038em</td>
+</tr>
+<tr>
+<td>Section eyebrow</td>
+<td>JetBrains Mono 400, 11px, uppercase, ls .12em, <code>faint</code></td>
+</tr>
+<tr>
+<td>Table header</td>
+<td>JetBrains Mono 400, 10px, uppercase, ls .1em, <code>faint</code></td>
+</tr>
+<tr>
+<td>Rank numeral</td>
+<td>JetBrains Mono 500, 16px (18px at full width), <code>ink</code></td>
+</tr>
+<tr>
+<td>School name</td>
+<td>Libre Franklin 600, 15px (16px at full width)</td>
+</tr>
+<tr>
+<td>Row metadata</td>
+<td>Libre Franklin 400, 12.5px (13.5px), <code>muted</code></td>
+</tr>
+<tr>
+<td>Track</td>
+<td>Libre Franklin 400, 13.5px, <code>ink-2</code></td>
+</tr>
+<tr>
+<td>Applicants / seat</td>
+<td>JetBrains Mono 400, 14px (15px), <code>ink</code></td>
+</tr>
+<tr>
+<td>Composition label</td>
+<td>Libre Franklin 400, 13.5px, <code>ink-2</code></td>
+</tr>
+<tr>
+<td>Composition count</td>
+<td>JetBrains Mono 400, 13px, <code>ink</code></td>
+</tr>
+<tr>
+<td>Breakdown cell value</td>
+<td>JetBrains Mono 500, 18px, ls −0.02em</td>
+</tr>
+<tr>
+<td>Breakdown cell label</td>
+<td>Libre Franklin 400, 11px, uppercase, ls .04em, <code>faint</code></td>
+</tr>
+<tr>
+<td>Criteria chip</td>
+<td>Libre Franklin 400, 12.5px, <code>5px 9px</code></td>
+</tr>
+<tr>
+<td>Export button</td>
+<td>Libre Franklin 500, 14px, <code>11px 20px</code></td>
+</tr>
+<tr>
+<td>Footer / disclaimers</td>
+<td>Libre Franklin 400, 13px, <code>faint</code></td>
+</tr>
+</tbody>
+</table>
+<p>Spacing steps: 2, 5, 7, 8, 9, 11, 12, 14, 16, 20, 24, 26, 28, 30, 36. Section padding <code>26px 36px 30px</code>; rail sections <code>26px 28px</code>.</p>
+<h2>States</h2>
+<p><strong>Empty (never saved anything).</strong> Not in the reference — it was designed, reviewed and cut, and it should be built as the simplest possible version: keep the header and title band, then one line stating nothing is saved and a single accent link to <code>/find</code>. Do not build an onboarding panel, a three-fact explainer or a three-up "start somewhere" grid; that was the rejected version. A parent who lands here by accident needs one door, not a tour.</p>
+<p><strong>1–3 saved (<code>6a</code>).</strong> Full-width single-column layout — no rail. Order: ranking → composition → match strip. The ranking is short, so composition sits below it rather than beside it, and the match strip carries the bottom of the page.</p>
+<p><strong>Long list (<code>6b</code>, the approved direction).</strong> Two columns from the criteria strip down. Ranking left, composition + last-edited right. No match strip. Applies at 7+ saved; there is no upper bound.</p>
+<p><strong>Thin data (<code>6c</code>).</strong> A school with no published applicants-per-seat renders mono uppercase <code>NOT REPORTED</code> in <code>faint</code> in that cell — never <code>—</code>, never <code>0</code>. Immediately below the row, spanning the content columns, a mono <code>DATA GAP</code> eyebrow + 13px <code>muted</code> sentence: <em>"The DOE doesn't publish an applicants-per-seat figure for this school. That's a gap in the source data, not a low number."</em> The final clause is required. The <code>READING THE SHAPE</code> line also notes that the column is incomplete for this list, so the family isn't comparing against a partial set unknowingly.</p>
+<p><strong>Reorder.</strong> Optimistic and immediate: renumber, then persist. On failure, revert to the previous order and show one 13px line under the table — never a toast that can be missed while the parent is reading the list. <code>↑</code>/<code>↓</code> must be keyboard-operable and announce the new position.</p>
+<p><strong>Remove.</strong> Optimistic; row leaves, list renumbers, header count decrements in the same tick. <strong>No confirmation dialog</strong> — instead, hold an undo affordance for ~10s in the same 13px line slot below the table. The list is a draft; a modal per removal is the wrong weight.</p>
+<p><strong>Export pending.</strong> Button takes a disabled state with the label unchanged; a mono status line appears in the footer band. Never a spinner overlay.</p>
+<p><strong>Hover.</strong> Rows and rail links take <code>surface-2</code>. Buttons invert to <code>ink</code> fill / white. Transitions 120ms ease-out. No transforms, no lift.</p>
+<p><strong>Focus.</strong> 2px <code>accent</code> outline, 2px offset, on every interactive element including the drag handle. The rank cell must be reachable by keyboard.</p>
+<h2>Responsive (below ~900px)</h2>
+<ul>
+<li>The 1120px layout <strong>reflows; it never compresses.</strong> Single column below 900px.</li>
+<li>The 316px rail moves below the ranking, in order: Composition → Last edited. It drops <code>border-right</code> and keeps its own 1px <code>rule</code> dividers.</li>
+<li><strong>The ranking table collapses to a two-line row, not a scrolling table.</strong> Line one: drag handle + rank numeral + school name, with <code>↑ ↓</code> and remove right-aligned. Line two, indented to the name: <code>Program · Neighborhood</code>, then <code>Track</code> and the mono ratio separated by <code>·</code>. Nothing scrolls horizontally.</li>
+<li>Reorder controls grow to 44px hit targets at ≤700px. They stay side by side, right-aligned.</li>
+<li>Composition band stays full width. The legend goes two-up. Borough and applicants-per-seat cell grids stay 3-up (they are narrow) and become 1-up only at ≤420px.</li>
+<li>Criteria strip wraps to two lines: label + chips, then <code>Edit criteria</code> on its own line.</li>
+<li><code>Export</code> stays in the title band, full width beneath the title at ≤520px.</li>
+<li>Footer disclaimers stack, left-aligned, 4px gap.</li>
+<li>Title drops to 30px at ≤700px. Horizontal padding 36px → 20px.</li>
+</ul>
+<h2>Data shape</h2>
+<pre><code class="language-ts">type SavedList = {
+  criteria: { id: string; label: string }[];   // from the /find query that built this list
+  items: SavedItem[];                           // stored in rank order — the array IS the ranking
+  lastEditedAt: string;
+  lastEditedSummary?: string;                   // &quot;moved Beacon to 3&quot;
+};
+
+type SavedItem = {
+  dbn: string; name: string; program: string;
+  neighborhood?: string; borough: string;
+  methods: string[];                            // as published: ['Screened','Audition']
+  applicantsPerSeat?: number;                   // absent → NOT REPORTED + data-gap line
+};
+</code></pre>
+<p>Derive on the server:</p>
+<pre><code class="language-ts">type Composition = {
+  total: number;
+  buckets: { key: 'shsat'|'audition'|'screened'|'open'; label: string; count: number }[]; // zeroes kept
+  byBorough: { label: string; count: number }[];
+  byRatio:   { label: string; count: number }[];   // Under 3 / 3 to 6 / Over 6
+  shapeSentence: string;                            // generated from buckets
+  ratioMissing: number;                             // drives the incomplete-column note
+};
+</code></pre>
+<p><code>buckets</code> drives both the band weights and the legend — one array, no second source. Assert <code>sum(buckets) === total</code>.</p>
+<h2>New primitives</h2>
+<p>On top of <code>/find</code>'s five (<code>Chip</code>, <code>SegmentedControl</code>, <code>Button</code>, <code>StatBlock</code>, <code>SchoolRow</code>) and <code>/school</code>'s four (<code>StatGrid</code>, <code>Eyebrow</code>, <code>DefinitionRow</code>, <code>NotReportedLine</code>):</p>
+<ul>
+<li><strong><code>RankRow</code></strong> — one saved school; owns the handle, numeral, <code>↑ ↓</code>, remove, and the two-line mobile collapse.</li>
+<li><strong><code>ProportionBand</code></strong> — takes <code>Composition.buckets</code>, renders weighted segments + legend, keeps zero buckets.</li>
+<li><strong><code>BreakdownCells</code></strong> — the 3-up mono-number cell grid (a <code>StatGrid</code> variant; consider merging with a <code>size</code> prop).</li>
+</ul>
+<p><code>NotReportedLine</code> is reused as-is for the data-gap line.</p>
+<h2>Build order</h2>
+<ol>
+<li><strong>Nav rename <code>Readiness</code> → <code>Checklist</code></strong> across all screens, and make the header saved count live.</li>
+<li><code>RankRow</code> + reorder persistence. Nothing else on this page works until order is durable.</li>
+<li>Composition derivation with the bucket-priority rule and the sum assertion.</li>
+<li><code>Export</code>.</li>
+<li>The match strip (needs <code>/find</code>'s criteria in the URL — see the <code>/find</code> diff doc).</li>
+</ol>
+<h2>Files</h2>
+<ul>
+<li><code>saved-list.html</code> — standalone reference. <code>6b</code> is the approved direction; <code>6a</code> short-list and <code>6c</code> thin-data are the other states. <strong>Build from this.</strong></li>
+<li><code>Admit Day - Saved List.dc.html</code> — source, scaled to fit the browser window.</li>
+<li><code>../design_handoff_find_screen/FIND-DIFF.md</code> — what <code>/find</code> needs before this screen can be reached.</li>
+</ul>
+<h2>Still not designed</h2>
+<p><code>/checklist</code> (requirements and deadlines across the saved set — the paid tier grows here), the empty state as described above, and the landing page. Same rules when they come: three faces, radius 0, one accent, no derived scores.</p></body></html>

--- a/design/saved-list.html
+++ b/design/saved-list.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Admit Day — Saved list (/my-schools) reference</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Libre+Franklin:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@1,6..72,400;1,6..72,500&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  body { margin: 0; background: #B9B9B5; font-family: 'Libre Franklin', sans-serif; }
+  a { color: #1D4ED8; text-decoration: none; }
+  a:hover { color: #163FB0; }
+</style>
+</head>
+<body>
+
+
+
+<section style="display: flex; flex-direction: column; gap: 40px; padding: 44px 32px 64px; background: #B9B9B5;">
+
+  
+
+  <!-- ===================== 6a ===================== -->
+  <div id="6a" style="display: flex; flex-direction: column; gap: 14px; width: 100%; max-width: 100%;">
+    
+
+    <div style="width: 1120px; margin: 0 auto; background: #FFFFFF; border: 1px solid #DEDEDA;">
+
+      <div style="display: flex; align-items: center; justify-content: space-between; padding: 18px 36px; border-bottom: 1px solid #E8E8E4;">
+        <div style="display: flex; align-items: center; gap: 9px;">
+          <div style="width: 9px; height: 9px; border-radius: 999px; background: #1D4ED8;"></div>
+          <span style="font-family: 'Space Grotesk', sans-serif; font-size: 21px; font-weight: 700; color: #0B0B0C; letter-spacing: -0.035em;">Admit</span><span style="font-family: 'Newsreader', serif; font-style: italic; font-size: 24px; font-weight: 500; color: #1D4ED8; letter-spacing: -0.01em; margin-left: 3px;">Day</span>
+        </div>
+        <div style="display: flex; align-items: center; gap: 28px; font-size: 14.5px; color: #55555A;">
+          <span>Find</span>
+          <span style="color: #0B0B0C; font-weight: 500; padding-bottom: 3px; border-bottom: 2px solid #1D4ED8;">My Schools <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #1D4ED8;">3</span></span>
+          <span>Checklist</span>
+        </div>
+      </div>
+
+      <div style="display: grid; grid-template-columns: 1fr auto; gap: 28px; align-items: end; padding: 30px 36px 24px; border-bottom: 1px solid #E8E8E4;">
+        <div style="font-family: 'Space Grotesk', sans-serif; font-size: 40px; font-weight: 700; line-height: 1.04; letter-spacing: -0.038em; color: #0B0B0C;">My Schools</div>
+        <a href="#6a" style="background: #0B0B0C; color: #FFFFFF; font-size: 14px; font-weight: 500; padding: 11px 20px;">Export</a>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 14px; padding: 11px 36px; background: #FAFAF8; border-bottom: 1px solid #E8E8E4;">
+        <span style="font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90; white-space: nowrap;">Selection Criteria</span>
+        <div style="display: flex; flex-wrap: wrap; gap: 7px; flex: 1;">
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">Brooklyn + Queens</span>
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">Computer Science</span>
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">PSAL Soccer</span>
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">Commute Under 45 Min</span>
+        </div>
+        <a href="#6a" style="font-size: 13px; white-space: nowrap;">Edit Criteria</a>
+      </div>
+
+      <div style="padding: 26px 36px 30px; border-bottom: 1px solid #E8E8E4; display: flex; flex-direction: column; gap: 14px;">
+        <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 16px;">
+          <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">Your Ranking</div>
+          <span style="font-size: 13px; color: #8A8A90;">Drag a row, or use ↑ ↓ — this order is the one you'll enter in MySchools</span>
+        </div>
+
+        <div style="display: flex; flex-direction: column; border-top: 1px solid #E8E8E4;">
+          <div style="display: grid; grid-template-columns: 54px 1fr 156px 112px 96px; gap: 16px; padding: 9px 0; border-bottom: 1px solid #E8E8E4; font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90;">
+            <span>Rank</span><span>School &amp; Program</span><span>Track</span><span>Appl / Seat</span><span></span>
+          </div>
+
+          <div style="display: grid; grid-template-columns: 54px 1fr 156px 112px 96px; gap: 16px; align-items: center; padding: 15px 0; border-bottom: 1px solid #F0F0EC;">
+            <div style="display: flex; align-items: center; gap: 8px;"><span style="color: #DEDEDA; font-size: 14px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 17px; font-weight: 500; color: #0B0B0C;">01</span></div>
+            <div style="display: flex; flex-direction: column; gap: 4px;">
+              <a href="#6a" style="font-size: 16px; font-weight: 600; color: #0B0B0C;">Brooklyn Technical High School</a>
+              <span style="font-size: 13.5px; color: #55555A;">Software Engineering · <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #8A8A90;">13K430</span> · Fort Greene, Brooklyn</span>
+            </div>
+            <span style="font-size: 14px; color: #2A2A2F;">SHSAT</span>
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 15px; color: #0B0B0C;">4.1</span>
+            <div style="display: flex; align-items: center; justify-content: flex-end; gap: 6px;"><span style="border: 1px solid #DEDEDA; color: #DEDEDA; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6a" style="font-size: 12.5px; color: #8A8A90; padding-left: 4px;">Remove</a></div>
+          </div>
+
+          <div style="display: grid; grid-template-columns: 54px 1fr 156px 112px 96px; gap: 16px; align-items: center; padding: 15px 0; border-bottom: 1px solid #F0F0EC;">
+            <div style="display: flex; align-items: center; gap: 8px;"><span style="color: #DEDEDA; font-size: 14px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 17px; font-weight: 500; color: #0B0B0C;">02</span></div>
+            <div style="display: flex; flex-direction: column; gap: 4px;">
+              <a href="#6a" style="font-size: 16px; font-weight: 600; color: #0B0B0C;">Millennium Brooklyn High School</a>
+              <span style="font-size: 13.5px; color: #55555A;">Humanities · <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #8A8A90;">15K684</span> · Park Slope, Brooklyn</span>
+            </div>
+            <span style="font-size: 14px; color: #2A2A2F;">Screened</span>
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 15px; color: #0B0B0C;">7.8</span>
+            <div style="display: flex; align-items: center; justify-content: flex-end; gap: 6px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6a" style="font-size: 12.5px; color: #8A8A90; padding-left: 4px;">Remove</a></div>
+          </div>
+
+          <div style="display: grid; grid-template-columns: 54px 1fr 156px 112px 96px; gap: 16px; align-items: center; padding: 15px 0; border-bottom: 1px solid #E8E8E4;">
+            <div style="display: flex; align-items: center; gap: 8px;"><span style="color: #DEDEDA; font-size: 14px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 17px; font-weight: 500; color: #0B0B0C;">03</span></div>
+            <div style="display: flex; flex-direction: column; gap: 4px;">
+              <a href="#6a" style="font-size: 16px; font-weight: 600; color: #0B0B0C;">Edward R. Murrow High School</a>
+              <span style="font-size: 13.5px; color: #55555A;">Theater · <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #8A8A90;">21K525</span> · Midwood, Brooklyn</span>
+            </div>
+            <span style="font-size: 14px; color: #2A2A2F;">Screened, Audition</span>
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 15px; color: #0B0B0C;">5.2</span>
+            <div style="display: flex; align-items: center; justify-content: flex-end; gap: 6px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #DEDEDA; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6a" style="font-size: 12.5px; color: #8A8A90; padding-left: 4px;">Remove</a></div>
+          </div>
+        </div>
+      </div>
+
+      <div style="padding: 24px 36px 26px; border-bottom: 1px solid #E8E8E4;">
+        <div style="display: flex; flex-direction: column; gap: 12px;">
+          <div style="display: flex; align-items: baseline; justify-content: space-between;">
+            <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">Composition by Admissions Track</div>
+            <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.06em; color: #8A8A90;">3 SAVED</div>
+          </div>
+          <div style="display: flex; height: 12px; gap: 1px; background: #E8E8E4;">
+            <div style="flex: 2; background: #0B0B0C;"></div>
+            <div style="flex: 1; background: #55555A;"></div>
+          </div>
+          <div style="display: flex; flex-wrap: wrap; gap: 20px; padding-top: 2px;">
+            <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #0B0B0C;"></div><span style="font-size: 13.5px; color: #2A2A2F;">Screened</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #0B0B0C;">2</span></div>
+            <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #55555A;"></div><span style="font-size: 13.5px; color: #2A2A2F;">SHSAT</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #0B0B0C;">1</span></div>
+            <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #FFFFFF; border: 1px solid #DEDEDA;"></div><span style="font-size: 13.5px; color: #8A8A90;">Open / Zoned</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #8A8A90;">0</span></div>
+          </div>
+          <div style="display: flex; gap: 10px; align-items: baseline; padding-top: 10px; border-top: 1px solid #F0F0EC; margin-top: 4px;">
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90; white-space: nowrap;">Reading the Shape</span>
+            <span style="font-size: 13.5px; color: #55555A; text-wrap: pretty;">Every school on the list screens or tests. No open or zoned program is on it yet. This describes your list; it isn't a rating.</span>
+          </div>
+        </div>
+
+      </div>
+
+      <div style="padding: 26px 36px 30px; border-bottom: 1px solid #E8E8E4; display: flex; flex-direction: column; gap: 16px;">
+        <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 16px;">
+          <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">From Your 31 Matches on Find</div>
+          <a href="#6a" style="font-size: 13px;">Open in Find ↗</a>
+        </div>
+        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: #E8E8E4; border: 1px solid #E8E8E4;">
+          <div style="background: #FFFFFF; padding: 18px 20px; display: flex; flex-direction: column; gap: 9px;">
+            <a href="#6a" style="font-size: 15.5px; font-weight: 600; color: #0B0B0C;">Leon M. Goldstein High School</a>
+            <span style="font-size: 13px; color: #55555A;">Screened · <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px;">3.6</span> appl/seat · Manhattan Beach, Brooklyn</span>
+            <span style="font-size: 12.5px; color: #1D4ED8;">Matches Computer Science, PSAL Soccer</span>
+            <a href="#6a" style="border: 1px solid #0B0B0C; color: #0B0B0C; text-align: center; font-size: 13.5px; padding: 8px 0; margin-top: auto;">Add to List</a>
+          </div>
+          <div style="background: #FFFFFF; padding: 18px 20px; display: flex; flex-direction: column; gap: 9px;">
+            <a href="#6a" style="font-size: 15.5px; font-weight: 600; color: #0B0B0C;">Bard High School Early College Queens</a>
+            <span style="font-size: 13px; color: #55555A;">Screened · <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px;">9.4</span> appl/seat · Long Island City, Queens</span>
+            <span style="font-size: 12.5px; color: #1D4ED8;">Matches Commute Under 45 Min</span>
+            <a href="#6a" style="border: 1px solid #0B0B0C; color: #0B0B0C; text-align: center; font-size: 13.5px; padding: 8px 0; margin-top: auto;">Add to List</a>
+          </div>
+          <div style="background: #FFFFFF; padding: 18px 20px; display: flex; flex-direction: column; gap: 9px;">
+            <a href="#6a" style="font-size: 15.5px; font-weight: 600; color: #0B0B0C;">Brooklyn Institute for Liberal Arts</a>
+            <span style="font-size: 13px; color: #55555A;">Open · Lottery · Sunset Park, Brooklyn</span>
+            <span style="font-size: 12.5px; color: #1D4ED8;">First Open-Admission Match in Your Area</span>
+            <a href="#6a" style="border: 1px solid #0B0B0C; color: #0B0B0C; text-align: center; font-size: 13.5px; padding: 8px 0; margin-top: auto;">Add to List</a>
+          </div>
+        </div>
+      </div>
+
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 16px 36px; background: #FAFAF8; border-top: 1px solid #E8E8E4;">
+        <span style="font-size: 13px; color: #8A8A90;">DOE-published data for the 2026–27 cycle · confirm each program on the official listing before you apply</span>
+        <span style="font-size: 13px; color: #8A8A90; text-align: right;">Counts only — we don't score a list or predict an outcome</span>
+      </div>
+
+    </div>
+    </div>
+  </div>
+
+  <!-- ===================== 6b ===================== -->
+  <div id="6b" style="display: flex; flex-direction: column; gap: 14px; width: 100%; max-width: 100%;">
+    
+
+    <div style="width: 1120px; margin: 0 auto; background: #FFFFFF; border: 1px solid #DEDEDA;">
+
+      <div style="display: flex; align-items: center; justify-content: space-between; padding: 18px 36px; border-bottom: 1px solid #E8E8E4;">
+        <div style="display: flex; align-items: center; gap: 9px;">
+          <div style="width: 9px; height: 9px; border-radius: 999px; background: #1D4ED8;"></div>
+          <span style="font-family: 'Space Grotesk', sans-serif; font-size: 21px; font-weight: 700; color: #0B0B0C; letter-spacing: -0.035em;">Admit</span><span style="font-family: 'Newsreader', serif; font-style: italic; font-size: 24px; font-weight: 500; color: #1D4ED8; letter-spacing: -0.01em; margin-left: 3px;">Day</span>
+        </div>
+        <div style="display: flex; align-items: center; gap: 28px; font-size: 14.5px; color: #55555A;">
+          <span>Find</span>
+          <span style="color: #0B0B0C; font-weight: 500; padding-bottom: 3px; border-bottom: 2px solid #1D4ED8;">My Schools <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #1D4ED8;">14</span></span>
+          <span>Checklist</span>
+        </div>
+      </div>
+
+      <div style="display: grid; grid-template-columns: 1fr auto; gap: 28px; align-items: end; padding: 30px 36px 24px; border-bottom: 1px solid #E8E8E4;">
+        <div style="font-family: 'Space Grotesk', sans-serif; font-size: 40px; font-weight: 700; line-height: 1.04; letter-spacing: -0.038em; color: #0B0B0C;">My Schools</div>
+        <a href="#6b" style="background: #0B0B0C; color: #FFFFFF; font-size: 14px; font-weight: 500; padding: 11px 20px;">Export</a>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 14px; padding: 11px 36px; background: #FAFAF8; border-bottom: 1px solid #E8E8E4;">
+        <span style="font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90; white-space: nowrap;">Selection Criteria</span>
+        <div style="display: flex; flex-wrap: wrap; gap: 7px; flex: 1;">
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">Brooklyn + Queens</span>
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">Computer Science</span>
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">PSAL Soccer</span>
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">Commute Under 45 Min</span>
+        </div>
+        <a href="#6b" style="font-size: 13px; white-space: nowrap;">Edit Criteria</a>
+      </div>
+
+      <div style="display: grid; grid-template-columns: 1fr 316px;">
+        <div style="border-right: 1px solid #E8E8E4; padding: 26px 36px 30px; display: flex; flex-direction: column; gap: 14px;">
+          <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 16px;">
+            <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">Your Ranking</div>
+            <span style="font-size: 12.5px; color: #8A8A90;">Drag a row, or use ↑ ↓</span>
+          </div>
+
+          <div style="display: flex; flex-direction: column; border-top: 1px solid #E8E8E4;">
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; padding: 8px 0; border-bottom: 1px solid #E8E8E4; font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90;">
+              <span>Rank</span><span>School &amp; Program</span><span>Track</span><span>A/Seat</span><span></span>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">01</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Brooklyn Technical High School</a><span style="font-size: 12.5px; color: #55555A;">Software Engineering · Fort Greene, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">SHSAT</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">4.1</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #DEDEDA; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">02</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Bard High School Early College Queens</a><span style="font-size: 12.5px; color: #55555A;">Early College · Long Island City, Queens</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Screened</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">9.4</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC; background: #FAFAF8;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #8A8A90; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">03</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">The Beacon School</a><span style="font-size: 12.5px; color: #55555A;">Humanities · Hell's Kitchen, Manhattan</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Screened, Portfolio</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">12.7</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #8A8A90; color: #0B0B0C; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #8A8A90; color: #0B0B0C; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #55555A;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">04</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Millennium Brooklyn High School</a><span style="font-size: 12.5px; color: #55555A;">Humanities · Park Slope, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Screened</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">7.8</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">05</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Edward R. Murrow High School</a><span style="font-size: 12.5px; color: #55555A;">Theater · Midwood, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Screened, Audition</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">5.2</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">06</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Leon M. Goldstein High School</a><span style="font-size: 12.5px; color: #55555A;">Math &amp; Science · Manhattan Beach, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Screened</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">3.6</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">07</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Fort Hamilton High School</a><span style="font-size: 12.5px; color: #55555A;">Law &amp; Government · Bay Ridge, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Screened</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">2.4</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">08</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Brooklyn Latin School</a><span style="font-size: 12.5px; color: #55555A;">Classical Studies · Bushwick, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">SHSAT</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">6.1</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">09</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">LaGuardia High School</a><span style="font-size: 12.5px; color: #55555A;">Drama · Lincoln Square, Manhattan</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Audition</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">10.2</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">10</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Midwood High School</a><span style="font-size: 12.5px; color: #55555A;">Medical Science · Midwood, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Screened</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">8.3</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">11</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Academy of Urban Planning</a><span style="font-size: 12.5px; color: #55555A;">Urban Design · Bushwick, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Open</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">1.6</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">12</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Brooklyn College Academy</a><span style="font-size: 12.5px; color: #55555A;">Early College · Flatbush, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Screened</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">4.7</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #F0F0EC;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">13</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Sunset Park High School</a><span style="font-size: 12.5px; color: #55555A;">Computer Science · Sunset Park, Brooklyn</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Zoned</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">1.2</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: 46px 1fr 132px 62px 74px; gap: 12px; align-items: center; padding: 11px 0; border-bottom: 1px solid #E8E8E4;">
+              <div style="display: flex; align-items: center; gap: 7px;"><span style="color: #DEDEDA; font-size: 13px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; font-weight: 500; color: #0B0B0C;">14</span></div>
+              <div style="display: flex; flex-direction: column; gap: 2px;"><a href="#6b" style="font-size: 15px; font-weight: 600; color: #0B0B0C;">Aviation Career &amp; Technical Education</a><span style="font-size: 12.5px; color: #55555A;">Aircraft Mechanics · Long Island City, Queens</span></div>
+              <span style="font-size: 13.5px; color: #2A2A2F;">Screened</span>
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 14px; color: #0B0B0C;">3.1</span>
+              <div style="display: flex; align-items: center; justify-content: flex-end; gap: 5px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #DEDEDA; font-size: 11px; width: 23px; height: 23px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6b" style="font-size: 12px; color: #8A8A90;">×</a></div>
+            </div>
+          </div>
+        </div>
+
+        <div style="display: flex; flex-direction: column;">
+          <div style="padding: 26px 28px; border-bottom: 1px solid #E8E8E4; display: flex; flex-direction: column; gap: 12px;">
+            <div style="display: flex; align-items: baseline; justify-content: space-between;">
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">Composition</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; color: #8A8A90;">14 SAVED</div>
+            </div>
+            <div style="display: flex; height: 12px; gap: 1px; background: #E8E8E4;">
+              <div style="flex: 7; background: #0B0B0C;"></div>
+              <div style="flex: 3; background: #2A2A2F;"></div>
+              <div style="flex: 2; background: #55555A;"></div>
+              <div style="flex: 2; background: #8A8A90;"></div>
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 8px; padding-top: 2px;">
+              <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #0B0B0C;"></div><span style="font-size: 13.5px; color: #2A2A2F; flex: 1;">Screened</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #0B0B0C;">7</span></div>
+              <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #2A2A2F;"></div><span style="font-size: 13.5px; color: #2A2A2F; flex: 1;">Audition / Portfolio</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #0B0B0C;">3</span></div>
+              <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #55555A;"></div><span style="font-size: 13.5px; color: #2A2A2F; flex: 1;">SHSAT</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #0B0B0C;">2</span></div>
+              <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #8A8A90;"></div><span style="font-size: 13.5px; color: #2A2A2F; flex: 1;">Open / Zoned</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #0B0B0C;">2</span></div>
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 9px; padding-top: 14px; border-top: 1px solid #F0F0EC;">
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90;">Boroughs</div>
+              <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; background: #E8E8E4; border: 1px solid #E8E8E4;">
+                <div style="background: #FFFFFF; padding: 9px 10px; display: flex; flex-direction: column; gap: 2px;"><span style="font-family: 'JetBrains Mono', monospace; font-size: 18px; font-weight: 500; color: #0B0B0C; letter-spacing: -0.02em;">10</span><span style="font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: #8A8A90;">Brooklyn</span></div>
+                <div style="background: #FFFFFF; padding: 9px 10px; display: flex; flex-direction: column; gap: 2px;"><span style="font-family: 'JetBrains Mono', monospace; font-size: 18px; font-weight: 500; color: #0B0B0C; letter-spacing: -0.02em;">2</span><span style="font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: #8A8A90;">Manhattan</span></div>
+                <div style="background: #FFFFFF; padding: 9px 10px; display: flex; flex-direction: column; gap: 2px;"><span style="font-family: 'JetBrains Mono', monospace; font-size: 18px; font-weight: 500; color: #0B0B0C; letter-spacing: -0.02em;">2</span><span style="font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: #8A8A90;">Queens</span></div>
+              </div>
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 9px; padding-top: 14px; border-top: 1px solid #F0F0EC;">
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90;">Applicants Per Seat</div>
+              <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; background: #E8E8E4; border: 1px solid #E8E8E4;">
+                <div style="background: #FFFFFF; padding: 9px 10px; display: flex; flex-direction: column; gap: 2px;"><span style="font-family: 'JetBrains Mono', monospace; font-size: 18px; font-weight: 500; color: #0B0B0C; letter-spacing: -0.02em;">3</span><span style="font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: #8A8A90;">Under 3</span></div>
+                <div style="background: #FFFFFF; padding: 9px 10px; display: flex; flex-direction: column; gap: 2px;"><span style="font-family: 'JetBrains Mono', monospace; font-size: 18px; font-weight: 500; color: #0B0B0C; letter-spacing: -0.02em;">5</span><span style="font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: #8A8A90;">3 to 6</span></div>
+                <div style="background: #FFFFFF; padding: 9px 10px; display: flex; flex-direction: column; gap: 2px;"><span style="font-family: 'JetBrains Mono', monospace; font-size: 18px; font-weight: 500; color: #0B0B0C; letter-spacing: -0.02em;">6</span><span style="font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: #8A8A90;">Over 6</span></div>
+              </div>
+            </div>
+          </div>
+
+          <div style="padding: 20px 28px; display: flex; align-items: baseline; gap: 8px;">
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90; white-space: nowrap;">Last Edited</span>
+            <span style="font-size: 13px; color: #2A2A2F;">Jul 28, 2026 · moved Beacon to 3</span>
+          </div>
+        </div>
+      </div>
+
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 16px 36px; background: #FAFAF8; border-top: 1px solid #E8E8E4;">
+        <span style="font-size: 13px; color: #8A8A90;">DOE-published data for the 2026–27 cycle · confirm each program on the official listing before you apply</span>
+        <span style="font-size: 13px; color: #8A8A90; text-align: right;">Counts only — we don't score a list or predict an outcome</span>
+      </div>
+
+    </div>
+    </div>
+  </div>
+
+  <!-- ===================== 6c ===================== -->
+  <div id="6c" style="display: flex; flex-direction: column; gap: 14px; width: 100%; max-width: 100%;">
+    
+
+    <div style="width: 1120px; margin: 0 auto; background: #FFFFFF; border: 1px solid #DEDEDA;">
+
+      <div style="display: flex; align-items: center; justify-content: space-between; padding: 18px 36px; border-bottom: 1px solid #E8E8E4;">
+        <div style="display: flex; align-items: center; gap: 9px;">
+          <div style="width: 9px; height: 9px; border-radius: 999px; background: #1D4ED8;"></div>
+          <span style="font-family: 'Space Grotesk', sans-serif; font-size: 21px; font-weight: 700; color: #0B0B0C; letter-spacing: -0.035em;">Admit</span><span style="font-family: 'Newsreader', serif; font-style: italic; font-size: 24px; font-weight: 500; color: #1D4ED8; letter-spacing: -0.01em; margin-left: 3px;">Day</span>
+        </div>
+        <div style="display: flex; align-items: center; gap: 28px; font-size: 14.5px; color: #55555A;">
+          <span>Find</span>
+          <span style="color: #0B0B0C; font-weight: 500; padding-bottom: 3px; border-bottom: 2px solid #1D4ED8;">My Schools <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #1D4ED8;">4</span></span>
+          <span>Checklist</span>
+        </div>
+      </div>
+
+      <div style="display: grid; grid-template-columns: 1fr auto; gap: 28px; align-items: end; padding: 30px 36px 24px; border-bottom: 1px solid #E8E8E4;">
+        <div style="font-family: 'Space Grotesk', sans-serif; font-size: 40px; font-weight: 700; line-height: 1.04; letter-spacing: -0.038em; color: #0B0B0C;">My Schools</div>
+        <a href="#6c" style="background: #0B0B0C; color: #FFFFFF; font-size: 14px; font-weight: 500; padding: 11px 20px;">Export</a>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 14px; padding: 11px 36px; background: #FAFAF8; border-bottom: 1px solid #E8E8E4;">
+        <span style="font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90; white-space: nowrap;">Selection Criteria</span>
+        <div style="display: flex; flex-wrap: wrap; gap: 7px; flex: 1;">
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">Brooklyn</span>
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">Small School</span>
+          <span style="font-size: 12.5px; padding: 4px 9px; background: #EEF2FF; border: 1px solid #C7D2FE; color: #1D4ED8;">Open Admission</span>
+        </div>
+        <a href="#6c" style="font-size: 13px; white-space: nowrap;">Edit Criteria</a>
+      </div>
+
+      <div style="padding: 26px 36px 30px; border-bottom: 1px solid #E8E8E4; display: flex; flex-direction: column; gap: 14px;">
+        <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 16px;">
+          <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">Your Ranking</div>
+          <span style="font-size: 13px; color: #8A8A90;">Drag a row, or use ↑ ↓ — this order is the one you'll enter in MySchools</span>
+        </div>
+
+        <div style="display: flex; flex-direction: column; border-top: 1px solid #E8E8E4;">
+          <div style="display: grid; grid-template-columns: 54px 1fr 156px 112px 96px; gap: 16px; padding: 9px 0; border-bottom: 1px solid #E8E8E4; font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90;">
+            <span>Rank</span><span>School &amp; Program</span><span>Track</span><span>Appl / Seat</span><span></span>
+          </div>
+
+          <div style="display: grid; grid-template-columns: 54px 1fr 156px 112px 96px; gap: 16px; align-items: center; padding: 15px 0; border-bottom: 1px solid #F0F0EC;">
+            <div style="display: flex; align-items: center; gap: 8px;"><span style="color: #DEDEDA; font-size: 14px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 17px; font-weight: 500; color: #0B0B0C;">01</span></div>
+            <div style="display: flex; flex-direction: column; gap: 4px;">
+              <a href="#6c" style="font-size: 16px; font-weight: 600; color: #0B0B0C;">Millennium Brooklyn High School</a>
+              <span style="font-size: 13.5px; color: #55555A;">Humanities · <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #8A8A90;">15K684</span> · Park Slope, Brooklyn</span>
+            </div>
+            <span style="font-size: 14px; color: #2A2A2F;">Screened</span>
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 15px; color: #0B0B0C;">7.8</span>
+            <div style="display: flex; align-items: center; justify-content: flex-end; gap: 6px;"><span style="border: 1px solid #DEDEDA; color: #DEDEDA; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6c" style="font-size: 12.5px; color: #8A8A90; padding-left: 4px;">Remove</a></div>
+          </div>
+
+          <div style="display: grid; grid-template-columns: 54px 1fr 156px 112px 96px; gap: 16px; align-items: center; padding: 15px 0; border-bottom: 1px solid #F0F0EC;">
+            <div style="display: flex; align-items: center; gap: 8px;"><span style="color: #DEDEDA; font-size: 14px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 17px; font-weight: 500; color: #0B0B0C;">02</span></div>
+            <div style="display: flex; flex-direction: column; gap: 4px;">
+              <a href="#6c" style="font-size: 16px; font-weight: 600; color: #0B0B0C;">Park Slope Collegiate</a>
+              <span style="font-size: 13.5px; color: #55555A;">Liberal Arts · <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #8A8A90;">15K497</span> · Park Slope, Brooklyn</span>
+            </div>
+            <span style="font-size: 14px; color: #2A2A2F;">Open</span>
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 15px; color: #0B0B0C;">2.1</span>
+            <div style="display: flex; align-items: center; justify-content: flex-end; gap: 6px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6c" style="font-size: 12.5px; color: #8A8A90; padding-left: 4px;">Remove</a></div>
+          </div>
+
+          <div style="display: grid; grid-template-columns: 54px 1fr 156px 112px 96px; gap: 16px; align-items: center; padding: 15px 0; border-bottom: 1px solid #F0F0EC;">
+            <div style="display: flex; align-items: center; gap: 8px;"><span style="color: #DEDEDA; font-size: 14px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 17px; font-weight: 500; color: #0B0B0C;">03</span></div>
+            <div style="display: flex; flex-direction: column; gap: 4px;">
+              <a href="#6c" style="font-size: 16px; font-weight: 600; color: #0B0B0C;">Brooklyn Institute for Liberal Arts</a>
+              <span style="font-size: 13.5px; color: #55555A;">Liberal Arts · <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #8A8A90;">15K493</span> · Sunset Park, Brooklyn</span>
+            </div>
+            <span style="font-size: 14px; color: #2A2A2F;">Open</span>
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: #8A8A90;">Not Reported</span>
+            <div style="display: flex; align-items: center; justify-content: flex-end; gap: 6px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6c" style="font-size: 12.5px; color: #8A8A90; padding-left: 4px;">Remove</a></div>
+          </div>
+
+          <div style="display: grid; grid-template-columns: 54px 1fr; gap: 16px; padding: 0 0 15px; border-bottom: 1px solid #F0F0EC;">
+            <span></span>
+            <div style="display: flex; gap: 10px; align-items: baseline;">
+              <span style="font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90; white-space: nowrap;">Data Gap</span>
+              <span style="font-size: 13px; color: #55555A; text-wrap: pretty;">The DOE doesn't publish an applicants-per-seat figure for this school. That's a gap in the source data, not a low number.</span>
+            </div>
+          </div>
+
+          <div style="display: grid; grid-template-columns: 54px 1fr 156px 112px 96px; gap: 16px; align-items: center; padding: 15px 0; border-bottom: 1px solid #E8E8E4;">
+            <div style="display: flex; align-items: center; gap: 8px;"><span style="color: #DEDEDA; font-size: 14px; line-height: 1;">⠿</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 17px; font-weight: 500; color: #0B0B0C;">04</span></div>
+            <div style="display: flex; flex-direction: column; gap: 4px;">
+              <a href="#6c" style="font-size: 16px; font-weight: 600; color: #0B0B0C;">Sunset Park High School</a>
+              <span style="font-size: 13.5px; color: #55555A;">Computer Science · <span style="font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #8A8A90;">15K463</span> · Sunset Park, Brooklyn</span>
+            </div>
+            <span style="font-size: 14px; color: #2A2A2F;">Zoned</span>
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 15px; color: #0B0B0C;">1.2</span>
+            <div style="display: flex; align-items: center; justify-content: flex-end; gap: 6px;"><span style="border: 1px solid #DEDEDA; color: #55555A; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↑</span><span style="border: 1px solid #DEDEDA; color: #DEDEDA; font-size: 12px; width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;">↓</span><a href="#6c" style="font-size: 12.5px; color: #8A8A90; padding-left: 4px;">Remove</a></div>
+          </div>
+        </div>
+      </div>
+
+      <div style="padding: 24px 36px 26px; border-bottom: 1px solid #E8E8E4;">
+        <div style="display: flex; flex-direction: column; gap: 12px;">
+          <div style="display: flex; align-items: baseline; justify-content: space-between;">
+            <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: #8A8A90;">Composition by Admissions Track</div>
+            <div style="font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.06em; color: #8A8A90;">4 SAVED</div>
+          </div>
+          <div style="display: flex; height: 12px; gap: 1px; background: #E8E8E4;">
+            <div style="flex: 1; background: #0B0B0C;"></div>
+            <div style="flex: 3; background: #8A8A90;"></div>
+          </div>
+          <div style="display: flex; flex-wrap: wrap; gap: 20px; padding-top: 2px;">
+            <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #0B0B0C;"></div><span style="font-size: 13.5px; color: #2A2A2F;">Screened</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #0B0B0C;">1</span></div>
+            <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #8A8A90;"></div><span style="font-size: 13.5px; color: #2A2A2F;">Open / Zoned</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #0B0B0C;">3</span></div>
+            <div style="display: flex; align-items: center; gap: 8px;"><div style="width: 9px; height: 9px; background: #FFFFFF; border: 1px solid #DEDEDA;"></div><span style="font-size: 13.5px; color: #8A8A90;">SHSAT</span><span style="font-family: 'JetBrains Mono', monospace; font-size: 13px; color: #8A8A90;">0</span></div>
+          </div>
+          <div style="display: flex; gap: 10px; align-items: baseline; padding-top: 10px; border-top: 1px solid #F0F0EC; margin-top: 4px;">
+            <span style="font-family: 'JetBrains Mono', monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: #8A8A90; white-space: nowrap;">Reading the Shape</span>
+            <span style="font-size: 13.5px; color: #55555A; text-wrap: pretty;">Three of four are open or zoned. One school has no published ratio, so the numbers column is incomplete for this list.</span>
+          </div>
+        </div>
+
+      </div>
+
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 16px 36px; background: #FAFAF8; border-top: 1px solid #E8E8E4;">
+        <span style="font-size: 13px; color: #8A8A90;">DOE-published data for the 2026–27 cycle · confirm each program on the official listing before you apply</span>
+        <span style="font-size: 13px; color: #8A8A90; text-align: right;">Counts only — we don't score a list or predict an outcome</span>
+      </div>
+
+    </div>
+    </div>
+  </div>
+
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
Adds the approved design for the saved-list screen (design/saved-list.html + design/saved-list-handoff.html) and refreshes the existing /find and school-detail references and handoffs so all three screens stay in sync. Also adds design/find-screen-diff.html — an audit of the live /find build against the design, with an ordered list of deltas. Static references only; no app code touched.