### PR TITLE
fix: issue #120 - Point Sentry at the renamed project slug (split from #107)

### DIFF
--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -695,7 +695,7 @@ describe('Issue #19: Sentry source maps in next.config.js', () => {
 
   it('has org and project set for Sentry upload targeting', () => {
     expect(nextConfigSource).toContain('org: "long-tail-studio"')
-    expect(nextConfigSource).toContain('project: "listready"')
+    expect(nextConfigSource).toContain('project: "admitday"')
   })
 })
 

--- a/next.config.js
+++ b/next.config.js
@@ -24,7 +24,7 @@ module.exports = withSentryConfig(module.exports, {
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
   org: "long-tail-studio",
-  project: "listready",
+  project: "admitday",
 
   // Authentication token for uploading source maps
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/sourcemaps/


### PR DESCRIPTION
Committed as `0949106`.

**Summary:** Updated `next.config.js` to point Sentry at the renamed project slug `"admitday"` (was the stale `"listready"` slug from before the repo rename), and updated the pinning assertion in `__tests__/schools.test.ts` to match. No other Sentry config (org, DSN, auth token) was touched. `npm test` (838 tests, 22 suites) and `npm run build` both pass.

Closes #120