### PR TITLE
fix: issue #128 - Never leak raw provider errors from /api/chat (live in production)

### DIFF
--- a/__tests__/chat-provider-errors.test.ts
+++ b/__tests__/chat-provider-errors.test.ts
@@ -1,0 +1,139 @@
+/**
+ * __tests__/chat-provider-errors.test.ts
+ *
+ * Issue #128: a real visitor hit /api/chat in production and got a raw
+ * 400 with vendor error text ("You have reached your specified API
+ * usage limits. You will regain access on 2026-08-01 at 00:00 UTC.").
+ * These tests mock the Anthropic call to fail in each of the ways a
+ * provider can fail, and assert the client only ever sees one of the
+ * small set of plain-language responses — never the upstream error.
+ */
+
+import type { NextRequest } from 'next/server'
+
+const mockCreate = jest.fn()
+const mockCaptureException = jest.fn()
+
+jest.mock('@anthropic-ai/sdk', () => {
+  return jest.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  }))
+})
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+jest.mock('@/lib/rag', () => ({
+  searchSchools: jest.fn().mockResolvedValue([
+    {
+      dbn: '01M001',
+      name: 'Test High School',
+      borough: 'Manhattan',
+      score: 0.87,
+      matchedChunkType: 'identity',
+      chunk: 'Test High School is a small school in Manhattan.',
+    },
+  ]),
+}))
+
+import { POST } from '@/app/api/chat/route'
+
+const FORBIDDEN_SUBSTRINGS = [
+  'usage limit',
+  'credit',
+  'quota',
+  'regain access',
+  'request_id',
+  'anthropic',
+]
+
+function fakeChatRequest(question: string, ip: string): NextRequest {
+  return {
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'x-forwarded-for' ? ip : null),
+    },
+    json: async () => ({ question }),
+  } as unknown as NextRequest
+}
+
+beforeEach(() => {
+  mockCreate.mockReset()
+  mockCaptureException.mockReset()
+})
+
+describe('/api/chat provider failure handling (issue #128)', () => {
+  it('returns a plain-language unavailable response for a usage-limit error, and logs the real error to Sentry', async () => {
+    const upstreamError = new Error(
+      '400 {"type":"error","error":{"type":"invalid_request_error","message":"You have reached your specified API usage limits. You will regain access on 2026-08-01 at 00:00 UTC."}}, "request_id": "req_abc123"'
+    )
+    ;(upstreamError as unknown as { status: number }).status = 400
+    mockCreate.mockRejectedValue(upstreamError)
+
+    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.1'))
+    expect(res.status).toBe(503)
+
+    const bodyText = await res.text()
+    for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+      expect(bodyText.toLowerCase()).not.toContain(forbidden)
+    }
+    const body = JSON.parse(bodyText)
+    expect(typeof body.error).toBe('string')
+    expect(body.error.length).toBeGreaterThan(0)
+
+    expect(mockCaptureException).toHaveBeenCalledWith(upstreamError)
+  })
+
+  it('returns a plain-language unavailable response for a provider outage (5xx)', async () => {
+    const upstreamError = new Error('Internal server error')
+    ;(upstreamError as unknown as { status: number }).status = 529
+    mockCreate.mockRejectedValue(upstreamError)
+
+    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.2'))
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    const serialized = JSON.stringify(body).toLowerCase()
+    for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+      expect(serialized).not.toContain(forbidden)
+    }
+  })
+
+  it('preserves the existing 429 rate-limit response when the provider itself rate-limits', async () => {
+    const upstreamError = new Error('429 rate_limit_error')
+    ;(upstreamError as unknown as { status: number }).status = 429
+    mockCreate.mockRejectedValue(upstreamError)
+
+    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.3'))
+    expect(res.status).toBe(429)
+    const body = await res.json()
+    expect(body.error).toBe(
+      "You're sending requests too quickly — please wait a moment and try again."
+    )
+  })
+
+  it('returns a generic failure message for an unrecognized error', async () => {
+    const upstreamError = new Error('something exploded')
+    mockCreate.mockRejectedValue(upstreamError)
+
+    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.4'))
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    const serialized = JSON.stringify(body).toLowerCase()
+    for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+      expect(serialized).not.toContain(forbidden)
+    }
+    expect(mockCaptureException).toHaveBeenCalledWith(upstreamError)
+  })
+
+  it('still returns a normal answer when the provider call succeeds (no regression)', async () => {
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: 'Test High School is a great fit.' }],
+    })
+
+    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.5'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.answer).toBe('Test High School is a great fit.')
+    expect(body.sources).toHaveLength(1)
+  })
+})

--- a/__tests__/provider-error.test.ts
+++ b/__tests__/provider-error.test.ts
@@ -1,0 +1,99 @@
+/**
+ * __tests__/provider-error.test.ts
+ *
+ * Unit tests for lib/provider-error.ts (issue #128).
+ * The chat/rationale routes must never leak raw upstream provider
+ * errors (vendor detail, request IDs, billing/quota language) to the
+ * client — this module is the single place that decides what the
+ * client is allowed to see.
+ */
+
+import {
+  classifyProviderError,
+  RATE_LIMIT_MESSAGE,
+  UNAVAILABLE_MESSAGE,
+  GENERIC_MESSAGE,
+} from '@/lib/provider-error'
+
+const FORBIDDEN_SUBSTRINGS = [
+  'usage limit',
+  'credit',
+  'quota',
+  'regain access',
+  'request_id',
+  'anthropic',
+]
+
+function fakeProviderError(message: string, status?: number): Error {
+  const err = new Error(message)
+  if (status !== undefined) {
+    ;(err as unknown as { status: number }).status = status
+  }
+  return err
+}
+
+describe('classifyProviderError (issue #128)', () => {
+  it('maps a usage-limit error (the real production incident) to the unavailable message, not a raw 400', () => {
+    const err = fakeProviderError(
+      '400 {"type":"error","error":{"type":"invalid_request_error","message":"You have reached your specified API usage limits. You will regain access on 2026-08-01 at 00:00 UTC."}} request_id: req_abc123',
+      400
+    )
+    const result = classifyProviderError(err)
+    expect(result.status).toBe(503)
+    expect(result.body).toEqual({ error: UNAVAILABLE_MESSAGE })
+  })
+
+  it('maps a credit-exhaustion error to the unavailable message', () => {
+    const err = fakeProviderError('Your credit balance is too low to access the API.', 400)
+    const result = classifyProviderError(err)
+    expect(result.status).toBe(503)
+    expect(result.body).toEqual({ error: UNAVAILABLE_MESSAGE })
+  })
+
+  it('maps a provider 5xx outage to the unavailable message', () => {
+    const err = fakeProviderError('Internal server error', 529)
+    const result = classifyProviderError(err)
+    expect(result.status).toBe(503)
+    expect(result.body).toEqual({ error: UNAVAILABLE_MESSAGE })
+  })
+
+  it('maps a timeout/connection error with no status to the unavailable message', () => {
+    const err = fakeProviderError('Request timed out (ETIMEDOUT)')
+    const result = classifyProviderError(err)
+    expect(result.status).toBe(503)
+    expect(result.body).toEqual({ error: UNAVAILABLE_MESSAGE })
+  })
+
+  it('maps a provider 429 to the existing rate-limit message and status, unchanged', () => {
+    const err = fakeProviderError('429 {"type":"error","error":{"type":"rate_limit_error"}}', 429)
+    const result = classifyProviderError(err)
+    expect(result.status).toBe(429)
+    expect(result.body).toEqual({ error: RATE_LIMIT_MESSAGE })
+  })
+
+  it('maps an unrecognized error to the generic failure message', () => {
+    const err = fakeProviderError('Something exploded unexpectedly', 418)
+    const result = classifyProviderError(err)
+    expect(result.status).toBe(500)
+    expect(result.body).toEqual({ error: GENERIC_MESSAGE })
+  })
+
+  it('maps a non-Error thrown value to the generic failure message', () => {
+    const result = classifyProviderError('a plain string throw')
+    expect(result.status).toBe(500)
+    expect(result.body).toEqual({ error: GENERIC_MESSAGE })
+  })
+
+  it.each([
+    ['usage-limit', fakeProviderError('You have reached your specified API usage limits. You will regain access on 2026-08-01 at 00:00 UTC.', 400)],
+    ['outage', fakeProviderError('Internal server error', 500)],
+    ['rate-limit', fakeProviderError('rate_limit_error', 429)],
+    ['generic', fakeProviderError('unexpected failure', 418)],
+  ])('never includes forbidden vendor/billing language for a %s error', (_label, err) => {
+    const result = classifyProviderError(err)
+    const serialized = JSON.stringify(result.body).toLowerCase()
+    for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+      expect(serialized).not.toContain(forbidden)
+    }
+  })
+})

--- a/__tests__/rationale-provider-errors.test.ts
+++ b/__tests__/rationale-provider-errors.test.ts
@@ -1,0 +1,123 @@
+/**
+ * __tests__/rationale-provider-errors.test.ts
+ *
+ * Issue #128: /api/rationale has the same shape as /api/chat (an
+ * unwrapped Anthropic call whose failures were returned to the client
+ * verbatim). Same mocking approach as chat-provider-errors.test.ts —
+ * mock the provider call to fail each way, assert only plain-language
+ * responses ever reach the client.
+ */
+
+import type { NextRequest } from 'next/server'
+
+const mockCreate = jest.fn()
+const mockCaptureException = jest.fn()
+
+jest.mock('@anthropic-ai/sdk', () => {
+  return jest.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  }))
+})
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+import { POST } from '@/app/api/rationale/route'
+
+const FORBIDDEN_SUBSTRINGS = [
+  'usage limit',
+  'credit',
+  'quota',
+  'regain access',
+  'request_id',
+  'anthropic',
+]
+
+const school = {
+  name: 'Test High School',
+  borough: 'Manhattan',
+  size: 'small',
+  admissions_types: ['screened'],
+}
+
+const userInputs = {
+  boroughs: ['Manhattan'],
+  interests: ['STEM'],
+  academicRatings: ['strong'],
+  shsat: false,
+  auditions: false,
+  iep: false,
+  size: 'small',
+}
+
+function fakeRationaleRequest(ip: string): NextRequest {
+  return {
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'x-forwarded-for' ? ip : null),
+    },
+    json: async () => ({ school, userInputs }),
+  } as unknown as NextRequest
+}
+
+beforeEach(() => {
+  mockCreate.mockReset()
+  mockCaptureException.mockReset()
+})
+
+describe('/api/rationale provider failure handling (issue #128)', () => {
+  it('returns a plain-language unavailable response for a usage-limit/credit error', async () => {
+    const upstreamError = new Error(
+      'Your credit balance is too low to access the API. Please go to Plans & Billing to upgrade or purchase credits.'
+    )
+    ;(upstreamError as unknown as { status: number }).status = 400
+    mockCreate.mockRejectedValue(upstreamError)
+
+    const res = await POST(fakeRationaleRequest('10.0.1.1'))
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    const serialized = JSON.stringify(body).toLowerCase()
+    for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+      expect(serialized).not.toContain(forbidden)
+    }
+    expect(mockCaptureException).toHaveBeenCalledWith(upstreamError)
+  })
+
+  it('preserves the existing 429 rate-limit response when the provider itself rate-limits', async () => {
+    const upstreamError = new Error('429 rate_limit_error')
+    ;(upstreamError as unknown as { status: number }).status = 429
+    mockCreate.mockRejectedValue(upstreamError)
+
+    const res = await POST(fakeRationaleRequest('10.0.1.2'))
+    expect(res.status).toBe(429)
+    const body = await res.json()
+    expect(body.error).toBe(
+      "You're sending requests too quickly — please wait a moment and try again."
+    )
+  })
+
+  it('returns a generic failure message for an unrecognized error', async () => {
+    const upstreamError = new Error('something exploded')
+    mockCreate.mockRejectedValue(upstreamError)
+
+    const res = await POST(fakeRationaleRequest('10.0.1.3'))
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    const serialized = JSON.stringify(body).toLowerCase()
+    for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+      expect(serialized).not.toContain(forbidden)
+    }
+  })
+
+  it('still returns a normal title/rationale when the provider call succeeds (no regression)', async () => {
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: '{"title":"Great fit","rationale":"Details here."}' }],
+    })
+
+    const res = await POST(fakeRationaleRequest('10.0.1.4'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.title).toBe('Great fit')
+    expect(body.rationale).toBe('Details here.')
+  })
+})

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -8,9 +8,11 @@
  */
 
 import Anthropic from "@anthropic-ai/sdk";
+import * as Sentry from "@sentry/nextjs";
 import { NextRequest } from "next/server";
 import { searchSchools } from "@/lib/rag";
 import { checkRateLimit } from "@/lib/rate-limit";
+import { classifyProviderError } from "@/lib/provider-error";
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
@@ -29,46 +31,54 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: "question is required" }, { status: 400 });
   }
 
-  // Step 1: Retrieve the top 5 most relevant schools
-  const results = await searchSchools(question, 5);
+  try {
+    // Step 1: Retrieve the top 5 most relevant schools
+    const results = await searchSchools(question, 5);
 
-  // Step 2: Build context from retrieved schools
-  // Each result already contains all chunks for that school, concatenated.
-  const schoolContext = results
-    .map(
-      (r, i) =>
-        `--- School ${i + 1} (similarity: ${r.score.toFixed(3)}, matched on: ${r.matchedChunkType}) ---\n${r.chunk}`
-    )
-    .join("\n\n");
+    // Step 2: Build context from retrieved schools
+    // Each result already contains all chunks for that school, concatenated.
+    const schoolContext = results
+      .map(
+        (r, i) =>
+          `--- School ${i + 1} (similarity: ${r.score.toFixed(3)}, matched on: ${r.matchedChunkType}) ---\n${r.chunk}`
+      )
+      .join("\n\n");
 
-  // Step 3: Send to Claude with the retrieved context
-  const message = await client.messages.create({
-    model: "claude-sonnet-5",
-    max_tokens: 600,
-    system:
-      "You are an experienced NYC high school admissions consultant. Answer the parent's question using ONLY the school information provided below.\n\nFor each school provided, state the school name, then 1-2 sentences about why it is relevant to the parent's question. Mention concrete details and numbers when available. Describe every school provided. Do not skip any.\n\nUse only facts from the provided context. Never say 'appears to', 'seems to', or other hedging language. If a specific detail is not stated in the context, say it is not listed. Do not make up information about schools.\n\nAfter describing all schools, provide a 1-2 sentence summary.",
-    messages: [
-      {
-        role: "user",
-        content:
-          `Here are the most relevant schools for this question:\n\n${schoolContext}\n\n` +
-          `Parent's question: ${question}`,
-      },
-    ],
-  });
+    // Step 3: Send to Claude with the retrieved context
+    const message = await client.messages.create({
+      model: "claude-sonnet-5",
+      max_tokens: 600,
+      system:
+        "You are an experienced NYC high school admissions consultant. Answer the parent's question using ONLY the school information provided below.\n\nFor each school provided, state the school name, then 1-2 sentences about why it is relevant to the parent's question. Mention concrete details and numbers when available. Describe every school provided. Do not skip any.\n\nUse only facts from the provided context. Never say 'appears to', 'seems to', or other hedging language. If a specific detail is not stated in the context, say it is not listed. Do not make up information about schools.\n\nAfter describing all schools, provide a 1-2 sentence summary.",
+      messages: [
+        {
+          role: "user",
+          content:
+            `Here are the most relevant schools for this question:\n\n${schoolContext}\n\n` +
+            `Parent's question: ${question}`,
+        },
+      ],
+    });
 
-  const answer =
-    message.content[0].type === "text" ? message.content[0].text : "";
+    const answer =
+      message.content[0].type === "text" ? message.content[0].text : "";
 
-  // Return the answer and the schools that were retrieved (for transparency)
-  return Response.json({
-    answer,
-    sources: results.map((r) => ({
-      name: r.name,
-      dbn: r.dbn,
-      borough: r.borough,
-      score: r.score,
-      matchedOn: r.matchedChunkType,
-    })),
-  });
+    // Return the answer and the schools that were retrieved (for transparency)
+    return Response.json({
+      answer,
+      sources: results.map((r) => ({
+        name: r.name,
+        dbn: r.dbn,
+        borough: r.borough,
+        score: r.score,
+        matchedOn: r.matchedChunkType,
+      })),
+    });
+  } catch (err) {
+    // Log the real error (vendor detail, status, request id) to Sentry —
+    // never let any part of it reach the client.
+    Sentry.captureException(err);
+    const { status, body } = classifyProviderError(err);
+    return Response.json(body, { status });
+  }
 }

--- a/app/api/rationale/route.ts
+++ b/app/api/rationale/route.ts
@@ -1,6 +1,8 @@
 import Anthropic from '@anthropic-ai/sdk'
+import * as Sentry from '@sentry/nextjs'
 import { NextRequest } from 'next/server'
 import { checkRateLimit } from '@/lib/rate-limit'
+import { classifyProviderError } from '@/lib/provider-error'
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
 
@@ -71,34 +73,42 @@ export async function POST(request: NextRequest) {
     .filter(Boolean)
     .join('\n')
 
-  const message = await client.messages.create({
-    model: 'claude-sonnet-5',
-    max_tokens: 150,
-    system:
-      'You are a helpful NYC high school admissions assistant. Respond with only a valid JSON object — no markdown, no explanation, no code fences. The JSON must have exactly two fields:\n' +
-      '- "title": a 4-6 word summary of what makes this school distinctive (e.g., "Elite STEM, highly competitive" or "Arts focus, open lottery")\n' +
-      '- "rationale": 2-3 short sentences (under 80 words total) describing what makes this school stand out. First sentence: describe the school\'s academic focus, curriculum, or culture based on available data. Then use the language and extracurricular data to give concrete details with counts and examples (e.g., "Offers 7 languages including Japanese and Latin. 190+ clubs spanning robotics, debate, and theater."). If the user selected sports, mention whether this school offers those specific sports (e.g., "Soccer offered through PSAL" or "Soccer not offered"). Do NOT repeat academic scores or applicants per seat — these are already shown on the card. Do NOT repeat the user\'s filter selections (academic level, size preference, borough). Focus on what makes THIS school interesting.\n' +
-      'Example: {"title":"Elite STEM, highly competitive","rationale":"Rigorous STEM-focused curriculum for top performers with strong humanities offerings. Offers 7 languages including Japanese and Latin. 190+ student-run clubs spanning robotics, debate, and theater. Soccer offered through PSAL."}',
-    messages: [
-      {
-        role: 'user',
-        content: `${schoolCtx}\n\nStudent profile:\n${studentCtx}\n\nReturn the JSON object.`,
-      },
-    ],
-  })
-
-  const raw = message.content[0].type === 'text' ? message.content[0].text : '{}'
-
-  let parsed: { title: string; rationale: string }
   try {
-    parsed = JSON.parse(raw)
-  } catch {
-    // If Claude returned something unexpected, surface it as rationale only
-    parsed = { title: '', rationale: raw.slice(0, 200) }
-  }
+    const message = await client.messages.create({
+      model: 'claude-sonnet-5',
+      max_tokens: 150,
+      system:
+        'You are a helpful NYC high school admissions assistant. Respond with only a valid JSON object — no markdown, no explanation, no code fences. The JSON must have exactly two fields:\n' +
+        '- "title": a 4-6 word summary of what makes this school distinctive (e.g., "Elite STEM, highly competitive" or "Arts focus, open lottery")\n' +
+        '- "rationale": 2-3 short sentences (under 80 words total) describing what makes this school stand out. First sentence: describe the school\'s academic focus, curriculum, or culture based on available data. Then use the language and extracurricular data to give concrete details with counts and examples (e.g., "Offers 7 languages including Japanese and Latin. 190+ clubs spanning robotics, debate, and theater."). If the user selected sports, mention whether this school offers those specific sports (e.g., "Soccer offered through PSAL" or "Soccer not offered"). Do NOT repeat academic scores or applicants per seat — these are already shown on the card. Do NOT repeat the user\'s filter selections (academic level, size preference, borough). Focus on what makes THIS school interesting.\n' +
+        'Example: {"title":"Elite STEM, highly competitive","rationale":"Rigorous STEM-focused curriculum for top performers with strong humanities offerings. Offers 7 languages including Japanese and Latin. 190+ student-run clubs spanning robotics, debate, and theater. Soccer offered through PSAL."}',
+      messages: [
+        {
+          role: 'user',
+          content: `${schoolCtx}\n\nStudent profile:\n${studentCtx}\n\nReturn the JSON object.`,
+        },
+      ],
+    })
 
-  return Response.json({
-    title: parsed.title ?? '',
-    rationale: parsed.rationale ?? '',
-  })
+    const raw = message.content[0].type === 'text' ? message.content[0].text : '{}'
+
+    let parsed: { title: string; rationale: string }
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      // If Claude returned something unexpected, surface it as rationale only
+      parsed = { title: '', rationale: raw.slice(0, 200) }
+    }
+
+    return Response.json({
+      title: parsed.title ?? '',
+      rationale: parsed.rationale ?? '',
+    })
+  } catch (err) {
+    // Log the real error (vendor detail, status, request id) to Sentry —
+    // never let any part of it reach the client.
+    Sentry.captureException(err)
+    const { status, body } = classifyProviderError(err)
+    return Response.json(body, { status })
+  }
 }

--- a/lib/provider-error.ts
+++ b/lib/provider-error.ts
@@ -1,0 +1,49 @@
+/**
+ * lib/provider-error.ts
+ *
+ * Maps upstream LLM provider failures (usage limits, credit exhaustion,
+ * rate limits, timeouts, outages, ...) to a small set of plain-language,
+ * client-safe responses. The real error (with vendor detail, status
+ * codes, request IDs) should always be logged separately to Sentry —
+ * this only controls what the client is allowed to see.
+ */
+
+export const RATE_LIMIT_MESSAGE =
+  "You're sending requests too quickly — please wait a moment and try again."
+
+export const UNAVAILABLE_MESSAGE =
+  "The assistant is unavailable right now. The filters and school data still work — please try again shortly."
+
+export const GENERIC_MESSAGE = "Something went wrong. Please try again."
+
+// Vendor language (usage limits, credit balance, quotas, outage wording)
+// that should always be treated as "temporarily unavailable" regardless
+// of the HTTP status the provider happened to attach to it.
+const UNAVAILABLE_PATTERN =
+  /usage limit|credit|quota|regain access|overloaded|unavailable|timed? ?out|ETIMEDOUT|ECONNRESET|ECONNREFUSED/i
+
+export interface ClientSafeError {
+  status: number
+  body: { error: string }
+}
+
+/**
+ * Classify an unknown error thrown by an upstream provider call into a
+ * status + plain-language body that is safe to send to the client.
+ * Never include any part of `err` (message, status, response body) in
+ * the returned body.
+ */
+export function classifyProviderError(err: unknown): ClientSafeError {
+  const status = typeof (err as any)?.status === "number" ? (err as any).status : undefined
+  const message = err instanceof Error ? err.message : String(err)
+
+  if (status === 429) {
+    return { status: 429, body: { error: RATE_LIMIT_MESSAGE } }
+  }
+
+  if ((status !== undefined && status >= 500) || UNAVAILABLE_PATTERN.test(message)) {
+    return { status: 503, body: { error: UNAVAILABLE_MESSAGE } }
+  }
+
+  return { status: 500, body: { error: GENERIC_MESSAGE } }
+}


### PR DESCRIPTION
I already started the build in the background — I'll just wait for its completion notification rather than polling.

Closes #128