### PR TITLE
fix: issue #138 - stop claiming 2025-2026 verification on 2018 DOE data

### DIFF
--- a/__tests__/data-provenance.test.ts
+++ b/__tests__/data-provenance.test.ts
@@ -1,0 +1,107 @@
+import fs from 'fs'
+import path from 'path'
+import {
+  DATA_SOURCES,
+  DOE_DATASET_ID,
+  DOE_DATASET_PUBLISHED,
+  buildProvenanceRows,
+  summariseDataVintage,
+  type SourceProvenance,
+} from '@/lib/data-provenance'
+
+/**
+ * Issue #138. The app used to stamp every record `last_verified: "2025-2026"`
+ * and render it as the cycle the data was verified for — while the DOE half of
+ * that record comes from NYC Open Data `uq7m-95z8`, the *2019* directory, whose
+ * data is dated 2018-08-16.
+ *
+ * Telling a family that 2018 requirements were verified for the current cycle
+ * is the one failure mode that can actually harm them. These tests exist so the
+ * claim cannot quietly return — including via a future data-source change.
+ */
+
+describe('data provenance — sources', () => {
+  it('describes the DOE directory with its real published year, not the current cycle', () => {
+    const doe = DATA_SOURCES.find((s) => s.key === 'doe-directory')
+    expect(doe).toBeDefined()
+    expect(doe!.publishedLabel).toBe(DOE_DATASET_PUBLISHED)
+    expect(DOE_DATASET_PUBLISHED).toBe('2018')
+    expect(doe!.url).toContain(DOE_DATASET_ID)
+  })
+
+  it('claims no vintage for NYC-SIFT, because no fetch date is recorded yet', () => {
+    const sift = DATA_SOURCES.find((s) => s.key === 'sift')
+    expect(sift).toBeDefined()
+    // Honest absence: we do not capture a scrape date, so we assert none.
+    expect(sift!.publishedLabel).toBeNull()
+  })
+
+  it('covers both halves of the record, so neither is silently unattributed', () => {
+    expect(DATA_SOURCES).toHaveLength(2)
+    const covers = DATA_SOURCES.map((s) => s.covers.toLowerCase()).join(' ')
+    expect(covers).toContain('requirements')
+    expect(covers).toContain('applicants per seat')
+  })
+})
+
+describe('data provenance — rendered rows', () => {
+  it('renders one row per source, naming what each supplies', () => {
+    const rows = buildProvenanceRows()
+    expect(rows).toHaveLength(DATA_SOURCES.length)
+    expect(rows.map((r) => r.key).sort()).toEqual(['doe-directory', 'sift'])
+  })
+
+  it('shows a published year only for the source that has one', () => {
+    const rows = buildProvenanceRows()
+    const doe = rows.find((r) => r.key === 'doe-directory')!
+    const sift = rows.find((r) => r.key === 'sift')!
+    expect(doe.value).toContain('published 2018')
+    expect(sift.value).not.toMatch(/published/i)
+  })
+
+  it('never presents the current admissions cycle as a verification date', () => {
+    const rendered = buildProvenanceRows()
+      .map((r) => `${r.label} ${r.value}`)
+      .join(' ')
+    expect(rendered).not.toMatch(/2025-?2026|2025–26|2026-?2027|2026–27/)
+    expect(rendered).not.toMatch(/verified/i)
+  })
+})
+
+describe('data provenance — summary line', () => {
+  it('reports the oldest known vintage, since that is the honest summary', () => {
+    const note = summariseDataVintage()
+    expect(note).toContain('2018')
+    expect(note).toMatch(/confirm at MySchools/i)
+  })
+
+  it('does not imply the data was verified for the current cycle', () => {
+    const note = summariseDataVintage() ?? ''
+    expect(note).not.toMatch(/2025-?2026|2025–26|verified/i)
+  })
+
+  it('renders nothing rather than hedging when no vintage is known', () => {
+    const unknown: SourceProvenance[] = [
+      { key: 'sift', label: 'X', covers: 'y', publishedLabel: null, url: 'https://example.com' },
+    ]
+    expect(summariseDataVintage(unknown)).toBeNull()
+  })
+})
+
+describe('the school page does not re-introduce the typed claim', () => {
+  const pageSource = fs.readFileSync(
+    path.join(__dirname, '../app/school/[dbn]/page.tsx'),
+    'utf-8'
+  )
+
+  it('derives provenance from the sources rather than from last_verified', () => {
+    expect(pageSource).toContain('buildProvenanceRows')
+    // `last_verified` is a typed string on the record; it must not be the basis
+    // of anything the page presents as provenance.
+    expect(pageSource).not.toMatch(/formatAdmissionsCycle\s*\(\s*school\.last_verified/)
+  })
+
+  it('hardcodes no admissions-cycle string in the page', () => {
+    expect(pageSource).not.toMatch(/['"`]20\d\d-20\d\d['"`]/)
+  })
+})

--- a/app/school/[dbn]/SchoolDetailClient.tsx
+++ b/app/school/[dbn]/SchoolDetailClient.tsx
@@ -32,8 +32,8 @@ interface Props {
   subwayLines: string[]
   busRoutes: string[]
   notReportedTransitLabel: string | null
-  provenanceSource: string
-  provenanceCycle: string | null
+  provenanceRows: { key: string; label: string; value: string }[]
+  dataVintageNote: string | null
   sourceUrl: string
   myschoolsUrl: string
   backHref: string
@@ -58,8 +58,8 @@ export default function SchoolDetailClient({
   subwayLines,
   busRoutes,
   notReportedTransitLabel,
-  provenanceSource,
-  provenanceCycle,
+  provenanceRows,
+  dataVintageNote,
   sourceUrl,
   myschoolsUrl,
   backHref,
@@ -383,12 +383,14 @@ export default function SchoolDetailClient({
           <div className="px-[22px] min-[900px]:px-7 py-[26px] flex flex-col gap-[11px]">
             <Eyebrow>Provenance</Eyebrow>
             <div className="flex flex-col gap-[10px]">
-              <DefinitionRow labelWidth={92} label="Source" value={provenanceSource} />
-              {provenanceCycle && <DefinitionRow labelWidth={92} label="Cycle" value={provenanceCycle} />}
+              {provenanceRows.map((row) => (
+                <DefinitionRow key={row.key} labelWidth={92} label={row.label} value={row.value} />
+              ))}
             </div>
             <a href={sourceUrl} target="_blank" rel="noopener noreferrer" className="text-[13.5px] text-accent">
               View source record ↗
             </a>
+            {dataVintageNote && <p className="text-[13px] text-faint">{dataVintageNote}</p>}
           </div>
         </div>
       </div>

--- a/app/school/[dbn]/page.tsx
+++ b/app/school/[dbn]/page.tsx
@@ -18,12 +18,11 @@ import {
   buildNotReportedTransitLabel,
   dedupePrograms,
   buildRequirementBlocks,
-  PROVENANCE_SOURCE,
   MYSCHOOLS_URL,
-  formatAdmissionsCycle,
   describeBackFilters,
   parseMatchedSignals,
 } from '@/lib/school-detail-utils'
+import { buildProvenanceRows, summariseDataVintage } from '@/lib/data-provenance'
 import SchoolDetailClient from './SchoolDetailClient'
 
 // Issue #116: the school detail view. Server component — loads via
@@ -81,7 +80,11 @@ export default async function SchoolDetailPage({
 
   const programs = dedupePrograms(school.programs)
   const requirementBlocks = buildRequirementBlocks(school)
-  const provenanceCycle = formatAdmissionsCycle(school.last_verified)
+  // Issue #138: provenance is derived from the sources themselves, never from
+  // the typed `last_verified` string, which claimed the current cycle for data
+  // published in 2018. See lib/data-provenance.ts.
+  const provenanceRows = buildProvenanceRows()
+  const dataVintageNote = summariseDataVintage()
 
   const alsoOnYourListIndex = schools
     .filter((s) => s.dbn !== school.dbn)
@@ -108,8 +111,8 @@ export default async function SchoolDetailPage({
         subwayLines={subwayLines}
         busRoutes={busRoutes}
         notReportedTransitLabel={notReportedTransitLabel}
-        provenanceSource={PROVENANCE_SOURCE}
-        provenanceCycle={provenanceCycle}
+        provenanceRows={provenanceRows}
+        dataVintageNote={dataVintageNote}
         sourceUrl={school.sift_url}
         myschoolsUrl={MYSCHOOLS_URL}
         backHref={backHref}

--- a/lib/data-provenance.ts
+++ b/lib/data-provenance.ts
@@ -1,0 +1,115 @@
+/**
+ * Where each part of a school record actually comes from, and how old it is.
+ *
+ * Issue #138. The app used to stamp every school `last_verified: "2025-2026"`
+ * and display it as the admissions cycle the data was verified for. That was a
+ * typed string, not a derived fact — it would have read "2025-2026" no matter
+ * how old the underlying data was.
+ *
+ * The dataset is really two datasets with different vintages:
+ *
+ *   NYC-SIFT            — actively maintained; school list, sizes, applicants
+ *                         per seat, academic/survey scores, admissions tracks.
+ *   NYC DOE Open Data   — dataset `uq7m-95z8`, "2019 DOE High School Directory",
+ *                         whose own metadata gives 2018-08-16 as the date the
+ *                         data was last updated. Everything under `doe_data`
+ *                         comes from here: overview, interests, PSAL sports, AP
+ *                         courses, languages, extracurriculars, requirements,
+ *                         transit, and the graduation/attendance/college rates.
+ *
+ * Telling a family that 2018 requirements were verified for the current cycle
+ * is the one failure mode that can actually harm them — they could prepare for
+ * a requirement that no longer exists, or miss one that now does. So we state
+ * what each source is and when it was published, and we say nothing we can't
+ * support.
+ *
+ * `publishedLabel` is null when we genuinely don't know. We do not record a
+ * fetch date at scrape time yet; when the scraper starts capturing one (see
+ * issue #135), fill it in here and the UI follows automatically. The point of
+ * this module is that the date is *derived from the source*, never typed into
+ * a component.
+ */
+
+export type SourceProvenance = {
+  /** Stable key for tests and rendering. */
+  key: 'sift' | 'doe-directory'
+  /** Source name as shown to a family. */
+  label: string
+  /** Plain-language description of what this source supplies. */
+  covers: string
+  /**
+   * What the source itself says about its vintage. `null` means unknown —
+   * render nothing rather than guessing.
+   */
+  publishedLabel: string | null
+  url: string
+}
+
+/** The NYC Open Data dataset the DOE half of every record is built from. */
+export const DOE_DATASET_ID = 'uq7m-95z8'
+
+/**
+ * The DOE directory is a frozen historical snapshot, not a live feed — one of a
+ * numbered series (2013…2021). Re-running the scraper returns identical data,
+ * so this vintage only changes by changing source (issue #135).
+ */
+export const DOE_DATASET_PUBLISHED = '2018'
+
+export const DATA_SOURCES: readonly SourceProvenance[] = [
+  {
+    key: 'sift',
+    label: 'NYC-SIFT',
+    covers: 'School list, size, applicants per seat, academic and survey scores, admissions tracks',
+    // We do not record a scrape date yet, so we claim none.
+    publishedLabel: null,
+    url: 'https://nycsift.com',
+  },
+  {
+    key: 'doe-directory',
+    label: 'NYC DOE School Directory',
+    covers: 'Programs, requirements, activities, transit, graduation and attendance rates',
+    publishedLabel: DOE_DATASET_PUBLISHED,
+    url: `https://data.cityofnewyork.us/resource/${DOE_DATASET_ID}.json`,
+  },
+] as const
+
+export type ProvenanceRow = {
+  key: string
+  label: string
+  value: string
+}
+
+/**
+ * Rows for the provenance section of a school page: one per source, naming what
+ * it supplies and — only when known — when it was published.
+ */
+export function buildProvenanceRows(
+  sources: readonly SourceProvenance[] = DATA_SOURCES
+): ProvenanceRow[] {
+  return sources.map((source) => ({
+    key: source.key,
+    label: source.label,
+    value: source.publishedLabel
+      ? `${source.covers} · published ${source.publishedLabel}`
+      : source.covers,
+  }))
+}
+
+/**
+ * One quiet line for the school page. States the older of the two vintages,
+ * because that is the honest summary — a family reading "current" would
+ * reasonably assume it applied to the requirements, which are the oldest part.
+ *
+ * Returns null when no source has a known vintage, so the UI renders nothing
+ * rather than an empty or hedging line.
+ */
+export function summariseDataVintage(
+  sources: readonly SourceProvenance[] = DATA_SOURCES
+): string | null {
+  const dated = sources.filter((s) => s.publishedLabel)
+  if (dated.length === 0) return null
+  const oldest = dated.reduce((a, b) =>
+    (a.publishedLabel as string) <= (b.publishedLabel as string) ? a : b
+  )
+  return `DOE data published ${oldest.publishedLabel} · confirm at MySchools before you apply`
+}


### PR DESCRIPTION
Closes #138.

Every school record carried `last_verified: "2025-2026"`, rendered on the school page as the cycle the data was verified for. That string was typed, not derived — it would have read 2025-2026 regardless of how old the data was. The DOE half of each record comes from NYC Open Data `uq7m-95z8` ("2019 DOE High School Directory"), whose data is dated 2018-08-16.

Telling a family that 2018 requirements were verified for the current cycle is the failure mode that can actually harm them — preparing for a requirement that no longer exists, or missing one that now does.

**What changed**
- New `lib/data-provenance.ts` declares each source with what it supplies and what it honestly says about its own vintage. The DOE directory reports `published 2018`; NYC-SIFT reports no date, because no fetch date is recorded at scrape time yet.
- The school page's provenance section now renders one row per source, derived from that module. The `Cycle: 2025–26 admissions` row is gone.
- A quiet line states the oldest known vintage and points at MySchools.

**Why it's built this way:** the date is derived from the source rather than typed into a component, so when the MySchools scrape lands (#135, which now requires capturing provenance) the displayed vintage updates automatically — no code change, no string to remember.

`formatAdmissionsCycle` and its existing tests are left untouched; the function is simply no longer used to make a verification claim.

**Tests:** new `__tests__/data-provenance.test.ts` (11 cases) asserts the DOE vintage is reported as 2018, that no provenance string presents the current cycle or the word "verified", and — as a source-level guard — that the page neither derives provenance from `last_verified` nor hardcodes a cycle string. Full suite: 1025 passing across 31 suites. Build green.