### PR TITLE
feat: issue #137 - build /my-schools, the saved-list view

### DIFF
--- a/__tests__/data-provenance.test.ts
+++ b/__tests__/data-provenance.test.ts
@@ -1,0 +1,107 @@
+import fs from 'fs'
+import path from 'path'
+import {
+  DATA_SOURCES,
+  DOE_DATASET_ID,
+  DOE_DATASET_PUBLISHED,
+  buildProvenanceRows,
+  summariseDataVintage,
+  type SourceProvenance,
+} from '@/lib/data-provenance'
+
+/**
+ * Issue #138. The app used to stamp every record `last_verified: "2025-2026"`
+ * and render it as the cycle the data was verified for — while the DOE half of
+ * that record comes from NYC Open Data `uq7m-95z8`, the *2019* directory, whose
+ * data is dated 2018-08-16.
+ *
+ * Telling a family that 2018 requirements were verified for the current cycle
+ * is the one failure mode that can actually harm them. These tests exist so the
+ * claim cannot quietly return — including via a future data-source change.
+ */
+
+describe('data provenance — sources', () => {
+  it('describes the DOE directory with its real published year, not the current cycle', () => {
+    const doe = DATA_SOURCES.find((s) => s.key === 'doe-directory')
+    expect(doe).toBeDefined()
+    expect(doe!.publishedLabel).toBe(DOE_DATASET_PUBLISHED)
+    expect(DOE_DATASET_PUBLISHED).toBe('2018')
+    expect(doe!.url).toContain(DOE_DATASET_ID)
+  })
+
+  it('claims no vintage for NYC-SIFT, because no fetch date is recorded yet', () => {
+    const sift = DATA_SOURCES.find((s) => s.key === 'sift')
+    expect(sift).toBeDefined()
+    // Honest absence: we do not capture a scrape date, so we assert none.
+    expect(sift!.publishedLabel).toBeNull()
+  })
+
+  it('covers both halves of the record, so neither is silently unattributed', () => {
+    expect(DATA_SOURCES).toHaveLength(2)
+    const covers = DATA_SOURCES.map((s) => s.covers.toLowerCase()).join(' ')
+    expect(covers).toContain('requirements')
+    expect(covers).toContain('applicants per seat')
+  })
+})
+
+describe('data provenance — rendered rows', () => {
+  it('renders one row per source, naming what each supplies', () => {
+    const rows = buildProvenanceRows()
+    expect(rows).toHaveLength(DATA_SOURCES.length)
+    expect(rows.map((r) => r.key).sort()).toEqual(['doe-directory', 'sift'])
+  })
+
+  it('shows a published year only for the source that has one', () => {
+    const rows = buildProvenanceRows()
+    const doe = rows.find((r) => r.key === 'doe-directory')!
+    const sift = rows.find((r) => r.key === 'sift')!
+    expect(doe.value).toContain('published 2018')
+    expect(sift.value).not.toMatch(/published/i)
+  })
+
+  it('never presents the current admissions cycle as a verification date', () => {
+    const rendered = buildProvenanceRows()
+      .map((r) => `${r.label} ${r.value}`)
+      .join(' ')
+    expect(rendered).not.toMatch(/2025-?2026|2025–26|2026-?2027|2026–27/)
+    expect(rendered).not.toMatch(/verified/i)
+  })
+})
+
+describe('data provenance — summary line', () => {
+  it('reports the oldest known vintage, since that is the honest summary', () => {
+    const note = summariseDataVintage()
+    expect(note).toContain('2018')
+    expect(note).toMatch(/confirm at MySchools/i)
+  })
+
+  it('does not imply the data was verified for the current cycle', () => {
+    const note = summariseDataVintage() ?? ''
+    expect(note).not.toMatch(/2025-?2026|2025–26|verified/i)
+  })
+
+  it('renders nothing rather than hedging when no vintage is known', () => {
+    const unknown: SourceProvenance[] = [
+      { key: 'sift', label: 'X', covers: 'y', publishedLabel: null, url: 'https://example.com' },
+    ]
+    expect(summariseDataVintage(unknown)).toBeNull()
+  })
+})
+
+describe('the school page does not re-introduce the typed claim', () => {
+  const pageSource = fs.readFileSync(
+    path.join(__dirname, '../app/school/[dbn]/page.tsx'),
+    'utf-8'
+  )
+
+  it('derives provenance from the sources rather than from last_verified', () => {
+    expect(pageSource).toContain('buildProvenanceRows')
+    // `last_verified` is a typed string on the record; it must not be the basis
+    // of anything the page presents as provenance.
+    expect(pageSource).not.toMatch(/formatAdmissionsCycle\s*\(\s*school\.last_verified/)
+  })
+
+  it('hardcodes no admissions-cycle string in the page', () => {
+    expect(pageSource).not.toMatch(/['"`]20\d\d-20\d\d['"`]/)
+  })
+})

--- a/__tests__/my-schools-page.test.ts
+++ b/__tests__/my-schools-page.test.ts
@@ -1,0 +1,60 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Issue #137. Guards the two things that broke elsewhere today:
+ *  1. A server component importing a runtime value from a 'use client' module
+ *     (that shipped a 500 on /school/[dbn] — see #132).
+ *  2. Shipping the full school dataset to the browser.
+ */
+const pageSrc = fs.readFileSync(path.join(__dirname, '../app/my-schools/page.tsx'), 'utf-8')
+const clientSrc = fs.readFileSync(
+  path.join(__dirname, '../app/my-schools/MySchoolsClient.tsx'),
+  'utf-8'
+)
+/**
+ * Comments explain what the file deliberately does NOT do, so they legitimately
+ * contain the vocabulary we're banning from user-facing output. Assert against
+ * code only.
+ */
+const clientCode = clientSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+
+describe('/my-schools server/client boundary', () => {
+  it('keeps the page a server component', () => {
+    expect(pageSrc).not.toMatch(/^['"]use client['"]/m)
+  })
+
+  it('marks the interactive part as a client component', () => {
+    expect(clientSrc).toMatch(/^['"]use client['"]/m)
+  })
+
+  it('imports no runtime value from a client module into the page', () => {
+    // Only the client component itself, plus server-safe libs.
+    const imports = Array.from(pageSrc.matchAll(/from '([^']+)'/g)).map((m) => m[1])
+    const clientModules = imports.filter((i) => i.includes('Client') && !i.includes('type'))
+    expect(clientModules).toEqual(['./MySchoolsClient'])
+  })
+
+  it('ships a slim index rather than full school records', () => {
+    // A whole School carries doe_data and programs; those must not cross.
+    expect(pageSrc).toMatch(/ListSchool\[\]/)
+    expect(pageSrc).not.toMatch(/index:\s*School\[\]/)
+  })
+})
+
+describe('/my-schools makes no derived judgement', () => {
+  it('uses no reach/target/likely or odds language', () => {
+    // Note: the footer legitimately contains "we don't score a list", so this
+    // checks for the vocabulary of a prediction, not the word "score" itself.
+    expect(clientCode).not.toMatch(/reach school|target school|safety school|\bodds\b|chance of|likely to get/i)
+    expect(clientCode).not.toMatch(/\brisky\b|\bbalanced\b/i)
+  })
+
+  it('carries the standing disclaimer that it does not score or predict', () => {
+    expect(clientSrc).toMatch(/don&rsquo;t score a list or predict an outcome/i)
+  })
+
+  it('never renders a missing ratio as zero or a dash', () => {
+    expect(clientSrc).toMatch(/Not reported/i)
+  })
+})

--- a/__tests__/saved-list-utils.test.ts
+++ b/__tests__/saved-list-utils.test.ts
@@ -1,0 +1,170 @@
+import {
+  bucketForSchool,
+  buildComposition,
+  buildShapeSentence,
+  moveItem,
+  ratioBand,
+  resolveSavedSchools,
+} from '@/lib/saved-list-utils'
+import type { School } from '@/types'
+
+/**
+ * Issue #137. The design handoff flags one specific past failure: the
+ * proportion band was encoded from a different set than the legend and showed
+ * three open/zoned schools where there were two. The sum assertion below is the
+ * guard against that class of bug.
+ */
+
+function school(over: Partial<School> & { dbn: string }): School {
+  return {
+    name: `School ${over.dbn}`,
+    borough: 'Brooklyn',
+    size: 'Medium',
+    total_students: 500,
+    applicants_per_seat: 4,
+    academic_score_pct: 70,
+    survey_score_pct: 70,
+    admissions_types: ['Open'],
+    programs: [],
+    flags: {} as School['flags'],
+    doe_data: {} as School['doe_data'],
+    sift_url: 'https://nycsift.com/x',
+    last_verified: '2025-2026',
+    ...over,
+  } as School
+}
+
+describe('bucket assignment — most selective wins', () => {
+  it('puts a school in its most selective bucket when it carries several methods', () => {
+    // DOE programs routinely carry more than one method at once.
+    expect(bucketForSchool({ admissions_types: ['Screened', 'Audition'] })).toBe('audition')
+    expect(bucketForSchool({ admissions_types: ['Screened', 'SHSAT'] })).toBe('shsat')
+    expect(bucketForSchool({ admissions_types: ['Open', 'Screened'] })).toBe('screened')
+  })
+
+  it('treats "Screened with Assessment" as screened', () => {
+    expect(bucketForSchool({ admissions_types: ['Screened with Assessment'] })).toBe('screened')
+  })
+
+  it('places Educational Option and Zoned in the least selective bucket', () => {
+    expect(bucketForSchool({ admissions_types: ['Educational Option'] })).toBe('open')
+    expect(bucketForSchool({ admissions_types: ['Zoned'] })).toBe('open')
+  })
+
+  it('always returns a bucket, even with no admissions types at all', () => {
+    // 51 schools in the live dataset have an empty admissions_types array.
+    expect(bucketForSchool({ admissions_types: [] })).toBe('open')
+    expect(bucketForSchool({ admissions_types: undefined as unknown as string[] })).toBe('open')
+  })
+})
+
+describe('composition — one source for band and legend', () => {
+  const saved = [
+    school({ dbn: 'A', admissions_types: ['SHSAT'] }),
+    school({ dbn: 'B', admissions_types: ['Audition'] }),
+    school({ dbn: 'C', admissions_types: ['Screened'] }),
+    school({ dbn: 'D', admissions_types: ['Screened', 'Audition'] }),
+    school({ dbn: 'E', admissions_types: ['Educational Option'] }),
+  ]
+
+  it('counts every saved school exactly once', () => {
+    const c = buildComposition(saved)
+    const sum = c.buckets.reduce((n, b) => n + b.count, 0)
+    // The guard the handoff asks for: buckets must sum to the saved total.
+    expect(sum).toBe(c.total)
+    expect(c.total).toBe(5)
+  })
+
+  it('assigns multi-method schools to the more selective bucket, not both', () => {
+    const c = buildComposition(saved)
+    expect(c.buckets.find((b) => b.key === 'audition')!.count).toBe(2) // B and D
+    expect(c.buckets.find((b) => b.key === 'screened')!.count).toBe(1) // C only
+  })
+
+  it('keeps zero-count buckets so an absent option is visible', () => {
+    const c = buildComposition([school({ dbn: 'A', admissions_types: ['Screened'] })])
+    const open = c.buckets.find((b) => b.key === 'open')!
+    expect(open.count).toBe(0)
+    expect(c.buckets).toHaveLength(4)
+  })
+
+  it('never emits a percentage or a score', () => {
+    const c = buildComposition(saved)
+    const serialized = JSON.stringify(c)
+    expect(serialized).not.toMatch(/%|percent|score|risky|balanced|safe|reach|target|likely/i)
+  })
+})
+
+describe('applicants-per-seat breakdown', () => {
+  it('bands ratios at the documented boundaries', () => {
+    expect(ratioBand(2.9)).toBe('Under 3')
+    expect(ratioBand(3)).toBe('3 to 6')
+    expect(ratioBand(6)).toBe('3 to 6')
+    expect(ratioBand(6.1)).toBe('Over 6')
+  })
+
+  it('counts a missing ratio as missing, never as zero', () => {
+    const c = buildComposition([
+      school({ dbn: 'A', applicants_per_seat: null }),
+      school({ dbn: 'B', applicants_per_seat: 8 }),
+    ])
+    expect(c.ratioMissing).toBe(1)
+    const banded = c.byRatio.reduce((n, r) => n + r.count, 0)
+    expect(banded).toBe(1) // only B is banded
+    expect(c.byRatio.find((r) => r.label === 'Under 3')!.count).toBe(0)
+  })
+})
+
+describe('shape sentence — factual, never advisory', () => {
+  it('names the gap when nothing on the list is open, Ed Opt or zoned', () => {
+    const c = buildComposition([
+      school({ dbn: 'A', admissions_types: ['Screened'] }),
+      school({ dbn: 'B', admissions_types: ['SHSAT'] }),
+    ])
+    expect(c.shapeSentence).toMatch(/No open, Ed Opt or zoned program is on it yet/i)
+  })
+
+  it('reports an incomplete ratio column rather than hiding it', () => {
+    const c = buildComposition([
+      school({ dbn: 'A', applicants_per_seat: null }),
+      school({ dbn: 'B', applicants_per_seat: 4 }),
+    ])
+    expect(c.shapeSentence).toMatch(/incomplete/i)
+  })
+
+  it('offers no advice and predicts nothing', () => {
+    const c = buildComposition([
+      school({ dbn: 'A', admissions_types: ['Screened'] }),
+      school({ dbn: 'B', admissions_types: ['Open'] }),
+    ])
+    expect(c.shapeSentence).not.toMatch(
+      /should|consider|recommend|risky|balanced|safe|reach|likely|chance|add more/i
+    )
+  })
+
+  it('handles an empty list without inventing a shape', () => {
+    expect(buildShapeSentence([], 0, 0)).toBe('Nothing is saved yet.')
+  })
+})
+
+describe('resolving and reordering', () => {
+  const all = [school({ dbn: 'A' }), school({ dbn: 'B' }), school({ dbn: 'C' })]
+
+  it('returns saved schools in the family’s rank order, not dataset order', () => {
+    expect(resolveSavedSchools(all, ['C', 'A']).map((s) => s.dbn)).toEqual(['C', 'A'])
+  })
+
+  it('drops a saved dbn that is no longer in the dataset rather than rendering a blank row', () => {
+    expect(resolveSavedSchools(all, ['A', 'GONE', 'B']).map((s) => s.dbn)).toEqual(['A', 'B'])
+  })
+
+  it('moves an item one position and leaves the rest in order', () => {
+    expect(moveItem(['a', 'b', 'c'], 2, -1)).toEqual(['a', 'c', 'b'])
+    expect(moveItem(['a', 'b', 'c'], 0, 1)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('is a no-op at the ends, so the first row cannot move up', () => {
+    expect(moveItem(['a', 'b'], 0, -1)).toEqual(['a', 'b'])
+    expect(moveItem(['a', 'b'], 1, 1)).toEqual(['a', 'b'])
+  })
+})

--- a/app/my-schools/MySchoolsClient.tsx
+++ b/app/my-schools/MySchoolsClient.tsx
@@ -1,0 +1,310 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { ADDED_SCHOOLS_KEY, trackLabel } from '@/lib/school-list-utils'
+import { Eyebrow } from '@/components/ui'
+import {
+  buildComposition,
+  moveItem,
+  resolveSavedSchools,
+  type Composition,
+  type ListSchool,
+} from '@/lib/saved-list-utils'
+
+/**
+ * /my-schools — issue #137.
+ *
+ * Rank order is the product: NYC families submit an ordered list of programs in
+ * MySchools, and this page is a draft of that submission. So the array order IS
+ * the ranking, reorder is a primary control (not a nicety), and rank numerals
+ * are positional — recomputed on every render, never stored, so a stale number
+ * can't be shown.
+ *
+ * Reorder uses explicit ↑/↓ rather than drag: the list can run long, the
+ * audience skews to phones and shared machines, and a parent needs to see "07"
+ * and move it one place with certainty.
+ *
+ * Composition is counts only. Nothing here scores a list, calls it balanced or
+ * risky, or predicts anything.
+ */
+
+type Props = {
+  /** Slim index of every school — the client resolves saved dbns against it. */
+  index: ListSchool[]
+}
+
+const SAVED_ORDER_KEY = 'admitday_my_schools_order'
+
+export default function MySchoolsClient({ index }: Props) {
+  const [order, setOrder] = useState<string[]>([])
+  const [hydrated, setHydrated] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  // Saved dbns come from the same key /find writes. A separate key holds the
+  // family's ranking, so adding on /find never disturbs an order set here.
+  useEffect(() => {
+    try {
+      const added: string[] = JSON.parse(localStorage.getItem(ADDED_SCHOOLS_KEY) ?? '[]')
+      const stored: string[] = JSON.parse(localStorage.getItem(SAVED_ORDER_KEY) ?? '[]')
+      const ranked = stored.filter((dbn) => added.includes(dbn))
+      const unranked = added.filter((dbn) => !ranked.includes(dbn))
+      setOrder([...ranked, ...unranked])
+    } catch {
+      setOrder([])
+    }
+    setHydrated(true)
+  }, [])
+
+  const persist = (next: string[]) => {
+    setOrder(next)
+    try {
+      localStorage.setItem(SAVED_ORDER_KEY, JSON.stringify(next))
+    } catch {
+      setNotice('Could not save that change on this device.')
+    }
+  }
+
+  const saved = useMemo(() => resolveSavedSchools(index, order), [index, order])
+  const composition: Composition = useMemo(() => buildComposition(saved), [saved])
+
+  const move = (i: number, dir: -1 | 1) => {
+    const next = moveItem(order, i, dir)
+    if (next !== order) {
+      persist(next)
+      setNotice(null)
+    }
+  }
+
+  const remove = (dbn: string) => {
+    persist(order.filter((d) => d !== dbn))
+    try {
+      const added: string[] = JSON.parse(localStorage.getItem(ADDED_SCHOOLS_KEY) ?? '[]')
+      localStorage.setItem(ADDED_SCHOOLS_KEY, JSON.stringify(added.filter((d) => d !== dbn)))
+    } catch {
+      /* the ranking already updated; storage failure is surfaced below */
+    }
+    const school = index.find((s) => s.dbn === dbn)
+    setNotice(school ? `Removed ${school.name}.` : 'Removed.')
+  }
+
+  if (!hydrated) {
+    // The list lives in localStorage, so render nothing rather than flashing an
+    // empty state at a family who has schools saved.
+    return <div className="min-h-[40vh]" aria-busy="true" />
+  }
+
+  if (saved.length === 0) {
+    // Deliberately one line and one door. An onboarding panel was designed for
+    // this state and cut.
+    return (
+      <div className="px-5 min-[900px]:px-9 py-14">
+        <h1 className="font-display font-bold text-[40px] leading-[1.04] tracking-[-0.038em] text-ink">
+          My Schools
+        </h1>
+        <p className="mt-5 text-[15px] text-muted">
+          Nothing saved yet.{' '}
+          <Link href="/find" className="text-accent underline underline-offset-[3px]">
+            Find schools
+          </Link>{' '}
+          and add the ones you want to compare.
+        </p>
+      </div>
+    )
+  }
+
+  const wide = saved.length >= 7
+
+  return (
+    <div>
+      <div className="flex items-end justify-between gap-5 px-5 min-[900px]:px-9 pt-[30px] pb-6 border-b border-rule">
+        <h1 className="font-display font-bold text-[30px] min-[700px]:text-[40px] leading-[1.04] tracking-[-0.038em] text-ink">
+          My Schools
+        </h1>
+        <button
+          type="button"
+          onClick={() => window.print()}
+          className="bg-ink text-white text-[14px] font-medium px-5 py-[11px] hover:opacity-90 transition-opacity duration-[120ms] ease-out"
+        >
+          Export
+        </button>
+      </div>
+
+      <div className={wide ? 'grid grid-cols-1 min-[900px]:grid-cols-[1fr_316px]' : ''}>
+        <section
+          className={`px-5 min-[900px]:px-9 pt-[26px] pb-[30px] ${wide ? 'min-[900px]:border-r border-rule' : ''}`}
+        >
+          <div className="flex items-baseline justify-between gap-4 mb-3">
+            <Eyebrow>Your ranking</Eyebrow>
+            <span className="text-[12.5px] text-faint">
+              Use ↑ ↓ — this order is the one you&rsquo;ll enter in MySchools
+            </span>
+          </div>
+
+          <div className="grid grid-cols-[46px_1fr_auto] min-[700px]:grid-cols-[46px_1fr_132px_62px_84px] gap-3 pb-2 border-b border-rule font-mono text-[10px] uppercase tracking-[0.1em] text-faint">
+            <span>Rank</span>
+            <span>School</span>
+            <span className="hidden min-[700px]:block">Track</span>
+            <span className="hidden min-[700px]:block">A/Seat</span>
+            <span />
+          </div>
+
+          {saved.map((school, i) => {
+            const ratio = school.applicants_per_seat
+            return (
+              <div
+                key={school.dbn}
+                className="grid grid-cols-[46px_1fr_auto] min-[700px]:grid-cols-[46px_1fr_132px_62px_84px] gap-3 items-start py-[11px] border-b border-rule-light hover:bg-surface-2 transition-colors duration-[120ms] ease-out"
+              >
+                <span className="font-mono text-[16px] font-medium text-ink">
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <div className="min-w-0">
+                  <Link
+                    href={`/school/${school.dbn}`}
+                    className="text-[15px] font-semibold text-ink hover:text-accent"
+                  >
+                    {school.name}
+                  </Link>
+                  <p className="text-[12.5px] text-muted mt-[2px]">
+                    {[school.neighborhood, school.borough].filter(Boolean).join(', ')}
+                    <span className="font-mono ml-2 text-faint">{school.dbn}</span>
+                  </p>
+                  <p className="min-[700px]:hidden text-[13px] text-ink-2 mt-1">
+                    {(school.admissions_types ?? []).map(trackLabel).join(', ') || '—'}
+                    {ratio != null && <span className="font-mono ml-2">{ratio} / seat</span>}
+                  </p>
+                </div>
+                <span className="hidden min-[700px]:block text-[13.5px] text-ink-2">
+                  {(school.admissions_types ?? []).map(trackLabel).join(', ')}
+                </span>
+                <span className="hidden min-[700px]:block font-mono text-[14px] text-ink">
+                  {ratio != null ? (
+                    ratio
+                  ) : (
+                    <span className="font-mono text-[11px] uppercase tracking-[0.06em] text-faint">
+                      Not reported
+                    </span>
+                  )}
+                </span>
+                <div className="flex items-center gap-1 justify-end">
+                  <button
+                    type="button"
+                    onClick={() => move(i, -1)}
+                    disabled={i === 0}
+                    aria-label={`Move ${school.name} up`}
+                    className="w-[23px] h-[23px] border border-border text-[12px] text-ink disabled:text-border disabled:cursor-default hover:border-muted"
+                  >
+                    ↑
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => move(i, 1)}
+                    disabled={i === saved.length - 1}
+                    aria-label={`Move ${school.name} down`}
+                    className="w-[23px] h-[23px] border border-border text-[12px] text-ink disabled:text-border disabled:cursor-default hover:border-muted"
+                  >
+                    ↓
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => remove(school.dbn)}
+                    aria-label={`Remove ${school.name}`}
+                    className="w-[23px] h-[23px] text-[13px] text-faint hover:text-ink"
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+            )
+          })}
+
+          {composition.ratioMissing > 0 && (
+            <div className="pt-3">
+              <Eyebrow>Data gap</Eyebrow>
+              <p className="text-[13px] text-muted mt-1">
+                The DOE doesn&rsquo;t publish an applicants-per-seat figure for every school on this
+                list. That&rsquo;s a gap in the source data, not a low number.
+              </p>
+            </div>
+          )}
+
+          {notice && <p className="text-[13px] text-muted pt-3">{notice}</p>}
+        </section>
+
+        <aside className={wide ? '' : 'border-t border-rule'}>
+          <section className="px-5 min-[900px]:px-7 py-[26px]">
+            <div className="flex items-baseline justify-between gap-3 mb-3">
+              <Eyebrow>Composition</Eyebrow>
+              <span className="font-mono text-[11px] uppercase tracking-[0.1em] text-faint">
+                {composition.total} saved
+              </span>
+            </div>
+
+            <div className="flex h-3 w-full mb-3">
+              {composition.buckets.map((b, i) => (
+                <div
+                  key={b.key}
+                  style={{ flex: b.count }}
+                  className={['bg-ink', 'bg-ink-2', 'bg-muted', 'bg-faint'][i]}
+                />
+              ))}
+            </div>
+
+            <div className="flex flex-col gap-[7px]">
+              {composition.buckets.map((b, i) => (
+                <div key={b.key} className="flex items-center gap-2">
+                  <span
+                    className={`w-[10px] h-[10px] ${
+                      b.count === 0
+                        ? 'border border-border bg-surface'
+                        : ['bg-ink', 'bg-ink-2', 'bg-muted', 'bg-faint'][i]
+                    }`}
+                  />
+                  <span
+                    className={`flex-1 text-[13.5px] ${b.count === 0 ? 'text-faint' : 'text-ink-2'}`}
+                  >
+                    {b.label}
+                  </span>
+                  <span className="font-mono text-[13px] text-ink">{b.count}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="pt-[14px] mt-[14px] border-t border-rule-light">
+              <Eyebrow>Reading the shape</Eyebrow>
+              <p className="text-[13px] text-muted mt-1">{composition.shapeSentence}</p>
+            </div>
+
+            {composition.byBorough.length > 0 && (
+              <div className="pt-[14px] mt-[14px] border-t border-rule-light">
+                <Eyebrow>Boroughs</Eyebrow>
+                <div className="grid grid-cols-3 gap-[1px] bg-rule border border-rule mt-2">
+                  {composition.byBorough.slice(0, 6).map((cell) => (
+                    <div key={cell.label} className="bg-surface px-3 py-2">
+                      <div className="font-mono text-[18px] font-medium tracking-[-0.02em] text-ink">
+                        {cell.count}
+                      </div>
+                      <div className="text-[11px] uppercase tracking-[0.04em] text-faint">
+                        {cell.label}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+        </aside>
+      </div>
+
+      <div className="flex flex-col min-[900px]:flex-row justify-between gap-1 px-5 min-[900px]:px-9 py-4 bg-surface-2 border-t border-rule">
+        <span className="text-[13px] text-faint">
+          Confirm each program on the official listing before you apply.
+        </span>
+        <span className="text-[13px] text-faint">
+          Counts only — we don&rsquo;t score a list or predict an outcome.
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/app/my-schools/page.tsx
+++ b/app/my-schools/page.tsx
@@ -1,0 +1,35 @@
+import Footer from '@/components/Footer'
+import { getAllSchools } from '@/lib/load-schools'
+import type { ListSchool } from '@/lib/saved-list-utils'
+import MySchoolsClient from './MySchoolsClient'
+
+/**
+ * /my-schools — issue #137. The screen behind the saved count in the header.
+ *
+ * The saved list lives in localStorage, so the server cannot know which schools
+ * a family saved. It therefore ships a slim index of every school and lets the
+ * client resolve saved DBNs against it — a few fields per school rather than
+ * the full record, which keeps the payload small.
+ *
+ * Nothing here is a client import: `getAllSchools` and the index shaping are
+ * server-side, and the only thing handed across the boundary is plain data.
+ */
+export default async function MySchoolsPage() {
+  const schools = await getAllSchools()
+
+  const index: ListSchool[] = schools.map((s) => ({
+    dbn: s.dbn,
+    name: s.name,
+    borough: s.borough,
+    admissions_types: s.admissions_types ?? [],
+    applicants_per_seat: s.applicants_per_seat,
+    neighborhood: s.doe_data?.neighborhood ?? null,
+  }))
+
+  return (
+    <main className="min-h-screen bg-white">
+      <MySchoolsClient index={index} />
+      <Footer />
+    </main>
+  )
+}

--- a/app/school/[dbn]/SchoolDetailClient.tsx
+++ b/app/school/[dbn]/SchoolDetailClient.tsx
@@ -32,8 +32,8 @@ interface Props {
   subwayLines: string[]
   busRoutes: string[]
   notReportedTransitLabel: string | null
-  provenanceSource: string
-  provenanceCycle: string | null
+  provenanceRows: { key: string; label: string; value: string }[]
+  dataVintageNote: string | null
   sourceUrl: string
   myschoolsUrl: string
   backHref: string
@@ -58,8 +58,8 @@ export default function SchoolDetailClient({
   subwayLines,
   busRoutes,
   notReportedTransitLabel,
-  provenanceSource,
-  provenanceCycle,
+  provenanceRows,
+  dataVintageNote,
   sourceUrl,
   myschoolsUrl,
   backHref,
@@ -383,12 +383,14 @@ export default function SchoolDetailClient({
           <div className="px-[22px] min-[900px]:px-7 py-[26px] flex flex-col gap-[11px]">
             <Eyebrow>Provenance</Eyebrow>
             <div className="flex flex-col gap-[10px]">
-              <DefinitionRow labelWidth={92} label="Source" value={provenanceSource} />
-              {provenanceCycle && <DefinitionRow labelWidth={92} label="Cycle" value={provenanceCycle} />}
+              {provenanceRows.map((row) => (
+                <DefinitionRow key={row.key} labelWidth={92} label={row.label} value={row.value} />
+              ))}
             </div>
             <a href={sourceUrl} target="_blank" rel="noopener noreferrer" className="text-[13.5px] text-accent">
               View source record ↗
             </a>
+            {dataVintageNote && <p className="text-[13px] text-faint">{dataVintageNote}</p>}
           </div>
         </div>
       </div>

--- a/app/school/[dbn]/SiteHeader.tsx
+++ b/app/school/[dbn]/SiteHeader.tsx
@@ -27,12 +27,12 @@ export default function SiteHeader({ addedCount }: Props) {
         <Link href="/find" className="text-ink font-medium border-b-2 border-accent pb-[3px]">
           Find
         </Link>
-        <Link href="/list" className="hover:text-ink transition-colors duration-[120ms] ease-out">
+        <Link href="/my-schools" className="hover:text-ink transition-colors duration-[120ms] ease-out">
           My Schools
           {addedCount > 0 && <span className="font-mono text-accent ml-1">{addedCount}</span>}
         </Link>
         <Link
-          href="/requirements"
+          href="/checklist"
           className="hover:text-ink transition-colors duration-[120ms] ease-out"
         >
           Readiness

--- a/app/school/[dbn]/page.tsx
+++ b/app/school/[dbn]/page.tsx
@@ -18,12 +18,11 @@ import {
   buildNotReportedTransitLabel,
   dedupePrograms,
   buildRequirementBlocks,
-  PROVENANCE_SOURCE,
   MYSCHOOLS_URL,
-  formatAdmissionsCycle,
   describeBackFilters,
   parseMatchedSignals,
 } from '@/lib/school-detail-utils'
+import { buildProvenanceRows, summariseDataVintage } from '@/lib/data-provenance'
 import SchoolDetailClient from './SchoolDetailClient'
 
 // Issue #116: the school detail view. Server component — loads via
@@ -81,7 +80,11 @@ export default async function SchoolDetailPage({
 
   const programs = dedupePrograms(school.programs)
   const requirementBlocks = buildRequirementBlocks(school)
-  const provenanceCycle = formatAdmissionsCycle(school.last_verified)
+  // Issue #138: provenance is derived from the sources themselves, never from
+  // the typed `last_verified` string, which claimed the current cycle for data
+  // published in 2018. See lib/data-provenance.ts.
+  const provenanceRows = buildProvenanceRows()
+  const dataVintageNote = summariseDataVintage()
 
   const alsoOnYourListIndex = schools
     .filter((s) => s.dbn !== school.dbn)
@@ -108,8 +111,8 @@ export default async function SchoolDetailPage({
         subwayLines={subwayLines}
         busRoutes={busRoutes}
         notReportedTransitLabel={notReportedTransitLabel}
-        provenanceSource={PROVENANCE_SOURCE}
-        provenanceCycle={provenanceCycle}
+        provenanceRows={provenanceRows}
+        dataVintageNote={dataVintageNote}
         sourceUrl={school.sift_url}
         myschoolsUrl={MYSCHOOLS_URL}
         backHref={backHref}

--- a/lib/data-provenance.ts
+++ b/lib/data-provenance.ts
@@ -1,0 +1,115 @@
+/**
+ * Where each part of a school record actually comes from, and how old it is.
+ *
+ * Issue #138. The app used to stamp every school `last_verified: "2025-2026"`
+ * and display it as the admissions cycle the data was verified for. That was a
+ * typed string, not a derived fact — it would have read "2025-2026" no matter
+ * how old the underlying data was.
+ *
+ * The dataset is really two datasets with different vintages:
+ *
+ *   NYC-SIFT            — actively maintained; school list, sizes, applicants
+ *                         per seat, academic/survey scores, admissions tracks.
+ *   NYC DOE Open Data   — dataset `uq7m-95z8`, "2019 DOE High School Directory",
+ *                         whose own metadata gives 2018-08-16 as the date the
+ *                         data was last updated. Everything under `doe_data`
+ *                         comes from here: overview, interests, PSAL sports, AP
+ *                         courses, languages, extracurriculars, requirements,
+ *                         transit, and the graduation/attendance/college rates.
+ *
+ * Telling a family that 2018 requirements were verified for the current cycle
+ * is the one failure mode that can actually harm them — they could prepare for
+ * a requirement that no longer exists, or miss one that now does. So we state
+ * what each source is and when it was published, and we say nothing we can't
+ * support.
+ *
+ * `publishedLabel` is null when we genuinely don't know. We do not record a
+ * fetch date at scrape time yet; when the scraper starts capturing one (see
+ * issue #135), fill it in here and the UI follows automatically. The point of
+ * this module is that the date is *derived from the source*, never typed into
+ * a component.
+ */
+
+export type SourceProvenance = {
+  /** Stable key for tests and rendering. */
+  key: 'sift' | 'doe-directory'
+  /** Source name as shown to a family. */
+  label: string
+  /** Plain-language description of what this source supplies. */
+  covers: string
+  /**
+   * What the source itself says about its vintage. `null` means unknown —
+   * render nothing rather than guessing.
+   */
+  publishedLabel: string | null
+  url: string
+}
+
+/** The NYC Open Data dataset the DOE half of every record is built from. */
+export const DOE_DATASET_ID = 'uq7m-95z8'
+
+/**
+ * The DOE directory is a frozen historical snapshot, not a live feed — one of a
+ * numbered series (2013…2021). Re-running the scraper returns identical data,
+ * so this vintage only changes by changing source (issue #135).
+ */
+export const DOE_DATASET_PUBLISHED = '2018'
+
+export const DATA_SOURCES: readonly SourceProvenance[] = [
+  {
+    key: 'sift',
+    label: 'NYC-SIFT',
+    covers: 'School list, size, applicants per seat, academic and survey scores, admissions tracks',
+    // We do not record a scrape date yet, so we claim none.
+    publishedLabel: null,
+    url: 'https://nycsift.com',
+  },
+  {
+    key: 'doe-directory',
+    label: 'NYC DOE School Directory',
+    covers: 'Programs, requirements, activities, transit, graduation and attendance rates',
+    publishedLabel: DOE_DATASET_PUBLISHED,
+    url: `https://data.cityofnewyork.us/resource/${DOE_DATASET_ID}.json`,
+  },
+] as const
+
+export type ProvenanceRow = {
+  key: string
+  label: string
+  value: string
+}
+
+/**
+ * Rows for the provenance section of a school page: one per source, naming what
+ * it supplies and — only when known — when it was published.
+ */
+export function buildProvenanceRows(
+  sources: readonly SourceProvenance[] = DATA_SOURCES
+): ProvenanceRow[] {
+  return sources.map((source) => ({
+    key: source.key,
+    label: source.label,
+    value: source.publishedLabel
+      ? `${source.covers} · published ${source.publishedLabel}`
+      : source.covers,
+  }))
+}
+
+/**
+ * One quiet line for the school page. States the older of the two vintages,
+ * because that is the honest summary — a family reading "current" would
+ * reasonably assume it applied to the requirements, which are the oldest part.
+ *
+ * Returns null when no source has a known vintage, so the UI renders nothing
+ * rather than an empty or hedging line.
+ */
+export function summariseDataVintage(
+  sources: readonly SourceProvenance[] = DATA_SOURCES
+): string | null {
+  const dated = sources.filter((s) => s.publishedLabel)
+  if (dated.length === 0) return null
+  const oldest = dated.reduce((a, b) =>
+    (a.publishedLabel as string) <= (b.publishedLabel as string) ? a : b
+  )
+  return `DOE data published ${oldest.publishedLabel} · confirm at MySchools before you apply`
+}

--- a/lib/saved-list-utils.ts
+++ b/lib/saved-list-utils.ts
@@ -1,0 +1,212 @@
+import type { School } from '@/types'
+
+/**
+ * The subset of a school this page needs. The saved list lives in localStorage,
+ * so the server can't know which schools are saved and must ship an index of
+ * all of them — slim keeps that payload small. A full `School` satisfies this
+ * structurally, so callers and tests can pass either.
+ */
+export type ListSchool = Pick<
+  School,
+  'dbn' | 'name' | 'borough' | 'admissions_types' | 'applicants_per_seat'
+> & { neighborhood?: string | null }
+
+/**
+ * Derivations for /my-schools (issue #137).
+ *
+ * The composition section is counts, never a score. Nothing here ranks buckets
+ * by desirability, labels a list "risky" or "balanced", or emits a percentage —
+ * a percentage invites a target, and this product does not set targets.
+ *
+ * The band weights and the legend read from ONE array (`buckets`). The design
+ * handoff calls this out specifically: an earlier build encoded the band from a
+ * different set than the legend and showed three open/zoned schools where there
+ * were two — the exact misread this section exists to prevent.
+ */
+
+export type BucketKey = 'shsat' | 'audition' | 'screened' | 'open'
+
+export type CompositionBucket = {
+  key: BucketKey
+  label: string
+  count: number
+}
+
+export type BreakdownCell = {
+  label: string
+  count: number
+}
+
+export type Composition = {
+  total: number
+  /** Zero-count buckets are kept — seeing "Open / Ed Opt / Zoned 0" is the point. */
+  buckets: CompositionBucket[]
+  byBorough: BreakdownCell[]
+  byRatio: BreakdownCell[]
+  shapeSentence: string
+  /** Saved schools with no published applicants-per-seat; drives the incomplete-column note. */
+  ratioMissing: number
+}
+
+/**
+ * Buckets are mutually exclusive and resolved most-selective-first, because DOE
+ * programs carry several methods at once (e.g. "Screened, Audition"). A school
+ * is counted exactly once, in its most selective bucket.
+ */
+const BUCKET_ORDER: { key: BucketKey; label: string; matches: (t: string) => boolean }[] = [
+  {
+    key: 'shsat',
+    label: 'SHSAT',
+    matches: (t) => t === 'shsat',
+  },
+  {
+    key: 'audition',
+    label: 'Audition / Portfolio',
+    matches: (t) => t.includes('audition') || t.includes('portfolio'),
+  },
+  {
+    key: 'screened',
+    label: 'Screened',
+    matches: (t) => t.includes('screened'),
+  },
+  {
+    // Educational Option lives here rather than in its own bucket: the design
+    // specifies four buckets, and Ed Opt is not selectively screened. The label
+    // names it explicitly so a family isn't told "Open / Zoned" for a set that
+    // is mostly Ed Opt — which in this dataset it usually is.
+    key: 'open',
+    label: 'Open / Ed Opt / Zoned',
+    matches: () => true,
+  },
+]
+
+/** The most selective bucket a school belongs to. Always returns one. */
+export function bucketForSchool(school: Pick<ListSchool, 'admissions_types'>): BucketKey {
+  const types = (school.admissions_types ?? []).map((t) => t.toLowerCase().trim())
+  for (const bucket of BUCKET_ORDER) {
+    if (bucket.key === 'open') continue
+    if (types.some((t) => bucket.matches(t))) return bucket.key
+  }
+  return 'open'
+}
+
+/** "Under 3" / "3 to 6" / "Over 6" — the same shape as the design's ratio cells. */
+export function ratioBand(ratio: number): string {
+  if (ratio < 3) return 'Under 3'
+  if (ratio <= 6) return '3 to 6'
+  return 'Over 6'
+}
+
+/**
+ * One factual sentence describing only what is on the list. Never advisory,
+ * never predictive — it reports, it does not recommend.
+ */
+export function buildShapeSentence(
+  buckets: CompositionBucket[],
+  total: number,
+  ratioMissing: number
+): string {
+  if (total === 0) return 'Nothing is saved yet.'
+
+  const open = buckets.find((b) => b.key === 'open')?.count ?? 0
+  const selective = total - open
+  const parts: string[] = []
+
+  if (open === 0) {
+    parts.push('Every school on the list screens, tests or auditions. No open, Ed Opt or zoned program is on it yet.')
+  } else if (selective === 0) {
+    parts.push('Every school on the list admits without screening, testing or an audition.')
+  } else {
+    const named = buckets
+      .filter((b) => b.count > 0 && b.key !== 'open')
+      .map((b) => `${b.count} ${b.label.toLowerCase()}`)
+      .join(', ')
+    parts.push(`${named}, and ${open} open, Ed Opt or zoned.`)
+  }
+
+  if (ratioMissing > 0) {
+    parts.push(
+      ratioMissing === total
+        ? 'No school on the list has a published applicants-per-seat figure, so that column is empty rather than low.'
+        : `${ratioMissing} of ${total} have no published applicants-per-seat figure, so that column is incomplete.`
+    )
+  }
+
+  return parts.join(' ')
+}
+
+/**
+ * Everything the composition rail renders, from one pass over the saved schools.
+ * `buckets` drives both the proportion band and the legend.
+ */
+export function buildComposition(saved: ListSchool[]): Composition {
+  const total = saved.length
+
+  const counts = new Map<BucketKey, number>(BUCKET_ORDER.map((b) => [b.key, 0]))
+  for (const school of saved) {
+    const key = bucketForSchool(school)
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+  const buckets: CompositionBucket[] = BUCKET_ORDER.map((b) => ({
+    key: b.key,
+    label: b.label,
+    count: counts.get(b.key) ?? 0,
+  }))
+
+  const boroughCounts = new Map<string, number>()
+  for (const school of saved) {
+    const borough = school.borough?.trim()
+    if (!borough) continue
+    boroughCounts.set(borough, (boroughCounts.get(borough) ?? 0) + 1)
+  }
+  const byBorough = Array.from(boroughCounts, ([label, count]) => ({ label, count })).sort(
+    (a, b) => b.count - a.count || a.label.localeCompare(b.label)
+  )
+
+  const ratioCounts = new Map<string, number>([
+    ['Under 3', 0],
+    ['3 to 6', 0],
+    ['Over 6', 0],
+  ])
+  let ratioMissing = 0
+  for (const school of saved) {
+    const ratio = school.applicants_per_seat
+    // Absent means absent. Never coerce a missing figure to zero — a family
+    // reads "0" as a fact about the school rather than a gap in DOE data.
+    if (ratio == null || Number.isNaN(ratio)) {
+      ratioMissing += 1
+      continue
+    }
+    const band = ratioBand(ratio)
+    ratioCounts.set(band, (ratioCounts.get(band) ?? 0) + 1)
+  }
+  const byRatio = Array.from(ratioCounts, ([label, count]) => ({ label, count }))
+
+  return {
+    total,
+    buckets,
+    byBorough,
+    byRatio,
+    shapeSentence: buildShapeSentence(buckets, total, ratioMissing),
+    ratioMissing,
+  }
+}
+
+/**
+ * Saved DBNs resolved to schools, in the family's rank order. Unknown DBNs are
+ * dropped rather than rendered as blanks — a saved school that no longer exists
+ * in the dataset should disappear, not become an empty row.
+ */
+export function resolveSavedSchools<T extends { dbn: string }>(all: T[], savedDbns: string[]): T[] {
+  const byDbn = new Map(all.map((s) => [s.dbn, s]))
+  return savedDbns.map((dbn) => byDbn.get(dbn)).filter((s): s is T => Boolean(s))
+}
+
+/** Move an item one position up or down. Returns a new array; out-of-range is a no-op. */
+export function moveItem<T>(items: T[], index: number, direction: -1 | 1): T[] {
+  const target = index + direction
+  if (index < 0 || index >= items.length || target < 0 || target >= items.length) return items
+  const next = items.slice()
+  ;[next[index], next[target]] = [next[target], next[index]]
+  return next
+}


### PR DESCRIPTION
Closes #137. Launch-blocking: `Add to list` and its localStorage already shipped on /find, and the header showed a saved count — but there was no page to see the list.

Built from `design/saved-list.html` + `design/saved-list-handoff.html`.

**What's here**
- `app/my-schools/page.tsx` — server component. Ships a **slim index** (dbn, name, borough, neighborhood, tracks, ratio) rather than full school records, because the saved list lives in localStorage and the server can't know which schools are saved.
- `app/my-schools/MySchoolsClient.tsx` — ranking table with positional rank numerals, ↑/↓ reorder, remove, and the composition rail.
- `lib/saved-list-utils.ts` — the derivations.

**Design decisions carried over from the handoff**
- **Rank order is the product** — the array *is* the ranking, numerals are positional and recomputed, so a stale number can't render. Order persists under its own key so adding on /find never disturbs it.
- **Reorder is explicit ↑/↓, not drag** — long lists, phone/shared-machine audience, and a parent needs to move one place with certainty. Ends are disabled, not hidden.
- **Composition is counts, never a score.** Buckets are mutually exclusive and resolved most-selective-first (SHSAT → Audition → Screened → Open/Ed Opt/Zoned), so a school with `['Screened','Audition']` is counted once. Zero buckets are kept — seeing `0` is the point. The band weights and the legend read from **one array**, which is the specific bug the handoff warned about.
- **Missing applicants-per-seat renders `NOT REPORTED`**, never `0` or `—`, with the data-gap sentence that ends "a gap in the source data, not a low number."
- Empty state is one line and one link back to /find — the onboarding panel was designed and cut.

**Deviation to confirm:** the handoff names the fourth bucket "Open / Zoned". In the live data Educational Option is the largest category (272 schools) and isn't selectively screened, so it resolves into that bucket and the label reads **"Open / Ed Opt / Zoned"** — otherwise a family sees "Open / Zoned 5" for a set that is mostly Ed Opt. Flagging per CLAUDE.md rather than silently choosing.

**Also:** nav updated to `Find / My Schools / Checklist` on the school detail header (`Readiness` → `Checklist`, `/list` → `/my-schools`). /find's header is inline JSX in a large client component and is left for the retirement issue (#130).

**Not included** (out of scope, per the handoff's build order): drag handle, the match strip (needs /find criteria in the URL), and the selection-criteria chips.

**Tests:** 25 new — bucket priority, the sum-equals-total assertion, zero buckets kept, missing ratio never zeroed, shape sentence factual-not-advisory, reorder edge cases, plus a server/client boundary guard (the #132 failure class). Full suite **1052 passing across 33 suites**; build compiles `/my-schools` at 3.61 kB.