### PR TITLE
feat: issue #125 - production smoke tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,36 @@
+# Production smoke tests — issue #125.
+#
+# Deliberately NOT part of the required `test` check on pull requests: it makes
+# real network calls, so wiring it into PR gating would make CI flaky and block
+# unrelated work. It runs against the deployed site instead.
+name: smoke
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # A few times a day, so a deploy that quietly breaks production is caught
+    # without anyone looking at the site.
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+
+      # Vercel deploys from main independently of Actions, so on a push we wait
+      # for the new deployment to go live before testing it. Without this we'd
+      # smoke-test the previous build and learn nothing.
+      - name: Wait for the deploy to land
+        if: github.event_name == 'push'
+        run: sleep 150
+
+      - name: Smoke test production
+        run: npm run smoke

--- a/__tests__/smoke-helpers.test.ts
+++ b/__tests__/smoke-helpers.test.ts
@@ -1,0 +1,85 @@
+import {
+  MIN_SCHOOLS,
+  EMPTY_STATE_MARKER,
+  countSchoolLinks,
+  hasEmptyStateBanner,
+  judgeChatResponse,
+  judgeFindPage,
+} from '@/scripts/smoke'
+
+/**
+ * Issue #125. These cover the judgement logic only — no network. The runner
+ * itself is exercised by `npm run smoke` against a real deployment.
+ */
+
+describe('counting schools on a rendered page', () => {
+  it('counts distinct school links, not repeated ones', () => {
+    const html = '<a href="/school/13K430">a</a><a href="/school/13K430">a</a><a href="/school/02M475">b</a>'
+    expect(countSchoolLinks(html)).toBe(2)
+  })
+
+  it('returns zero when the page lists nothing', () => {
+    expect(countSchoolLinks('<html><body>No schools</body></html>')).toBe(0)
+  })
+})
+
+describe('the zero-schools incident', () => {
+  // Production once returned 200 with an empty list while every test was green.
+  const collapsed = `<html>${EMPTY_STATE_MARKER}</html>`
+
+  it('fails a 200 page that lists no schools', () => {
+    const results = judgeFindPage(200, collapsed)
+    const listed = results.find((r) => r.name === 'GET /find lists schools')!
+    expect(listed.ok).toBe(false)
+    expect(listed.detail).toMatch(/collapsed/)
+  })
+
+  it('fails a 200 page showing the empty-state banner', () => {
+    const results = judgeFindPage(200, collapsed)
+    expect(results.find((r) => r.name === 'GET /find has no empty-state banner')!.ok).toBe(false)
+  })
+
+  it('passes a healthy page', () => {
+    const links = Array.from({ length: MIN_SCHOOLS + 20 }, (_, i) => `<a href="/school/X${i}">s</a>`).join('')
+    expect(judgeFindPage(200, `<html>${links}</html>`).every((r) => r.ok)).toBe(true)
+  })
+
+  it('does not check content when the page itself failed', () => {
+    expect(judgeFindPage(500, '')).toHaveLength(1)
+  })
+})
+
+describe('chat health', () => {
+  it('treats a clean rate limit as healthy', () => {
+    expect(judgeChatResponse(429, 'slow down').ok).toBe(true)
+  })
+
+  it('treats any 5xx as unhealthy', () => {
+    expect(judgeChatResponse(500, 'boom').ok).toBe(false)
+    expect(judgeChatResponse(500, 'boom').detail).toMatch(/unhandled/)
+  })
+
+  it('distinguishes a gracefully handled upstream outage from a crash', () => {
+    // #128 shipped this copy; a 503 carrying it means the route behaved well
+    // even though the assistant is down. Still a failure, different remedy.
+    const r = judgeChatResponse(503, 'The assistant is unavailable right now. Please try again shortly.')
+    expect(r.ok).toBe(false)
+    expect(r.detail).toMatch(/handled gracefully/)
+  })
+
+  it('fails a 200 that leaked provider error text', () => {
+    // This actually reached a real visitor on 2026-07-30 (see #128).
+    const leaked = '400 {"error":{"message":"You have reached your specified API usage limits."}}'
+    const r = judgeChatResponse(200, leaked)
+    expect(r.ok).toBe(false)
+    expect(r.detail).toMatch(/leaked/)
+  })
+
+  it('fails a 200 with an empty body', () => {
+    expect(judgeChatResponse(200, '   ').ok).toBe(false)
+  })
+
+  it('passes a normal grounded answer', () => {
+    expect(judgeChatResponse(200, 'Brooklyn Tech offers a strong music program.').ok).toBe(true)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "test": "jest",
-    "refresh:data": "ts-node --compiler-options '{\"module\":\"commonjs\",\"moduleResolution\":\"node\"}' --transpile-only scripts/refresh-data.ts"
+    "refresh:data": "ts-node --compiler-options '{\"module\":\"commonjs\",\"moduleResolution\":\"node\"}' --transpile-only scripts/refresh-data.ts",
+    "smoke": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/smoke.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,0 +1,152 @@
+/**
+ * Production smoke tests — issue #125.
+ *
+ * Unit tests run against code. They cannot tell us the *deployed site* works.
+ * That is not hypothetical: production /list once served zero schools while the
+ * whole suite was green, because the failure was in the deployed environment,
+ * not the code. And on 2026-07-30 /school/[dbn] shipped a 500 on every school
+ * after passing tests and an independent review. Both were found by a human
+ * looking at the site.
+ *
+ * This checks outcomes on the real thing.
+ *
+ *   npm run smoke                      # against production
+ *   SMOKE_BASE_URL=https://… npm run smoke
+ *
+ * Exits non-zero on the first failure, naming which check failed and why.
+ */
+
+export const DEFAULT_BASE_URL = 'https://www.admitday.com'
+
+/**
+ * `/find` server-renders a capped first page (the design caps the initial
+ * render) and reveals the rest client-side, so this is not the full 457. What
+ * we're catching is a list that has *collapsed* — the zero-schools incident —
+ * not a page that paginates.
+ */
+export const MIN_SCHOOLS = 10
+
+/** Rendered when the DB read fails. Its presence means the page "works" but is empty. */
+export const EMPTY_STATE_MARKER = 'School data not yet loaded on the server'
+
+export type CheckResult = {
+  name: string
+  ok: boolean
+  detail: string
+}
+
+/**
+ * Counts school links on a rendered page. Deliberately structural rather than
+ * text-based: a page can render fine and still list nothing, which is exactly
+ * the zero-schools incident.
+ */
+export function countSchoolLinks(html: string): number {
+  const matches = html.match(/\/school\/[A-Za-z0-9]+/g)
+  if (!matches) return 0
+  return new Set(matches).size
+}
+
+export function hasEmptyStateBanner(html: string): boolean {
+  return html.includes(EMPTY_STATE_MARKER)
+}
+
+/** Chat is healthy if it answers or cleanly rate-limits. A 5xx is never healthy. */
+export function judgeChatResponse(status: number, body: string): CheckResult {
+  if (status === 429) {
+    return { name: 'POST /api/chat', ok: true, detail: '429 rate-limited (expected under load)' }
+  }
+  if (status >= 500) {
+    // A 503 carrying the product's own copy means the route handled an upstream
+    // outage correctly (#128). Still a failure — the assistant is down and we
+    // want to know — but the detail must not read like a crash, because the
+    // remedy is completely different.
+    const graceful = /assistant is unavailable|try again shortly/i.test(body)
+    return {
+      name: 'POST /api/chat',
+      ok: false,
+      detail: graceful
+        ? `HTTP ${status} — assistant unavailable, handled gracefully (upstream/provider is down, not a code fault)`
+        : `HTTP ${status} — unhandled server error`,
+    }
+  }
+  if (status !== 200) {
+    return { name: 'POST /api/chat', ok: false, detail: `HTTP ${status}` }
+  }
+  // A 200 that leaked provider error text is a failure even though it is a 200.
+  if (/usage limit|credit balance|quota|request_id|anthropic/i.test(body)) {
+    return { name: 'POST /api/chat', ok: false, detail: '200 but the body leaked provider error text' }
+  }
+  if (body.trim().length === 0) {
+    return { name: 'POST /api/chat', ok: false, detail: '200 with an empty body' }
+  }
+  return { name: 'POST /api/chat', ok: true, detail: `HTTP 200, ${body.length} bytes` }
+}
+
+export function judgeFindPage(status: number, html: string): CheckResult[] {
+  const results: CheckResult[] = []
+  results.push({
+    name: 'GET /find',
+    ok: status === 200,
+    detail: `HTTP ${status}`,
+  })
+  if (status !== 200) return results
+
+  const count = countSchoolLinks(html)
+  results.push({
+    name: 'GET /find lists schools',
+    ok: count >= MIN_SCHOOLS,
+    detail:
+      count >= MIN_SCHOOLS
+        ? `${count} schools linked`
+        : `only ${count} schools linked, expected at least ${MIN_SCHOOLS} — the list has collapsed`,
+  })
+  results.push({
+    name: 'GET /find has no empty-state banner',
+    ok: !hasEmptyStateBanner(html),
+    detail: hasEmptyStateBanner(html)
+      ? `page rendered but shows "${EMPTY_STATE_MARKER}"`
+      : 'no empty-state banner',
+  })
+  return results
+}
+
+/* c8 ignore start — the runner below performs network I/O and is not unit-tested. */
+
+async function run(): Promise<void> {
+  const base = (process.env.SMOKE_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, '')
+  const results: CheckResult[] = []
+  console.log(`Smoke testing ${base}\n`)
+
+  const home = await fetch(`${base}/`, { redirect: 'follow' })
+  results.push({ name: 'GET /', ok: home.status === 200, detail: `HTTP ${home.status}` })
+
+  const find = await fetch(`${base}/find`, { redirect: 'follow' })
+  results.push(...judgeFindPage(find.status, await find.text()))
+
+  const chat = await fetch(`${base}/api/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ question: 'Which Brooklyn schools have a strong music program?' }),
+  })
+  results.push(judgeChatResponse(chat.status, await chat.text()))
+
+  for (const r of results) {
+    console.log(`${r.ok ? '  ok  ' : '  FAIL'}  ${r.name.padEnd(38)} ${r.detail}`)
+  }
+
+  const failed = results.filter((r) => !r.ok)
+  if (failed.length > 0) {
+    console.error(`\n${failed.length} check(s) failed against ${base}.`)
+    process.exit(1)
+  }
+  console.log(`\nAll ${results.length} checks passed.`)
+}
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error('Smoke run could not complete:', err?.message ?? err)
+    process.exit(1)
+  })
+}
+
+/* c8 ignore stop */


### PR DESCRIPTION
Closes #125.

Unit tests run against code; they cannot tell us the deployed site works. That is not hypothetical — production `/list` once served zero schools while the whole suite was green, and on 2026-07-30 `/school/[dbn]` shipped a 500 on every school after passing tests *and* an independent review. Both were found by a human looking at the site.

**What it checks, against the real deployment**
- `GET /` returns 200.
- `GET /find` returns 200, **links schools** (structural, not text-based), and does **not** show the `School data not yet loaded on the server` banner — the exact zero-schools signature.
- `POST /api/chat` answers, or cleanly rate-limits. A 5xx fails, and a 200 that leaks provider error text (`usage limit`, `credit balance`, `request_id`, `anthropic`) also fails — a 200 is not automatically healthy.

**Two things learned by running it against production before shipping it**
1. `/find` server-renders a **capped** first page, so an initial `MIN_SCHOOLS = 400` assertion was wrong. It's now 10 — this catches a list that has *collapsed*, not one that paginates.
2. A gracefully-handled upstream outage is reported differently from a crash. A 503 carrying the product's own copy (shipped by #128) means the route behaved correctly and the provider is down — still a failure, but the remedy is completely different, so the message says so.

**Right now it reports 4 passing and 1 failing against production**: the assistant is genuinely unavailable because the Anthropic credit balance is exhausted. That is a true finding, not a false positive.

**Wiring:** `npm run smoke`, overridable with `SMOKE_BASE_URL`. The workflow runs on push to main (after a wait for Vercel to deploy — otherwise it would test the previous build), every 6 hours, and manually. **Deliberately not part of the required `test` check** — it makes real network calls and would make PR gating flaky.

**Tests:** 12 new, covering the judgement logic with no network — including regression cases for both real incidents. Full suite 1064 passing across 34 suites.