### PR TITLE
feat: build the landing page at /

### DIFF
--- a/__tests__/landing.test.ts
+++ b/__tests__/landing.test.ts
@@ -1,0 +1,75 @@
+import fs from 'fs'
+import path from 'path'
+import { buildLandscape, landscapeIsPublishable, roundDownTo } from '@/lib/landscape'
+import type { School } from '@/types'
+
+const pageSrc = fs.readFileSync(path.join(__dirname, '../app/page.tsx'), 'utf-8')
+/** JSX wraps copy across lines, so assertions about sentences read this. */
+const pageCopy = pageSrc.replace(/\s+/g, ' ')
+
+function s(over: Partial<School> & { dbn: string }): School {
+  return {
+    name: 'S', borough: 'Brooklyn', size: 'Medium', total_students: 1,
+    applicants_per_seat: 1, academic_score_pct: 1, survey_score_pct: 1,
+    admissions_types: ['Open'], programs: [{} as never], flags: {} as School['flags'],
+    doe_data: {} as School['doe_data'], sift_url: '', last_verified: '', ...over,
+  } as School
+}
+
+describe('landscape numbers are derived, never claimed', () => {
+  it('rounds down so the claim stays true as the data shifts', () => {
+    expect(roundDownTo(780, 100)).toBe(700)
+    expect(roundDownTo(457, 100)).toBe(400)
+    expect(roundDownTo(0, 100)).toBe(0)
+  })
+
+  it('counts programs, schools and distinct admissions methods from the data', () => {
+    const l = buildLandscape([
+      s({ dbn: 'A', admissions_types: ['Screened'], programs: [{}, {}] as never }),
+      s({ dbn: 'B', admissions_types: ['Screened', 'Audition'], programs: [{}] as never }),
+    ])
+    expect(l.schools).toBe(2)
+    expect(l.programs).toBe(3)
+    expect(l.methods).toBe(2) // Screened, Audition — deduped
+  })
+
+  it('refuses to publish a landscape it cannot back', () => {
+    // getAllSchools() returns [] on a DB error by design; the page must not
+    // then advertise "0+ programs".
+    expect(landscapeIsPublishable(buildLandscape([]))).toBe(false)
+  })
+})
+
+describe('the landing page keeps the product’s promises', () => {
+  it('states the refusal to predict', () => {
+    expect(pageSrc).toMatch(/No chance of admission/i)
+    expect(pageSrc).toMatch(/No reach, target or likely/i)
+  })
+
+  it('uses no odds or rating language of its own', () => {
+    const copy = pageSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+    expect(copy).not.toMatch(/your odds|chance of getting|we predict|guarantee/i)
+  })
+
+  it('carries the mandatory non-affiliation line', () => {
+    expect(pageCopy).toMatch(/not affiliated with, or endorsed by, the New York City Department of Education/i)
+  })
+
+  it('admits the data can be older than the current cycle', () => {
+    expect(pageSrc).toMatch(/older than the current cycle/i)
+  })
+
+  it('invents no social proof', () => {
+    expect(pageSrc).not.toMatch(/trusted by|\d+[,\d]* (families|parents|users) (use|trust)|testimonial/i)
+  })
+
+  it('has exactly one destination, used twice', () => {
+    const links = Array.from(pageSrc.matchAll(/href="\/(find|my-schools)"/g)).map((m) => m[1])
+    expect(links.filter((l) => l === 'find').length).toBeGreaterThanOrEqual(2)
+    expect(pageSrc).not.toMatch(/href="\/(pricing|about|faq|signup|login)"/)
+  })
+
+  it('is a server component so the numbers render without JS', () => {
+    expect(pageSrc).not.toMatch(/^['"]use client['"]/m)
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,239 @@
-import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import Footer from '@/components/Footer'
+import { getAllSchools } from '@/lib/load-schools'
+import { buildLandscape, landscapeIsPublishable } from '@/lib/landscape'
+import { Eyebrow, DefinitionRow } from '@/components/ui'
 
 /**
- * Issue #130. The old filter flow (/ → /list → /requirements) and the standalone
- * /chat were retired in favour of the unified /find surface plus /school/[dbn].
+ * The landing page — the front door for a parent who has never heard of
+ * AdmitDay, arriving from a Facebook group, a Reddit thread, or another parent.
+ * Replaces the redirect that stood here after the old filter flow was retired
+ * in #130.
  *
- * A redirect rather than moving the route: the landing page is designed and will
- * own / soon, so this keeps that swap to a single file instead of relocating the
- * find surface twice.
+ * Written for the overwhelmed first-timer rather than the spreadsheet-building
+ * researcher: it explains the process before it explains the product, and every
+ * piece of vocabulary carries its meaning. One job — get them into /find with
+ * enough trust to try it.
+ *
+ * Deliberately absent: pricing, a feature list, an FAQ, newsletter capture, a
+ * second destination, and any social proof. There are no users yet, so the only
+ * honest trust signals are checkable properties of the product itself — which is
+ * why the trust section is made of claims you can verify on the very next
+ * screen, and why the refusal to predict gets its own block.
+ *
+ * The landscape numbers are derived from the school table (lib/landscape.ts),
+ * never typed here.
  */
-export default function Home() {
-  redirect('/find')
+
+function Cta({ className = '' }: { className?: string }) {
+  return (
+    <Link
+      href="/find"
+      className={`inline-block bg-accent text-white text-[15px] font-medium px-[26px] py-[13px] hover:opacity-90 transition-opacity duration-[120ms] ease-out ${className}`}
+    >
+      Start with your schools
+    </Link>
+  )
+}
+
+export default async function Landing() {
+  const schools = await getAllSchools()
+  const landscape = buildLandscape(schools)
+  // If the data layer degrades, render the page without the numbers rather than
+  // printing zeros — the same rule the rest of the product follows.
+  const showNumbers = landscapeIsPublishable(landscape)
+
+  return (
+    <main className="min-h-screen bg-white">
+      {/* No active nav item: / isn't one of the app's sections. */}
+      <header className="flex items-center justify-between px-5 min-[900px]:px-9 py-[18px] border-b border-rule">
+        <div className="flex items-center gap-[9px]">
+          <span className="w-[9px] h-[9px] bg-accent inline-block" />
+          <div className="flex items-baseline">
+            <span className="font-display font-bold text-[21px] text-ink tracking-[-0.035em]">Admit</span>
+            <span className="font-wordmark italic text-[24px] text-accent ml-[3px] tracking-[-0.01em]">Day</span>
+          </div>
+        </div>
+        <nav className="flex items-center gap-7 text-[14.5px] text-muted">
+          <Link href="/find" className="hover:text-ink transition-colors duration-[120ms] ease-out">Find</Link>
+          <Link href="/my-schools" className="hover:text-ink transition-colors duration-[120ms] ease-out">My Schools</Link>
+        </nav>
+      </header>
+
+      <section className="grid grid-cols-1 min-[900px]:grid-cols-[1fr_300px] gap-6 min-[900px]:gap-10 items-end px-5 min-[900px]:px-9 pt-11 pb-[34px] border-b border-rule">
+        <div>
+          <h1 className="font-display font-bold text-[34px] min-[700px]:text-[44px] leading-[1.02] tracking-[-0.038em] text-ink max-w-[700px]">
+            Every NYC high school, in one list you can actually use.
+          </h1>
+          <p className="text-[15.5px] text-muted mt-4 max-w-[560px]">
+            Set what matters — borough, size, how a school admits — or just describe what
+            you&rsquo;re looking for. You get a ranked shortlist with what each school actually
+            requires, built from the DOE&rsquo;s own directory.
+          </p>
+        </div>
+        <div>
+          <Cta />
+          <p className="text-[13px] text-faint mt-[10px]">Free. No account, no email.</p>
+        </div>
+      </section>
+
+      <section className="px-5 min-[900px]:px-9 pt-[26px] pb-[30px] border-b border-rule">
+        <Eyebrow>What you&rsquo;re actually up against</Eyebrow>
+        {showNumbers && (
+          <div className="grid grid-cols-2 min-[700px]:grid-cols-4 gap-[1px] bg-rule border border-rule mt-3">
+            {[
+              { v: landscape.programsLabel, l: 'Programs' },
+              { v: landscape.schoolsLabel, l: 'Schools' },
+              { v: String(landscape.methods), l: 'Ways they admit' },
+            ].map((c) => (
+              <div key={c.l} className="bg-surface px-[18px] py-4">
+                <div className="font-mono text-[24px] font-medium tracking-[-0.02em] text-ink">{c.v}</div>
+                <div className="text-[10.5px] uppercase tracking-[0.06em] text-faint mt-1">{c.l}</div>
+              </div>
+            ))}
+            <div className="bg-surface-2 px-[18px] py-4">
+              <p className="text-[12.5px] text-faint leading-[1.5]">
+                Counted from the DOE directory we build on. Not an estimate.
+              </p>
+            </div>
+          </div>
+        )}
+        <div className="grid grid-cols-1 min-[700px]:grid-cols-2 gap-7 mt-6 text-[14.5px] text-ink-2 leading-[1.55]">
+          <p>
+            A single school can admit several different ways at once — one program screens on
+            grades, another holds an audition, a third takes anyone who applies. Two programs at the
+            same address can have completely different requirements.
+          </p>
+          <p>
+            None of this is secret. It&rsquo;s just scattered across PDFs, a portal, and parent
+            Facebook threads — which means the families with the most time and the best contacts end
+            up with the best lists.
+          </p>
+        </div>
+      </section>
+
+      <section className="px-5 min-[900px]:px-9 pt-[26px] pb-[30px] border-b border-rule">
+        <Eyebrow>How it works</Eyebrow>
+        <div className="mt-3">
+          {[
+            {
+              n: '01',
+              t: 'Set your guardrails',
+              b: 'Borough, school size, how a school admits. These are hard filters — a school that doesn’t match is left out, so the list stays yours.',
+            },
+            {
+              n: '02',
+              t: 'Say the rest in your own words',
+              b: 'A strong music program, soccer, small classes. What you type never removes a school — it moves the ones that fit up the list.',
+            },
+            {
+              n: '03',
+              t: 'Open a school and see the real thing',
+              b: 'Programs, what applying actually requires, sports and courses, how many applied per seat — each with a link to the official listing.',
+            },
+          ].map((s, i, arr) => (
+            <div
+              key={s.n}
+              className={`grid grid-cols-[34px_1fr] min-[900px]:grid-cols-[34px_300px_1fr] gap-4 py-4 ${
+                i < arr.length - 1 ? 'border-b border-rule-light' : ''
+              }`}
+            >
+              <span className="font-mono text-[13px] text-[#B8B8B4] pt-1">{s.n}</span>
+              <h3 className="text-[18px] font-bold text-ink">{s.t}</h3>
+              <p className="text-[14.5px] text-ink-2 max-w-[560px] col-start-2 min-[900px]:col-start-3">
+                {s.b}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 min-[900px]:grid-cols-[1fr_316px]">
+        <div className="px-5 min-[900px]:px-9 pt-[26px] pb-7 min-[900px]:border-r border-rule">
+          <Eyebrow>Why you can check us</Eyebrow>
+          <div className="mt-3">
+            <div className="border-b border-rule-light py-4">
+              <DefinitionRow label="Every number" value="Is a figure the DOE published. We don’t compute our own." />
+            </div>
+            <div className="border-b border-rule-light py-4">
+              <DefinitionRow
+                label="Every requirement"
+                value="Links out to the official listing, so you can confirm it before you apply."
+              />
+            </div>
+            <div className="py-4">
+              <DefinitionRow
+                label="Missing data"
+                value="Is said in words, never shown as a zero or a dash. A gap in the source is not a low score."
+              />
+            </div>
+          </div>
+
+          <div className="bg-surface-2 border border-rule px-5 py-[18px] mt-5">
+            <Eyebrow>And what it will never do</Eyebrow>
+            <p className="text-[15px] font-semibold text-ink mt-2">{'No chance of admission. No reach, target or likely. No score or rating of any kind.'}</p>
+            <p className="text-[14.5px] text-muted mt-2 leading-[1.55]">
+              Other tools will give you a number. We won&rsquo;t, because the inputs aren&rsquo;t
+              public — and a confident-looking estimate is how families talk themselves out of
+              applying somewhere they should have ranked.
+            </p>
+          </div>
+        </div>
+
+        <aside className="px-5 min-[900px]:px-7 py-[26px] border-t min-[900px]:border-t-0 border-rule">
+          <Eyebrow>Where the data comes from</Eyebrow>
+          <div className="mt-2 flex flex-col gap-[10px]">
+            <DefinitionRow labelWidth={92} label="Source" value="NYC DOE school directory" />
+            <DefinitionRow labelWidth={92} label="Also" value="NYC-SIFT, for school-level statistics" />
+          </div>
+          <p className="text-[13px] text-faint mt-4 pt-4 border-t border-rule-light leading-[1.5]">
+            Some DOE figures are older than the current cycle. Those are labelled with their own date
+            wherever they appear.
+          </p>
+
+          <div className="mt-6 pt-6 border-t border-rule">
+            <Eyebrow>Who made this</Eyebrow>
+            <p className="text-[14.5px] text-ink-2 leading-[1.6] mt-2">
+              I went through this with my own kid. I read the PDFs, kept the spreadsheet, and still
+              missed things — not because the information was hidden, but because it was everywhere.
+            </p>
+            <p className="text-[14.5px] text-ink-2 leading-[1.6] mt-3">
+              So I built the tool I wanted: one list, real requirements, and a link to the source for
+              every claim.
+            </p>
+            <p className="text-[13px] text-faint mt-3">— A public school parent in Brooklyn</p>
+          </div>
+        </aside>
+      </section>
+
+      <section className="grid grid-cols-1 min-[900px]:grid-cols-[1fr_300px] gap-6 items-end px-5 min-[900px]:px-9 pt-[30px] pb-8 border-t border-rule">
+        <div>
+          <p className="font-display font-bold text-[26px] tracking-[-0.03em] text-ink">
+            You don&rsquo;t have to know the vocabulary to start.
+          </p>
+          <p className="text-[14.5px] text-muted mt-2 max-w-[560px]">
+            Pick a borough. Everything else can come later, and nothing you do here is final.
+          </p>
+        </div>
+        <div>
+          <Cta />
+          <p className="text-[13px] text-faint mt-[10px]">
+            Free while it&rsquo;s being built. More is coming.
+          </p>
+        </div>
+      </section>
+
+      <div className="flex flex-col min-[900px]:flex-row justify-between gap-1 px-5 min-[900px]:px-9 py-4 bg-surface-2 border-t border-rule">
+        <span className="text-[13px] text-faint">
+          Independent and not affiliated with, or endorsed by, the New York City Department of
+          Education.
+        </span>
+        <span className="text-[13px] text-faint">
+          Confirm every program on the official listing before you apply.
+        </span>
+      </div>
+
+      <Footer />
+    </main>
+  )
 }

--- a/lib/banned-phrases.ts
+++ b/lib/banned-phrases.ts
@@ -29,8 +29,17 @@ export const BANNED_ADMISSIONS_ODDS_PHRASES: string[] = [
 
 // Exact, lowercase substrings that are explicitly permitted even though they
 // contain a banned phrase above (e.g. copy that explicitly disclaims doing
-// odds prediction). Empty today.
-export const ADMISSIONS_ODDS_ALLOWLIST: string[] = []
+// odds prediction).
+//
+// Reviewed exemptions only. Each entry must be copy that *refuses* to predict —
+// never copy that predicts. Adding a phrase here is a deliberate decision; if a
+// new string nearly matches an entry, write the copy to match the entry rather
+// than adding a near-duplicate.
+export const ADMISSIONS_ODDS_ALLOWLIST: string[] = [
+  // Landing page (app/page.tsx), "And what it will never do" — the product's
+  // refusal to predict, which necessarily names what it won't produce.
+  'no chance of admission. no reach, target or likely. no score or rating of any kind.',
+]
 
 /**
  * Returns every banned phrase found in `text` (case-insensitive), after

--- a/lib/landscape.ts
+++ b/lib/landscape.ts
@@ -1,0 +1,60 @@
+import type { School } from '@/types'
+
+/**
+ * The three landscape numbers on the landing page, derived from the real school
+ * table rather than typed into the markup.
+ *
+ * The design handoff is explicit about why: "a landing page that claims 700+
+ * programs while the database holds 300 is the exact failure this product cannot
+ * afford." The whole pitch is that our numbers are checkable, so the first
+ * numbers a visitor ever sees must be as honest as the ones on a school page.
+ *
+ * Rounded down to a "+" figure so the copy stays stable between data refreshes —
+ * a landing page that changes from 781 to 779 on a re-scrape is noise, but one
+ * that says 700+ when the table holds 300 is a lie. `roundDownTo` gives the
+ * first and prevents the second.
+ */
+
+export type Landscape = {
+  programs: number
+  schools: number
+  methods: number
+  programsLabel: string
+  schoolsLabel: string
+}
+
+/** 780 -> 700, 457 -> 400. Never rounds up: the claim stays true as data shifts. */
+export function roundDownTo(value: number, step: number): number {
+  if (value <= 0) return 0
+  return Math.floor(value / step) * step
+}
+
+export function buildLandscape(schools: School[]): Landscape {
+  const schoolCount = schools.length
+  const programCount = schools.reduce((n, s) => n + (s.programs?.length ?? 0), 0)
+
+  const methods = new Set<string>()
+  for (const s of schools) {
+    for (const t of s.admissions_types ?? []) {
+      const trimmed = t.trim()
+      if (trimmed) methods.add(trimmed)
+    }
+  }
+
+  return {
+    programs: programCount,
+    schools: schoolCount,
+    methods: methods.size,
+    programsLabel: `${roundDownTo(programCount, 100)}+`,
+    schoolsLabel: `${roundDownTo(schoolCount, 100)}+`,
+  }
+}
+
+/**
+ * The landing page must never advertise a landscape it can't back. If the data
+ * layer degrades (the loader returns [] on a DB error by design), we render the
+ * page without the numbers rather than printing zeros at a family.
+ */
+export function landscapeIsPublishable(l: Landscape): boolean {
+  return l.schools > 0 && l.programs > 0 && l.methods > 0
+}


### PR DESCRIPTION
Replaces the redirect that stood at `/` after #130 retired the old filter flow. Built from `design/landing.html` + `design/landing-handoff.html`.

**Written for the overwhelmed first-timer** — a parent with no local network who doesn't yet know that "screened" and "Ed Opt" are different things. It explains the process before the product, and every piece of vocabulary carries its meaning.

**Landscape numbers are derived, not claimed.** `lib/landscape.ts` counts programs, schools and distinct admissions methods from the real school table and rounds *down* to a "+" figure, so the claim stays true between refreshes. Current data gives 780 programs / 457 schools / 7 methods → "700+ / 400+ / 7". The handoff assumed 5 methods; the data has 7 because SHSAT and "Screened with Assessment" are separate values, so the derived number is used. If `getAllSchools()` degrades to `[]`, the numbers are **omitted** rather than rendered as zeros.

**Deliberately absent:** pricing, feature list, FAQ, newsletter capture, a second destination, and any social proof. With no users, no press and no testimonials, the only honest trust signals are checkable properties of the product — so the trust section is claims you can verify on the very next screen, and the freshness caveat admits DOE figures can be older than the current cycle (matching #138).

**One guardrail note:** the refusal block trips #127's odds-language scan, because refusing to predict requires naming what we won't produce. Per that issue's own instruction, this is handled with an **explicit entry in `ADMISSIONS_ODDS_ALLOWLIST`** — the pattern was not loosened. I added a comment stating the rule for future entries: only copy that *refuses* to predict qualifies.

**Not included** (handoff build order defers them): the returning-visitor variant `7b`, the sample product fragment, and OG/meta. `7a` is static with no client data dependency, which is why it ships first.

**Tests:** 10 new — derived-number correctness, the refuse-to-publish-zeros rule, the stated refusal, no invented social proof, one destination, and server-rendered so numbers work without JS. Suite: 766 passing across 33 suites.