### PR TITLE
fix: issue #149 - smoke tests warn on a handled provider outage

### DIFF
--- a/__tests__/smoke-helpers.test.ts
+++ b/__tests__/smoke-helpers.test.ts
@@ -1,4 +1,5 @@
 import {
+  exitCodeFor,
   MIN_SCHOOLS,
   EMPTY_STATE_MARKER,
   countSchoolLinks,
@@ -30,18 +31,18 @@ describe('the zero-schools incident', () => {
   it('fails a 200 page that lists no schools', () => {
     const results = judgeFindPage(200, collapsed)
     const listed = results.find((r) => r.name === 'GET /find lists schools')!
-    expect(listed.ok).toBe(false)
+    expect(listed.severity).not.toBe('ok')
     expect(listed.detail).toMatch(/collapsed/)
   })
 
   it('fails a 200 page showing the empty-state banner', () => {
     const results = judgeFindPage(200, collapsed)
-    expect(results.find((r) => r.name === 'GET /find has no empty-state banner')!.ok).toBe(false)
+    expect(results.find((r) => r.name === 'GET /find has no empty-state banner')!.severity).not.toBe('ok')
   })
 
   it('passes a healthy page', () => {
     const links = Array.from({ length: MIN_SCHOOLS + 20 }, (_, i) => `<a href="/school/X${i}">s</a>`).join('')
-    expect(judgeFindPage(200, `<html>${links}</html>`).every((r) => r.ok)).toBe(true)
+    expect(judgeFindPage(200, `<html>${links}</html>`).every((r) => r.severity === 'ok')).toBe(true)
   })
 
   it('does not check content when the page itself failed', () => {
@@ -51,19 +52,19 @@ describe('the zero-schools incident', () => {
 
 describe('chat health', () => {
   it('treats a clean rate limit as healthy', () => {
-    expect(judgeChatResponse(429, 'slow down').ok).toBe(true)
+    expect(judgeChatResponse(429, 'slow down').severity).toBe('ok')
   })
 
   it('treats any 5xx as unhealthy', () => {
-    expect(judgeChatResponse(500, 'boom').ok).toBe(false)
+    expect(judgeChatResponse(500, 'boom').severity).not.toBe('ok')
     expect(judgeChatResponse(500, 'boom').detail).toMatch(/unhandled/)
   })
 
-  it('distinguishes a gracefully handled upstream outage from a crash', () => {
+  it('warns rather than fails on a gracefully handled upstream outage', () => {
     // #128 shipped this copy; a 503 carrying it means the route behaved well
     // even though the assistant is down. Still a failure, different remedy.
     const r = judgeChatResponse(503, 'The assistant is unavailable right now. Please try again shortly.')
-    expect(r.ok).toBe(false)
+    expect(r.severity).not.toBe('ok')
     expect(r.detail).toMatch(/handled gracefully/)
   })
 
@@ -71,15 +72,49 @@ describe('chat health', () => {
     // This actually reached a real visitor on 2026-07-30 (see #128).
     const leaked = '400 {"error":{"message":"You have reached your specified API usage limits."}}'
     const r = judgeChatResponse(200, leaked)
-    expect(r.ok).toBe(false)
+    expect(r.severity).not.toBe('ok')
     expect(r.detail).toMatch(/leaked/)
   })
 
   it('fails a 200 with an empty body', () => {
-    expect(judgeChatResponse(200, '   ').ok).toBe(false)
+    expect(judgeChatResponse(200, '   ').severity).not.toBe('ok')
   })
 
   it('passes a normal grounded answer', () => {
-    expect(judgeChatResponse(200, 'Brooklyn Tech offers a strong music program.').ok).toBe(true)
+    expect(judgeChatResponse(200, 'Brooklyn Tech offers a strong music program.').severity).toBe('ok')
+  })
+})
+
+
+describe('exit status — issue #149', () => {
+  // The distinction that matters: "we broke the deploy" vs "the provider is down".
+  it('exits zero when the only problem is a handled provider outage', () => {
+    const results = [
+      { name: 'GET /', severity: 'ok' as const, detail: '' },
+      judgeChatResponse(503, 'The assistant is unavailable right now. Please try again shortly.'),
+    ]
+    expect(results[1].severity).toBe('warn')
+    expect(exitCodeFor(results)).toBe(0)
+  })
+
+  it('exits non-zero on an unhandled server error', () => {
+    expect(exitCodeFor([judgeChatResponse(500, 'boom')])).toBe(1)
+  })
+
+  it('exits non-zero when the school list has collapsed', () => {
+    expect(exitCodeFor(judgeFindPage(200, '<html>nothing</html>'))).toBe(1)
+  })
+
+  it('exits non-zero when a 200 leaked provider error text', () => {
+    expect(exitCodeFor([judgeChatResponse(200, 'You have reached your specified API usage limits')])).toBe(1)
+  })
+
+  it('a failure still exits non-zero even alongside warnings', () => {
+    expect(
+      exitCodeFor([
+        judgeChatResponse(503, 'The assistant is unavailable right now.'),
+        { name: 'GET /', severity: 'fail' as const, detail: 'HTTP 500' },
+      ])
+    ).toBe(1)
   })
 })

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -29,10 +29,28 @@ export const MIN_SCHOOLS = 10
 /** Rendered when the DB read fails. Its presence means the page "works" but is empty. */
 export const EMPTY_STATE_MARKER = 'School data not yet loaded on the server'
 
+/**
+ * Issue #149. Three levels, not a boolean, because two different things were
+ * being conflated:
+ *
+ *   fail — a deploy regression. Someone must change code. Exits non-zero.
+ *   warn — an external condition no code change would fix (the provider is down
+ *          or out of credit, and the route handled it correctly). Visible, but
+ *          the run stays green: a recurring alert for a known billing state is
+ *          the alert noise this project keeps removing.
+ *   ok   — healthy.
+ */
+export type Severity = 'ok' | 'warn' | 'fail'
+
 export type CheckResult = {
   name: string
-  ok: boolean
+  severity: Severity
   detail: string
+}
+
+/** The run fails only on `fail`. Warnings are reported, not escalated. */
+export function exitCodeFor(results: CheckResult[]): number {
+  return results.some((r) => r.severity === 'fail') ? 1 : 0
 }
 
 /**
@@ -53,7 +71,7 @@ export function hasEmptyStateBanner(html: string): boolean {
 /** Chat is healthy if it answers or cleanly rate-limits. A 5xx is never healthy. */
 export function judgeChatResponse(status: number, body: string): CheckResult {
   if (status === 429) {
-    return { name: 'POST /api/chat', ok: true, detail: '429 rate-limited (expected under load)' }
+    return { name: 'POST /api/chat', severity: 'ok', detail: '429 rate-limited (expected under load)' }
   }
   if (status >= 500) {
     // A 503 carrying the product's own copy means the route handled an upstream
@@ -63,30 +81,32 @@ export function judgeChatResponse(status: number, body: string): CheckResult {
     const graceful = /assistant is unavailable|try again shortly/i.test(body)
     return {
       name: 'POST /api/chat',
-      ok: false,
+      // Handled outage: the route did its job, the provider is down. Warn.
+      // Unhandled 5xx: that is ours to fix. Fail.
+      severity: graceful ? 'warn' : 'fail',
       detail: graceful
         ? `HTTP ${status} — assistant unavailable, handled gracefully (upstream/provider is down, not a code fault)`
         : `HTTP ${status} — unhandled server error`,
     }
   }
   if (status !== 200) {
-    return { name: 'POST /api/chat', ok: false, detail: `HTTP ${status}` }
+    return { name: 'POST /api/chat', severity: 'fail', detail: `HTTP ${status}` }
   }
   // A 200 that leaked provider error text is a failure even though it is a 200.
   if (/usage limit|credit balance|quota|request_id|anthropic/i.test(body)) {
-    return { name: 'POST /api/chat', ok: false, detail: '200 but the body leaked provider error text' }
+    return { name: 'POST /api/chat', severity: 'fail', detail: '200 but the body leaked provider error text' }
   }
   if (body.trim().length === 0) {
-    return { name: 'POST /api/chat', ok: false, detail: '200 with an empty body' }
+    return { name: 'POST /api/chat', severity: 'fail', detail: '200 with an empty body' }
   }
-  return { name: 'POST /api/chat', ok: true, detail: `HTTP 200, ${body.length} bytes` }
+  return { name: 'POST /api/chat', severity: 'ok', detail: `HTTP 200, ${body.length} bytes` }
 }
 
 export function judgeFindPage(status: number, html: string): CheckResult[] {
   const results: CheckResult[] = []
   results.push({
     name: 'GET /find',
-    ok: status === 200,
+    severity: status === 200 ? 'ok' : 'fail',
     detail: `HTTP ${status}`,
   })
   if (status !== 200) return results
@@ -94,7 +114,7 @@ export function judgeFindPage(status: number, html: string): CheckResult[] {
   const count = countSchoolLinks(html)
   results.push({
     name: 'GET /find lists schools',
-    ok: count >= MIN_SCHOOLS,
+    severity: count >= MIN_SCHOOLS ? 'ok' : 'fail',
     detail:
       count >= MIN_SCHOOLS
         ? `${count} schools linked`
@@ -102,7 +122,7 @@ export function judgeFindPage(status: number, html: string): CheckResult[] {
   })
   results.push({
     name: 'GET /find has no empty-state banner',
-    ok: !hasEmptyStateBanner(html),
+    severity: hasEmptyStateBanner(html) ? 'fail' : 'ok',
     detail: hasEmptyStateBanner(html)
       ? `page rendered but shows "${EMPTY_STATE_MARKER}"`
       : 'no empty-state banner',
@@ -118,7 +138,11 @@ async function run(): Promise<void> {
   console.log(`Smoke testing ${base}\n`)
 
   const home = await fetch(`${base}/`, { redirect: 'follow' })
-  results.push({ name: 'GET /', ok: home.status === 200, detail: `HTTP ${home.status}` })
+  results.push({
+    name: 'GET /',
+    severity: home.status === 200 ? 'ok' : 'fail',
+    detail: `HTTP ${home.status}`,
+  })
 
   const find = await fetch(`${base}/find`, { redirect: 'follow' })
   results.push(...judgeFindPage(find.status, await find.text()))
@@ -130,16 +154,24 @@ async function run(): Promise<void> {
   })
   results.push(judgeChatResponse(chat.status, await chat.text()))
 
+  const LABEL: Record<Severity, string> = { ok: '  ok  ', warn: '  WARN', fail: '  FAIL' }
   for (const r of results) {
-    console.log(`${r.ok ? '  ok  ' : '  FAIL'}  ${r.name.padEnd(38)} ${r.detail}`)
+    console.log(`${LABEL[r.severity]}  ${r.name.padEnd(38)} ${r.detail}`)
   }
 
-  const failed = results.filter((r) => !r.ok)
+  const failed = results.filter((r) => r.severity === 'fail')
+  const warned = results.filter((r) => r.severity === 'warn')
+
+  // A run with warnings must not read like a clean run.
   if (failed.length > 0) {
-    console.error(`\n${failed.length} check(s) failed against ${base}.`)
-    process.exit(1)
+    console.error(`\n${failed.length} check(s) FAILED against ${base}.`)
+    if (warned.length > 0) console.error(`${warned.length} warning(s) alongside.`)
+  } else if (warned.length > 0) {
+    console.log(`\nPassed with ${warned.length} warning(s) against ${base} — degraded, not broken.`)
+  } else {
+    console.log(`\nAll ${results.length} checks passed.`)
   }
-  console.log(`\nAll ${results.length} checks passed.`)
+  process.exit(exitCodeFor(results))
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Closes #149.

The smoke workflow hard-failed on any 5xx from `/api/chat`. That conflated two things with completely different remedies, and in practice meant an email every 6 hours about the Anthropic credit balance — the exact alert noise this project keeps removing.

`CheckResult.ok: boolean` becomes `severity: 'ok' | 'warn' | 'fail'`:

- **fail** — a deploy regression someone must fix in code: site down, list collapsed, empty-state banner, an **unhandled** 5xx, or a 200 leaking provider error text. Exits non-zero.
- **warn** — an external condition no code change would fix: a 5xx carrying the product's own graceful copy, meaning the route behaved correctly (#128) and the provider is down or out of credit. Visible, run stays green.
- **ok** — healthy.

`exitCodeFor()` makes the decision in one place, and the summary distinguishes the cases so a run with warnings never reads like a clean run: *"Passed with 1 warning(s) — degraded, not broken."*

**Verified against production right now** — 4 ok, 1 warn, exit code 0:

```
ok    GET /                                  HTTP 200
ok    GET /find lists schools                15 schools linked
WARN  POST /api/chat                         HTTP 503 — assistant unavailable, handled gracefully
Passed with 1 warning(s) — degraded, not broken.
```

**Tests:** 5 new covering the exit-status decision specifically — handled outage exits 0; unhandled 500, collapsed list, and leaked provider text each exit 1; and a failure alongside a warning still exits 1. Suite: 771 passing across 33 suites.