### PR TITLE
Package AdmitDay as portfolio project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AdmitDay Agent Instructions
+
+These are the shared rules for any coding agent working in this repo: Claude Code, Codex, open-weight model runners, or future orchestrator workers. Agent-specific adapters should load this file rather than duplicating rules.
+
+## Core Rules
+
+- **Never modify `data/schools.json`.** It is curated source data.
+- Filtering logic lives in `lib/school-list-utils.ts` — look there first for anything about school list filtering.
+- Tests live in `__tests__/`. **Add** new test files or cases; never overwrite or delete existing tests.
+- Run `npm test` and `npm run build` before considering any change done; both must exit 0.
+- After broad exploration, write a compact task brief and start a fresh implementation session instead of carrying the full exploratory context forward.
+- Before implementation, state success criteria cold: expected behavior, files likely involved, verification commands, and reviewer risks.
+- The app deploys to Vercel automatically from `main`. Do not add local deploy or pm2 steps.
+- The product name in UI copy is **"AdmitDay"**.
+- If a change alters user-facing behavior, the data model, or the architecture, update `README.md` in the same PR so the README never drifts from reality.
+- Never push, never merge, never switch branches unless the active orchestrator or human operator explicitly assigns that responsibility.
+- `LESSONS.md` is coordinator-owned runtime state — read it for context, but never commit it.
+- Stay strictly within the scope of the issue you were given; an independent reviewer rejects scope creep.
+
+## Issue Sequencing
+
+The coordinator picks up `agent-ok` issues in ascending issue-number order. File issues in the order they should be built.
+
+An issue whose body contains a line `Blocked by #N` is skipped while issue #N is still open.
+
+## Design System
+
+Design lives in `design/`.
+
+- `design/DESIGN-SYSTEM.html` is the canonical source for color, type, geometry, layout, primitives, states, and visual invariants.
+- Per-screen files such as `find-screen`, `school-detail`, `saved-list`, and `landing` are deltas on top of the design system.
+- Never hardcode a hex value or type size that the system already defines; use Tailwind tokens.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,5 @@
-# AdmitDay — house rules for agents
+# Claude Code Adapter
 
-- **Never modify `data/schools.json`.** It is curated source data.
-- Filtering logic lives in `lib/school-list-utils.ts` — look there first for anything about school list filtering.
-- Tests live in `__tests__/`. **Add** new test files or cases; never overwrite or delete existing tests.
-- Run `npm test` and `npm run build` before considering any change done; both must exit 0.
-- The app deploys to Vercel automatically from `main`. Do not add local deploy or pm2 steps.
-- The product name in UI copy is **"AdmitDay"** (the repo was renamed from hs-navigator; don't reintroduce the old name).
-- If a change alters user-facing behavior, the data model, or the architecture, update `README.md` in the same PR so the README never drifts from reality (`README.md` is on the markdown allowlist, so editing it is always allowed).
-- Never push, never merge, never switch branches — the coordinator owns git remotes.
-- `LESSONS.md` is coordinator-owned runtime state — read it for context, but never commit it (use `git add -A -- ':(exclude)LESSONS.md'`).
-- Stay strictly within the scope of the issue you were given; an independent reviewer rejects scope creep.
-- **Issue sequencing:** the coordinator picks up `agent-ok` issues in **ascending issue-number order** (file them in the order they should be built). An issue whose body contains a line `Blocked by #N` is skipped while issue #N is still open.
-- **Design lives in `design/`.** `design/DESIGN-SYSTEM.html` is the canonical source for colour, type, geometry, layout, primitives, states and the product's visual invariants — read it before building any UI. The per-screen files (`find-screen`, `school-detail`, `saved-list`, `landing`, each with a `-handoff`) are *deltas* on top of it, not restatements. Never hardcode a hex value or type size that the system already defines; use the Tailwind tokens.
+Read and follow [AGENTS.md](AGENTS.md) before making changes in this repo.
+
+This file exists because Claude Code loads `CLAUDE.md` automatically. The shared source of truth for all agents is `AGENTS.md`.

--- a/README.md
+++ b/README.md
@@ -1,76 +1,77 @@
 # AdmitDay
 
-AI-powered NYC public high school admissions navigator. Helps families build a personalized school list from 700+ programs across 400+ schools, based on what actually matters to them.
+AI-powered NYC public high school admissions navigator. AdmitDay helps families turn a scattered admissions process into a grounded, personalized school list.
 
-## Problem
+- Live app: https://www.admitday.com
+- Chat search: https://www.admitday.com/chat
+- Unified finder in progress: `/find` and `/school/[dbn]`
 
-Every year, roughly 75,000 NYC families navigate high school admissions. The information exists (NYC DOE website, School Information Finder, NYC_SIFT), but it's scattered, hard to filter, and impossible to personalize. Parents end up relying on Facebook groups, word of mouth, and spreadsheets. AdmitDay turns that mess into one trustworthy, personalized tool.
+## Why This Exists
 
-## How It Works
+Every year, roughly 75,000 NYC families navigate high school admissions. The information exists across DOE pages, School Information Finder, NYC-SIFT, school sites, Facebook groups, and spreadsheets, but it is hard to filter and harder to personalize.
 
-Two discovery surfaces today (unifying them into a single flow is the next build — see below):
+AdmitDay is built around a simple product bet: parents do not need more raw information. They need to know which schools are plausible, why they match, and what to do next.
 
-1. **Structured filters** (https://www.admitday.com). Deterministic matching on borough, size, admissions track, and interests. Filter-then-generate: match on structured fields in code, then Claude writes a personalized rationale for each school.
-2. **RAG-powered chat** (https://www.admitday.com/chat). Ask in plain language ("which Brooklyn schools have strong CS and soccer?"). The system extracts exact signals from the question (borough, sport, interest), hard-filters the candidate pool, then semantic-ranks within it (**hybrid search**), and generates a grounded answer citing only the schools it found.
+## What It Does
 
-The filter page and the chat page are still two separate, linked surfaces that don't share state. `/find` + `/school/[dbn]` (see below) are the unified replacement — hard rail filters plus an ask box that re-ranks without ever removing a school, then a detail view per school — but they're reachable only by direct URL for now; they don't yet replace `/list`, `/requirements`, or `/chat` on the live site.
+- Builds a school list from 700+ programs across 400+ NYC public high schools.
+- Applies deterministic filters for facts that should never be guessed, including borough, admissions track, size, requirements, activities, and programs.
+- Uses RAG-powered chat for plain-language questions like "which Brooklyn schools have strong CS and soccer?"
+- Generates grounded rationales only from retrieved school data.
+- Keeps DOE-reported facts separate from model-generated interpretation.
+
+## Product Shape
+
+AdmitDay currently has two live discovery surfaces:
+
+1. **Structured filters:** users narrow schools by concrete constraints, then get personalized rationale text.
+2. **RAG chat:** users ask in natural language; the system extracts exact signals, hard-filters the candidate pool, semantic-ranks within it, and cites only the schools it found.
+
+The next product surface is a unified `/find` flow: hard rail filters plus an ask box that re-ranks without removing schools, linked to `/school/[dbn]` detail pages. These routes exist but do not yet replace the older live `/list`, `/requirements`, and `/chat` flows.
 
 ## Architecture
 
-- **Frontend:** Next.js 14 (App Router), Tailwind CSS.
-- **Design system:** a token layer + nine primitives (`Chip`, `SegmentedControl`, `Button`, `StatBlock`, `SchoolRow`, `Eyebrow`, `DefinitionRow`, `NotReportedLine`, `StatGrid`) in `components/ui/`, consumed by the rebuilt `/find` (rail + ask band + ranked results, matching `design/find-screen.html`) and `/school/[dbn]` (matching `design/school-detail.html`). Named color tokens and four `next/font/google` families (Space Grotesk, Newsreader, Libre Franklin, JetBrains Mono) live in `tailwind.config.ts` / `lib/fonts.ts`. `/find`'s rail filters (borough, admissions track, size) are a hard floor and round-trip through the URL (`app/find/page.tsx`'s `searchParams`); the ask box's extracted signals (`lib/query-filters.ts`) only re-rank the same result set (`lib/soft-match.ts`) and are individually removable as chips without another model call.
-- **School detail (`/school/[dbn]`):** a server component that renders only DOE-published values — no computed scores, ratings, or admissions-odds language anywhere. `lib/school-detail-utils.ts` shapes the raw `School` record into the stat grid, activity chip groups, transit chips, and requirement blocks; a stat or activity group with no data is omitted entirely (never shown as zero or a dash), and its absence is stated once in words — "NOT REPORTED" for a DOE data gap (missing stats, missing subway/bus) versus "NOT OFFERED" for a fact about the school (no PSAL teams, no AP courses). `matchedSignals` (which ask-derived chips to accent) arrives from `/find` as a query param; the detail page never calls the LLM. An unknown or retired DBN renders `app/school/[dbn]/not-found.tsx` with a real HTTP 404. Add/Remove is optimistic against the same `localStorage` key (`ADDED_SCHOOLS_KEY` in `lib/school-list-utils.ts`) `/find` uses, so the header's My Schools count stays in sync between the two screens.
-- **Generation:** Claude **Sonnet 5** (Anthropic), grounded prompts to prevent hallucination.
-- **Retrieval (RAG):** built from scratch — OpenAI `text-embedding-3-small` (1536-dim), semantic chunking (identity / academics / activities per school), hybrid deterministic-plus-semantic search, grounded chat API route.
-- **Data:** 457 NYC public high schools in Vercel Postgres (`dbn TEXT PRIMARY KEY, data JSONB`), read through a cached loader (`lib/load-schools.ts` → `getAllSchools()`) that degrades gracefully to an empty-state banner on any DB error. Refresh the data with `npm run refresh:data` (see below); the JSON files it produces are gitignored and never ship in the repo.
-- **Cost protection:** per-IP rate limiting on the LLM routes (`/api/chat`, `/api/rationale`); returns 429 under abuse.
-- **Observability:** Sentry (errors), PostHog (analytics).
-- **Deployment:** Vercel — production auto-deploys from `main`; GitHub Actions CI runs the Jest suite as a required check on every PR.
+- **Frontend:** Next.js 14 App Router and Tailwind CSS.
+- **Design system:** token layer plus reusable UI primitives in `components/ui/`.
+- **Data:** 457 NYC public high schools in Vercel Postgres, keyed by `dbn`.
+- **Retrieval:** OpenAI `text-embedding-3-small`, semantic chunking by identity, academics, and activities, plus deterministic filtering.
+- **Generation:** Claude Sonnet 5 through grounded prompts.
+- **Cost protection:** per-IP rate limiting on LLM routes.
+- **Observability:** Sentry for errors and PostHog for analytics.
+- **Deployment:** Vercel from `main`; GitHub Actions runs Jest on pushes and PRs.
 
-## Refreshing School Data
+## Data Quality
 
-Data currency is the app's core differentiator, so refreshing it for a new admissions cycle is meant to be routine, not archaeology. One command runs the full pipeline in order and validates the result before writing anything:
+Data currency is the core differentiator. One command runs the refresh pipeline:
 
 ```bash
 npm run refresh:data
 ```
 
-This runs `scripts/refresh-data.ts`, which does, in order:
+The pipeline runs `build_school_data.py`, validates counts and required fields, writes the validated JSON, seeds Postgres with `scripts/seed-schools.ts`, and rebuilds embeddings with `scripts/embed-schools.ts`. It refuses to write if the scrape looks structurally wrong, such as a large school-count drop, duplicate DBNs, or missing required fields.
 
-1. **Scrape** current DOE / NYC-SIFT data: `python3 build_school_data.py` → writes `schools.json` at the repo root.
-2. **Validate** the scrape (`lib/validate-school-data.ts`) before anything is written to `data/`. It fails loudly — refuses to write and exits non-zero — if:
-   - the school count falls outside the expected range (~457 ± 10%),
-   - the count drops more than ~10% versus the previously-seeded `data/schools.json`,
-   - any record is missing a required field (`dbn`, `name`, or `borough`), or
-   - any `dbn` value is duplicated.
-   It also prints a human-readable summary: schools before/after, added dbns, removed dbns, and any records that failed validation.
-3. **Write** the validated data to `data/schools.json`.
-4. **Seed Postgres**: `npx ts-node scripts/seed-schools.ts` — upserts every record into the `schools` table, keyed by `dbn`.
-5. **Re-embed**: `npx ts-node scripts/embed-schools.ts` — rebuilds `data/school-embeddings.json` for RAG retrieval.
+## Evals And Guardrails
 
-Steps 4 and 5 need `POSTGRES_URL` and `OPENAI_API_KEY` in `.env.local`. This is a manual, on-demand command today — no scheduling (cron/CI) is wired up.
+AdmitDay uses product rules and tests to keep the AI parts bounded:
 
-## How AdmitDay gets built — the autonomous coding agent
+- Deterministic filters live in code, not in the LLM.
+- The school detail page renders only DOE-published values.
+- Missing data is never shown as zero.
+- Admissions-odds language is banned.
+- Golden evals check factual accuracy, decision quality, output format, and completeness.
+- Smoke tests check the deployed site, not just local code.
 
-AdmitDay is built through a self-hosted coding-agent pipeline, designed to be a repeatable platform for this and future apps:
+Key lessons from building the retrieval layer:
 
-1. File a GitHub issue and label it `agent-ok`.
-2. A coordinator (`agent-coordinator.sh`, on a VPS) picks it up, runs Claude Code on a fresh task branch, and **objectively verifies** the result with `npm test` + `npm run build`.
-3. An independent reviewer pass — a second, read-only Claude — checks the diff against the issue and rejects scope creep.
-4. The coordinator opens a PR. Low-risk, reviewer-approved changes are **auto-merged** (squash) once the required `test` check passes; anything touching the database, secrets, or infrastructure is escalated to a human instead of auto-merging.
-5. Branch protection makes the PR the only path to `main` — no direct pushes, no force-pushes.
+- Semantic chunking beats one giant chunk per school.
+- Hybrid deterministic-plus-semantic search beats pure semantic search for compound queries.
+- Evals caught real production bugs, including hallucinated data, domain misclassification, and chunk dilution.
 
-Every outcome is recorded on the issue itself — labels and an explanatory comment — so the state of the queue is always readable from GitHub rather than a separate notification channel. Guardrails — branch protection, secret scanning + push protection, a markdown-allowlist CI guard, product rules encoded as tests, and production smoke tests that check the deployed site rather than the code — keep the autonomy safe by structure.
+## Agentic Build System
 
-## Lessons Learned Building This
+AdmitDay is also a testbed for a guarded autonomous coding workflow. A coordinator on a DigitalOcean VPS picks up GitHub issues labeled `agent-ok`, loads shared rules from `AGENTS.md`, runs Claude Code on task branches, verifies with tests and build checks, asks a second model to review the diff, and opens PRs back on GitHub.
 
-**Semantic chunking matters.** Naive single-chunk-per-school embeddings caused chunk dilution: a 3,900-character school description produces an embedding that matches no single query well. Splitting into identity, academics, and activities chunks for schools with descriptions longer than 800 chars (e.g., Brooklyn Tech went from 1 chunk to 3) improved retrieval scores significantly.
-
-**Evals catch real bugs.** Built golden datasets and scored on a 4-dimension rubric (factual accuracy, decision quality, output format, completeness). Found data hallucination, domain misclassification, and chunk dilution in production, and wrote prompt fixes for all three.
-
-**Code for rules, LLM for reasoning.** Important, deterministic filters (borough, admissions track) should never go through an LLM. Deterministic matching happens in code; Claude handles the nuanced generation and conversational retrieval.
-
-**Hybrid search beats pure semantic for compound queries.** A query like "CS + soccer + Brooklyn" gets blended into one average vector, so no single chunk matches all signals well. The fix (now shipped): extract deterministic filters — borough, sport, interest — from the question, hard-filter the candidate set, then semantic-rank within it.
+The full operator workflow, including who uses it, where it runs, session discipline, compact task briefs, cost gates, Langfuse observability, and future model routing, lives in [docs/agent-pipeline.md](docs/agent-pipeline.md).
 
 ## Running Locally
 
@@ -79,10 +80,10 @@ git clone https://github.com/neinna/AdmitDay.git
 cd AdmitDay
 npm install
 cp .env.local.example .env.local
-# Add ANTHROPIC_API_KEY, OPENAI_API_KEY, and the Postgres connection vars to .env.local
+# Add ANTHROPIC_API_KEY, OPENAI_API_KEY, and Postgres vars to .env.local
 npm run dev
 ```
 
 ## Status
 
-Live in production at https://www.admitday.com. Recent cycle: fixed the production school list (Postgres data layer), shipped hybrid chat search, moved both LLM routes to Claude Sonnet 5, added rate limiting, and brought the autonomous agent pipeline (with guarded auto-merge) online. Five moderated user sessions with NYC parents. Active development toward the October application window.
+Live in production at https://www.admitday.com. Recent work shipped the Postgres data layer, hybrid chat search, Claude Sonnet 5 routing for LLM calls, per-IP rate limiting, and the guarded autonomous agent pipeline. Five moderated user sessions with NYC parents are complete; active development is focused on the October application window.

--- a/__tests__/md-allowlist.test.ts
+++ b/__tests__/md-allowlist.test.ts
@@ -3,12 +3,12 @@ import { execSync } from 'child_process'
 // ── Public-repo privacy guard ────────────────────────────────────────────────
 // This repo is PUBLIC. Planning/strategy/PRD docs must never be committed here
 // (a strategy PRD leaked for months before being purged from history — see the
-// md-privacy-guard change). Only the two markdown files below may be tracked.
+// md-privacy-guard change). Only the markdown files below may be tracked.
 //
 // To intentionally add another markdown file, add its exact repo-relative path
 // to ALLOWED in the SAME pull request — that makes the decision explicit and
 // reviewable rather than accidental.
-const ALLOWED = ['README.md', 'CLAUDE.md']
+const ALLOWED = ['AGENTS.md', 'CLAUDE.md', 'README.md', 'docs/agent-pipeline.md']
 
 describe('markdown allowlist (public-repo privacy guard)', () => {
   it('only the allowlisted markdown files are tracked in the repo', () => {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -14,7 +14,12 @@ import { searchSchools } from "@/lib/rag";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { classifyProviderError } from "@/lib/provider-error";
 
-const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+let anthropicClient: Anthropic | null = null;
+
+function getAnthropicClient(): Anthropic {
+  anthropicClient ??= new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  return anthropicClient;
+}
 
 export async function POST(request: NextRequest) {
   const rl = checkRateLimit(request);
@@ -45,7 +50,7 @@ export async function POST(request: NextRequest) {
       .join("\n\n");
 
     // Step 3: Send to Claude with the retrieved context
-    const message = await client.messages.create({
+    const message = await getAnthropicClient().messages.create({
       model: "claude-sonnet-5",
       max_tokens: 600,
       system:

--- a/docs/agent-pipeline.md
+++ b/docs/agent-pipeline.md
@@ -1,0 +1,125 @@
+# AdmitDay Agent Pipeline
+
+AdmitDay is built with a guarded autonomous coding workflow that runs on a DigitalOcean VPS. The goal is not to let an agent do anything it wants; the goal is to make small, reviewable changes move through a repeatable system with objective checks.
+
+This pipeline is for the project operator, not for AdmitDay users. Parents use the product. The agent pipeline is the build system behind the product.
+
+## Who Uses This
+
+- **You:** file issues, decide priorities, review risky PRs, and merge work that should stay human-controlled.
+- **GitHub:** acts as the control plane: issues are the queue, labels are state, branches hold work, and PRs are the review surface.
+- **The VPS coordinator:** polls GitHub, starts agent runs, verifies results, comments on issues, and opens PRs.
+- **Claude Code:** performs the current implementation and review passes on the VPS.
+- **Future model router:** will decide which model should handle planning, simple edits, complex implementation, and review.
+
+`AGENTS.md` is the shared instruction file for all coding agents. Claude Code gets a tiny `CLAUDE.md` adapter because it loads that filename automatically, but the adapter points back to `AGENTS.md`. Open-weight model runners and future orchestrator workers should receive the same `AGENTS.md` content in their harness prompt.
+
+## Where It Runs
+
+The coordinator runs on the VPS, not on the production user's browser session. The basic deployment shape is:
+
+1. GitHub issue gets labeled `agent-ok`.
+2. VPS coordinator sees the issue and creates a task branch.
+3. Coordinator loads `AGENTS.md` into the runner prompt.
+4. Agent writes code on the VPS checkout.
+5. Coordinator runs verification.
+6. Coordinator pushes the branch to GitHub and opens a PR.
+7. GitHub checks run.
+8. Approved changes merge through GitHub.
+9. Production deploys from the merged GitHub state.
+
+That keeps GitHub as the source of truth even though the coding work happens on the VPS.
+
+## Current Flow
+
+1. File a GitHub issue and label it `agent-ok`.
+2. The coordinator (`agent-coordinator.sh`) picks up eligible issues in ascending issue-number order.
+3. Claude Code runs on a fresh task branch.
+4. The coordinator loads `AGENTS.md` into the runner prompt.
+5. The coordinator verifies the result with `npm test` and `npm run build`.
+6. A separate read-only reviewer model inspects the issue and diff for correctness, risk, and scope creep.
+7. The coordinator opens a PR.
+8. Low-risk, reviewer-approved changes can be auto-merged after required checks pass.
+9. Changes touching database, secrets, deployment, seeding, or infrastructure are labeled for human review.
+
+The coordinator never pushes to `main` directly and never merges directly.
+
+## Session Discipline
+
+Long agent sessions are expensive because they carry large context forward. The working rule is:
+
+- Use one session for exploration.
+- End exploration with a compact task brief.
+- Start a fresh implementation session from that brief.
+- Start another fresh session for independent review.
+
+The task brief should be short enough to fit in a GitHub issue comment. It should include:
+
+- User goal.
+- Files and routes likely involved.
+- Known constraints.
+- Acceptance criteria.
+- Verification commands.
+- Risks or areas requiring human review.
+
+This keeps the implementation context focused and avoids paying repeatedly for irrelevant exploratory history.
+
+## Cost Gate
+
+Before launching a long autonomous run, estimate whether the task deserves a frontier model.
+
+Use a cheap or mid-tier model when the task is:
+
+- File search.
+- README or issue drafting.
+- Mechanical edits.
+- Small UI copy changes.
+- Test-only updates.
+- Dependency-free refactors with narrow scope.
+
+Use a frontier model when the task is:
+
+- Architecture or data-model design.
+- Retrieval, ranking, or eval logic.
+- User-facing behavior with ambiguous requirements.
+- Security, privacy, auth, database, or deployment work.
+- A change that needs an independent reviewer before merge.
+
+The target is not "cheapest model always." The target is "cheapest model that can reliably satisfy the written success criteria."
+
+## Success Criteria
+
+Define success before looking at model output. A cheap model succeeded only if:
+
+- The requested behavior is implemented.
+- Existing tests pass.
+- New tests cover changed behavior when risk justifies it.
+- `npm run build` passes.
+- The reviewer flags no correctness, scope, or risk issue.
+- The PR body clearly explains what changed and how it was verified.
+
+If any of these fail, escalate the task to a stronger model or a human review path.
+
+## Planned Observability
+
+The next instrumentation step is Langfuse, self-hosted on the VPS:
+
+- Log every agent run.
+- Capture model, provider, latency, tokens, cost, issue number, branch, verification result, reviewer verdict, and final PR result.
+- Compare model tiers against the same written success criteria.
+- Route future tasks from the plan output, not keyword matching.
+
+That turns the coding agent from a black box into an evalable system.
+
+## Model Analytics And Routing Roadmap
+
+The first phase should be measurement only. Nothing routes differently until the baseline is visible.
+
+1. **Trace every run:** log cost, latency, tokens, model, task type, issue number, branch, test result, build result, and reviewer verdict.
+2. **Write success criteria before output:** define what counts as a successful cheap-model run before reading the model's work.
+3. **Classify from the plan:** ask the planning pass for complexity, risk areas, likely files, and verification commands, then route from that structured plan.
+4. **Route conservatively:** cheap model for search, README drafting, issue grooming, and mechanical edits; stronger model for architecture, retrieval, evals, security, data, and ambiguous product behavior.
+5. **Keep a reviewer lane:** complex or user-facing changes still get an independent review pass.
+6. **Add open-weight models after instrumentation:** compare an open-weight local/VPS model on bounded tasks where success can be judged by tests, build, and reviewer outcome.
+
+The useful metric is not whether a model sounded good. The useful metric is whether it shipped a correct, scoped change at lower cost without increasing review failures.

--- a/lib/rag.ts
+++ b/lib/rag.ts
@@ -180,14 +180,23 @@ function applyDeterministicFilters(
 // Search: embed query, find top matches, deduplicate by school
 // ---------------------------------------------------------------------------
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+let openaiClient: OpenAI | null = null;
+
+function getOpenAIClient(): OpenAI {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error("OPENAI_API_KEY is required for RAG search");
+  }
+
+  openaiClient ??= new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  return openaiClient;
+}
 
 export async function searchSchools(
   query: string,
   topK: number = 5
 ): Promise<SearchResult[]> {
   // Embed the user's query
-  const response = await openai.embeddings.create({
+  const response = await getOpenAIClient().embeddings.create({
     model: "text-embedding-3-small",
     input: query,
   });


### PR DESCRIPTION
## Summary
- Refocus the top-level README around the public product, architecture, evals, and current status
- Add docs/agent-pipeline.md with the VPS coordinator workflow, shared AGENTS.md instructions, cost gates, and model analytics roadmap
- Add AGENTS.md as the shared agent instruction file and reduce CLAUDE.md to a Claude Code adapter
- Lazy-initialize provider clients so Vercel preview builds do not require runtime AI secrets at module import time

## Verification
- npm test
- npm run build