### PR TITLE
Wire agent run observability baseline

### DIFF
--- a/.env.agents.example
+++ b/.env.agents.example
@@ -1,0 +1,44 @@
+# Environment for the autonomous coding agent (agent-coordinator.sh).
+#
+# The coordinator sources this from /home/agent/.env.agents on the VPS.
+# Copy this file there and fill in real values. NEVER commit the filled-in copy:
+# .env.agents is gitignored, this .example is the only version that belongs here.
+#
+#   cp .env.agents.example /home/agent/.env.agents && chmod 600 /home/agent/.env.agents
+#
+# (The Next.js app's own environment is separate — see .env.local.example.)
+
+# --- GitHub ---
+# Fine-grained PAT with issues + pull requests + contents write on this repo.
+GITHUB_TOKEN=
+GITHUB_REPO=neinna/AdmitDay
+
+# --- Telegram control channel ---
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
+# --- Langfuse (observability) ---
+# Every coordinator run writes one trace: cost, tokens, model, and latency per
+# phase. Logging only — it never influences routing, model choice, or whether a
+# run succeeds. If these are unset the coordinator behaves exactly as it did
+# before Langfuse existed, so leaving them blank is a supported configuration.
+#
+# Keys come from your Langfuse project: Settings -> API Keys. For the intended
+# AdmitDay setup, Langfuse is self-hosted on the same VPS as the coordinator.
+# If you use Langfuse Cloud instead, replace LANGFUSE_HOST with the correct
+# region host:
+#   EU region: https://cloud.langfuse.com
+#   US region: https://us.cloud.langfuse.com
+#
+# Note: if you switch to cloud Langfuse, these traces leave the VPS. The
+# coordinator sends only issue number, issue title, branch, repo, outcome,
+# model names, token counts, cost, timings, test/build result, reviewer result,
+# and PR outcome — never prompt text, diffs, file contents, or agent output.
+# See scripts/langfuse_trace.py.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+LANGFUSE_HOST=http://127.0.0.1:3000
+
+# Optional: seconds before the trace writer gives up and exits (default 20).
+# A dead or slow Langfuse can never cost a run more than this.
+# LANGFUSE_TRACE_TIMEOUT=20

--- a/.env.agents.example
+++ b/.env.agents.example
@@ -23,21 +23,19 @@ TELEGRAM_CHAT_ID=
 # run succeeds. If these are unset the coordinator behaves exactly as it did
 # before Langfuse existed, so leaving them blank is a supported configuration.
 #
-# Keys come from your Langfuse project: Settings -> API Keys. For the intended
-# AdmitDay setup, Langfuse is self-hosted on the same VPS as the coordinator.
-# If you use Langfuse Cloud instead, replace LANGFUSE_HOST with the correct
-# region host:
+# Keys come from your Langfuse Cloud project: Settings -> API Keys. Use the
+# same region host as the project that issued the keys:
 #   EU region: https://cloud.langfuse.com
 #   US region: https://us.cloud.langfuse.com
 #
-# Note: if you switch to cloud Langfuse, these traces leave the VPS. The
-# coordinator sends only issue number, issue title, branch, repo, outcome,
-# model names, token counts, cost, timings, test/build result, reviewer result,
-# and PR outcome — never prompt text, diffs, file contents, or agent output.
+# These traces leave the VPS for Langfuse Cloud. The coordinator sends only
+# issue number, issue title, branch, repo, outcome, model names, token counts,
+# cost, timings, test/build result, reviewer result, and PR outcome — never
+# prompt text, diffs, file contents, or agent output.
 # See scripts/langfuse_trace.py.
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
-LANGFUSE_HOST=http://127.0.0.1:3000
+LANGFUSE_HOST=https://cloud.langfuse.com
 
 # Optional: seconds before the trace writer gives up and exits (default 20).
 # A dead or slow Langfuse can never cost a run more than this.

--- a/.gitignore
+++ b/.gitignore
@@ -18,12 +18,17 @@
 # env files — never commit
 .env
 .env.local
+# agent coordinator credentials (GitHub, Telegram, Langfuse) — .example only
+.env.agents
 .env.development.local
 .env.test.local
 .env.production.local
 
 # vercel
 .vercel
+
+# python
+__pycache__/
 
 # typescript
 *.tsbuildinfo
@@ -62,3 +67,4 @@ planning-docs/
 
 # Finder duplicate files
 * copy*
+.env*.local

--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -180,9 +180,9 @@ describe('agent-coordinator.sh PR flow', () => {
     expect(langfuseTraceSource).not.toContain('"diff"')
   })
 
-  it('documents self-hosted Langfuse as the default VPS baseline', () => {
-    expect(envAgentsExampleSource).toContain('Langfuse is self-hosted on the same VPS')
-    expect(envAgentsExampleSource).toContain('LANGFUSE_HOST=http://127.0.0.1:3000')
+  it('documents Langfuse Cloud as the configured VPS baseline', () => {
+    expect(envAgentsExampleSource).toContain('Keys come from your Langfuse Cloud project')
+    expect(envAgentsExampleSource).toContain('LANGFUSE_HOST=https://cloud.langfuse.com')
   })
 })
 

--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -91,6 +91,8 @@ describe('parseIssueCommand', () => {
 
 describe('agent-coordinator.sh PR flow', () => {
   const coordinatorSource = fs.readFileSync(path.join(__dirname, '../agent-coordinator.sh'), 'utf-8')
+  const langfuseTraceSource = fs.readFileSync(path.join(__dirname, '../scripts/langfuse_trace.py'), 'utf-8')
+  const envAgentsExampleSource = fs.readFileSync(path.join(__dirname, '../.env.agents.example'), 'utf-8')
 
   it('uses the "agent-ok" trigger label (nothing runs unless deliberately labeled)', () => {
     expect(coordinatorSource).toContain('TRIGGER_LABEL="agent-ok"')
@@ -156,6 +158,31 @@ describe('agent-coordinator.sh PR flow', () => {
     expect(successBranch).not.toBeNull()
     const body = successBranch![1]
     expect(body).toMatch(/REVIEW_RC.*-eq 2/)
+  })
+
+  it('writes a sanitized run metadata artifact for every Langfuse trace', () => {
+    expect(coordinatorSource).toContain('RUN_METADATA_DIR="/home/agent/agent-run-metadata"')
+    expect(coordinatorSource).toContain('LF_METADATA_DIR="$RUN_METADATA_DIR"')
+    expect(coordinatorSource).toContain('metadata_file')
+  })
+
+  it('records the baseline fields needed before model routing', () => {
+    for (const field of ['test_result', 'build_result', 'reviewer_result', 'pr_outcome']) {
+      expect(coordinatorSource).toContain(field)
+      expect(langfuseTraceSource).toContain(`"${field}"`)
+    }
+  })
+
+  it('keeps private task context out of Langfuse payloads', () => {
+    expect(langfuseTraceSource).toContain('No prompt text, no diffs, no file contents')
+    expect(langfuseTraceSource).not.toContain('"issue_body"')
+    expect(langfuseTraceSource).not.toContain('"prompt"')
+    expect(langfuseTraceSource).not.toContain('"diff"')
+  })
+
+  it('documents self-hosted Langfuse as the default VPS baseline', () => {
+    expect(envAgentsExampleSource).toContain('Langfuse is self-hosted on the same VPS')
+    expect(envAgentsExampleSource).toContain('LANGFUSE_HOST=http://127.0.0.1:3000')
   })
 })
 
@@ -1743,4 +1770,3 @@ describe('Issue #56: source — isEligible has audition-only guard before has_op
 
 
 // ── Issue #84: Hide the unbuilt "Full Access" paid-tier UI ────────────────────
-

--- a/agent-coordinator.sh
+++ b/agent-coordinator.sh
@@ -12,6 +12,11 @@
 
 # Load credentials
 source /home/agent/.env.agents
+
+# The Langfuse SDK reads these from the environment, so they must survive into
+# the trace script's process whether or not .env.agents used `export`. Values
+# are never logged, never passed as arguments, and never written to the repo.
+export LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY LANGFUSE_HOST
 ANTHROPIC_API_KEY=$(grep ANTHROPIC_API_KEY /home/agent/app/.env.local | cut -d '=' -f2 | tr -d '"' | tr -d "'")
 
 APP_DIR="/home/agent/app"
@@ -20,9 +25,165 @@ OFFSET_FILE="/home/agent/.tg_offset"
 LESSONS_FILE="/home/agent/app/LESSONS.md"
 TRIGGER_LABEL="agent-ok"
 CLAUDE_TIMEOUT=1800
+LF_TRACE_SCRIPT="${APP_DIR}/scripts/langfuse_trace.py"
+RUN_METADATA_DIR="/home/agent/agent-run-metadata"
+LF_RUN_FILE=""
 
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# --- Langfuse instrumentation -------------------------------------------------
+# Observability only. These helpers must never change what the coordinator does,
+# so they touch no shared state, always return 0, and send diagnostics to
+# $LOG_FILE rather than stdout (review_change's stdout is its return value).
+# If Langfuse is unconfigured, unreachable, or the script is missing, a run
+# proceeds exactly as it did before this was added.
+
+lf_now_ns() {
+  python3 -c 'import time; print(time.time_ns())' 2>/dev/null || echo ""
+}
+
+# lf_record NAME START_NS END_NS OK CLAUDE_JSON ATTEMPT [STATUS]
+#   OK:           1, 0, or "" when the notion of pass/fail does not apply
+#   CLAUDE_JSON:  a claude --output-format json file, or "" for a non-LLM phase
+#   STATUS:       optional small enum, e.g. passed, failed, skipped-test-failed
+# Appends one JSON line per phase to this run's buffer — one line per model when
+# a single claude call billed more than one, so per-model spend stays exact.
+# Only names, numbers and timings are written here. No prompts, no diffs, no
+# agent output: what is not extracted below cannot leave the VPS.
+lf_record() {
+  [ -n "$LF_RUN_FILE" ] || return 0
+  LF_NAME="$1" LF_START="$2" LF_END="$3" LF_OK="$4" LF_JSON="$5" LF_ATTEMPT="$6" \
+  LF_STATUS="$7" \
+  python3 << 'PYEOF' >> "$LF_RUN_FILE" 2>> "$LOG_FILE"
+import json, os
+
+def num(key):
+    v = os.environ.get(key, "")
+    return int(v) if v.isdigit() else None
+
+base = {"name": os.environ["LF_NAME"]}
+for field, key in (("start_ns", "LF_START"), ("end_ns", "LF_END"),
+                   ("attempt", "LF_ATTEMPT")):
+    value = num(key)
+    if value is not None:
+        base[field] = value
+if os.environ.get("LF_OK") in ("0", "1"):
+    base["ok"] = os.environ["LF_OK"] == "1"
+if os.environ.get("LF_STATUS"):
+    base["status"] = os.environ["LF_STATUS"]
+
+rows = []
+path = os.environ.get("LF_JSON") or ""
+if path and os.path.exists(path):
+    try:
+        d = json.load(open(path))
+    except Exception:
+        d = {}
+    # Newer claude CLIs report per-model usage; older ones only report totals.
+    for model, u in (d.get("modelUsage") or {}).items():
+        row = dict(base, model=model,
+                   input_tokens=u.get("inputTokens"),
+                   output_tokens=u.get("outputTokens"),
+                   cache_read_tokens=u.get("cacheReadInputTokens"),
+                   cache_creation_tokens=u.get("cacheCreationInputTokens"),
+                   cost_usd=u.get("costUSD"))
+        rows.append(row)
+    if not rows and d:
+        u = d.get("usage") or {}
+        rows.append(dict(base, model=d.get("model") or "unknown",
+                         input_tokens=u.get("input_tokens"),
+                         output_tokens=u.get("output_tokens"),
+                         cache_read_tokens=u.get("cache_read_input_tokens"),
+                         cache_creation_tokens=u.get("cache_creation_input_tokens"),
+                         cost_usd=d.get("total_cost_usd")))
+
+for row in (rows or [base]):
+    print(json.dumps({k: v for k, v in row.items() if v is not None}))
+PYEOF
+  return 0
+}
+
+# lf_emit ISSUE TITLE BRANCH OUTCOME ATTEMPTS LABEL START_NS END_NS TEST BUILD REVIEWER PR
+# Assembles this run's buffered phases into one payload and hands it to the only
+# script that talks to Langfuse. Hard-timed and swallowed: a hung or dead
+# Langfuse costs the loop at most 30 seconds and nothing else. The same
+# sanitized payload is also written under RUN_METADATA_DIR for baseline analysis.
+lf_emit() {
+  local RUN_FILE="$LF_RUN_FILE"
+  LF_RUN_FILE=""
+  [ -n "$RUN_FILE" ] || return 0
+  if [ ! -f "$LF_TRACE_SCRIPT" ]; then
+    log "Langfuse: ${LF_TRACE_SCRIPT} not found, skipping trace for #${1}"
+    rm -f "$RUN_FILE"
+    return 0
+  fi
+
+  LF_ISSUE="$1" LF_TITLE="$2" LF_BRANCH="$3" LF_OUTCOME="$4" LF_ATTEMPTS="$5" \
+  LF_LABEL="$6" LF_TSTART="$7" LF_TEND="$8" LF_SPANS="$RUN_FILE" \
+  LF_TEST_RESULT="$9" LF_BUILD_RESULT="${10}" LF_REVIEWER_RESULT="${11}" \
+  LF_PR_OUTCOME="${12}" LF_METADATA_DIR="$RUN_METADATA_DIR" \
+  GITHUB_REPO="$GITHUB_REPO" \
+  python3 << 'PYEOF' 2>> "$LOG_FILE" | timeout 30 python3 "$LF_TRACE_SCRIPT" 2>> "$LOG_FILE"
+import json, os
+
+spans = []
+try:
+    with open(os.environ["LF_SPANS"]) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                spans.append(json.loads(line))
+            except Exception:
+                pass
+except Exception:
+    pass
+
+def num(key):
+    v = os.environ.get(key, "")
+    return int(v) if v.isdigit() else None
+
+trace = {
+    "issue_number": num("LF_ISSUE"),
+    "issue_title": os.environ.get("LF_TITLE") or None,
+    "branch": os.environ.get("LF_BRANCH") or None,
+    "repo": os.environ.get("GITHUB_REPO") or None,
+    "outcome": os.environ.get("LF_OUTCOME") or None,
+    "attempts": num("LF_ATTEMPTS"),
+    "github_label": os.environ.get("LF_LABEL") or None,
+    "test_result": os.environ.get("LF_TEST_RESULT") or None,
+    "build_result": os.environ.get("LF_BUILD_RESULT") or None,
+    "reviewer_result": os.environ.get("LF_REVIEWER_RESULT") or None,
+    "pr_outcome": os.environ.get("LF_PR_OUTCOME") or None,
+    "start_ns": num("LF_TSTART"),
+    "end_ns": num("LF_TEND"),
+}
+payload = {"trace": {k: v for k, v in trace.items() if v is not None},
+           "spans": spans}
+
+metadata_dir = os.environ.get("LF_METADATA_DIR") or ""
+if metadata_dir:
+    try:
+        os.makedirs(metadata_dir, exist_ok=True)
+        issue = payload["trace"].get("issue_number") or "unknown"
+        started = payload["trace"].get("start_ns") or "unknown"
+        path = os.path.join(metadata_dir, f"issue-{issue}-{started}.json")
+        tmp = path + ".tmp"
+        payload["trace"]["metadata_file"] = path
+        with open(tmp, "w") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        pass
+
+print(json.dumps(payload))
+PYEOF
+  rm -f "$RUN_FILE"
+  return 0
 }
 
 telegram() {
@@ -165,15 +326,29 @@ except Exception:
 # the build runs (webpack treats failed cache writes as non-fatal warnings).
 verify_app() {
   local OUT="$1" RC=0
+  local T0 T1
+  TEST_RESULT="not-run"
+  BUILD_RESULT="not-run"
   rm -rf "$APP_DIR/.next"
+  T0=$(lf_now_ns)
   (cd "$APP_DIR" && npm test) > "$OUT" 2>&1 || RC=1
+  T1=$(lf_now_ns)
+  TEST_RESULT="$([ $RC -eq 0 ] && echo passed || echo failed)"
+  lf_record "test" "$T0" "$T1" "$([ $RC -eq 0 ] && echo 1 || echo 0)" "" "" "$TEST_RESULT"
   if [ $RC -eq 0 ]; then
+    T0=$(lf_now_ns)
     ( while true; do rm -rf "$APP_DIR/.next/cache" 2>/dev/null; sleep 10; done ) &
     local PRUNE_PID=$!
     (cd "$APP_DIR" && npm run build) >> "$OUT" 2>&1 || RC=1
     kill "$PRUNE_PID" 2>/dev/null
     wait "$PRUNE_PID" 2>/dev/null
     rm -rf "$APP_DIR/.next/cache"
+    T1=$(lf_now_ns)
+    BUILD_RESULT="$([ $RC -eq 0 ] && echo passed || echo failed)"
+    lf_record "build" "$T0" "$T1" "$([ $RC -eq 0 ] && echo 1 || echo 0)" "" "" "$BUILD_RESULT"
+  else
+    BUILD_RESULT="skipped-test-failed"
+    lf_record "build" "" "" "0" "" "" "$BUILD_RESULT"
   fi
   return $RC
 }
@@ -214,18 +389,36 @@ VERDICT: REJECT - <one-line reason>
 Then, ONLY if the diff touches the database/connection layer, migrations, seeding, environment/secrets handling, or deploy/infra config (regardless of the verdict above), add exactly one more line:
 RISK: LIVE-VERIFY-NEEDED"
 
+  # No log() calls in this function: its stdout is the review text.
+  local T0 T1
+  T0=$(lf_now_ns)
   run_claude "$REVIEW_OUT" "" "Read,Glob,Grep"
   local RC=$?
+  T1=$(lf_now_ns)
   local REVIEW_TEXT
   REVIEW_TEXT=$(claude_json_field "$REVIEW_OUT" "result")
+  local REVIEW_STATUS="unavailable"
+  local REVIEW_OK=0
+  if [ $RC -eq 0 ] && [ -n "$REVIEW_TEXT" ]; then
+    if echo "$REVIEW_TEXT" | grep -q "VERDICT: APPROVE"; then
+      REVIEW_STATUS="approved"
+      REVIEW_OK=1
+    else
+      REVIEW_STATUS="rejected"
+    fi
+  fi
+  lf_record "review" "$T0" "$T1" "$REVIEW_OK" "$REVIEW_OUT" "" "$REVIEW_STATUS"
   rm -f "$REVIEW_OUT"
   echo "$REVIEW_TEXT"
   if [ $RC -ne 0 ] || [ -z "$REVIEW_TEXT" ]; then
+    REVIEWER_RESULT="unavailable"
     return 2
   fi
   if echo "$REVIEW_TEXT" | grep -q "VERDICT: APPROVE"; then
+    REVIEWER_RESULT="approved"
     return 0
   fi
+  REVIEWER_RESULT="rejected"
   return 1
 }
 
@@ -259,8 +452,12 @@ Write the complete new content of LESSONS.md and nothing else (no fences, no com
 - Deduplicate: never repeat an existing lesson in different words.
 - Hard cap 30 lines total: if adding would exceed it, drop the least useful existing line."
 
+  local T0 T1
+  T0=$(lf_now_ns)
   run_claude "$RETRO_OUT" "" "Read"
   local RC=$?
+  T1=$(lf_now_ns)
+  lf_record "retrospective" "$T0" "$T1" "$([ $RC -eq 0 ] && echo 1 || echo 0)" "$RETRO_OUT" ""
   if [ $RC -eq 0 ]; then
     local NEW_LESSONS
     NEW_LESSONS=$(claude_json_field "$RETRO_OUT" "result" | head -30)
@@ -391,6 +588,8 @@ for u in data.get('result', []):
 
 run_agent() {
   local ISSUE_NUMBER=$1
+  local RUN_START
+  RUN_START=$(lf_now_ns)
 
   # Fetch full issue (title + body with newlines preserved) and its comments
   local ISSUE_FILE="/tmp/issue-${ISSUE_NUMBER}.json"
@@ -420,6 +619,11 @@ except Exception:
   local CLAUDE_OUT="/tmp/claude-issue-${ISSUE_NUMBER}.json"
   local VERIFY_OUT="/tmp/verify-issue-${ISSUE_NUMBER}.log"
 
+  # Open this run's phase buffer. Everything lf_record writes from here until
+  # lf_emit belongs to this issue's trace.
+  LF_RUN_FILE="/tmp/lf-run-${ISSUE_NUMBER}.jsonl"
+  : > "$LF_RUN_FILE" 2>/dev/null || LF_RUN_FILE=""
+
   log "Starting issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
   telegram "Starting issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}"
 
@@ -427,7 +631,7 @@ except Exception:
   github_remove_label "$ISSUE_NUMBER" "$TRIGGER_LABEL"
   github_label "$ISSUE_NUMBER" "in-progress"
 
-  cd "$APP_DIR" || { log "FATAL: cannot cd to $APP_DIR"; return; }
+  cd "$APP_DIR" || { log "FATAL: cannot cd to $APP_DIR"; LF_RUN_FILE=""; return; }
   git checkout main >> "$LOG_FILE" 2>&1 && git pull origin main >> "$LOG_FILE" 2>&1
   git branch -D "$BRANCH" 2>/dev/null
   git checkout -b "$BRANCH" >> "$LOG_FILE" 2>&1
@@ -461,16 +665,29 @@ Instructions:
 - End with a short summary of what you changed and why (it becomes the pull request description)."
 
   local ATTEMPT=1
+  local ATTEMPTS_USED=0
   local SESSION_ID=""
   local SUCCESS=0
   local FAIL_REASON=""
   local REVIEW_TEXT=""
   local PROMPT="$BRIEF"
+  local OUTCOME="failed"
+  local GH_LABEL=""
+  local TEST_RESULT="not-run"
+  local BUILD_RESULT="not-run"
+  local REVIEWER_RESULT="not-run"
+  local PR_OUTCOME="not-run"
 
   while [ $ATTEMPT -le 2 ]; do
     log "Issue #${ISSUE_NUMBER}: agent attempt ${ATTEMPT}"
+    ATTEMPTS_USED=$ATTEMPT
+    local T0 T1
+    T0=$(lf_now_ns)
     run_claude "$CLAUDE_OUT" "$([ $ATTEMPT -gt 1 ] && echo "$SESSION_ID")"
     local RC=$?
+    T1=$(lf_now_ns)
+    lf_record "implement" "$T0" "$T1" "$([ $RC -eq 0 ] && echo 1 || echo 0)" \
+      "$CLAUDE_OUT" "$ATTEMPT"
     if [ $RC -eq 124 ]; then
       log "Issue #${ISSUE_NUMBER}: claude timed out on attempt ${ATTEMPT}"
       telegram "Timeout: agent hit the 30min limit on issue #${ISSUE_NUMBER} (attempt ${ATTEMPT})"
@@ -536,12 +753,17 @@ Diagnose why this failed before changing anything else. Then fix it, re-run npm 
     SUMMARY=$(claude_json_field "$CLAUDE_OUT" "result")
     [ -z "$SUMMARY" ] && SUMMARY="(agent produced no summary)"
 
+    local T0 T1
+    T0=$(lf_now_ns)
     git push origin "$BRANCH" >> "$LOG_FILE" 2>&1
     local PR_BODY="${SUMMARY}
 
 Closes #${ISSUE_NUMBER}"
     local PR_URL
     PR_URL=$(github_open_pr "$BRANCH" "$COMMIT_TITLE" "$PR_BODY")
+    T1=$(lf_now_ns)
+    PR_OUTCOME="$([ -n "$PR_URL" ] && echo opened || echo creation-failed)"
+    lf_record "pr" "$T0" "$T1" "$([ -n "$PR_URL" ] && echo 1 || echo 0)" "" "" "$PR_OUTCOME"
 
     if [ -n "$PR_URL" ]; then
       if echo "$REVIEW_TEXT" | grep -q "RISK: LIVE-VERIFY-NEEDED" || [ "$REVIEW_RC" -eq 2 ]; then
@@ -551,11 +773,13 @@ Closes #${ISSUE_NUMBER}"
         # case of "can't truly verify" and must never auto-merge unattended.
         local ESCALATION_REASON="flagged it as touching the database/connection layer, migrations, seeding, environment/secrets, or deploy/infra config (RISK: LIVE-VERIFY-NEEDED)"
         [ "$REVIEW_RC" -eq 2 ] && ESCALATION_REASON="was unavailable, so this diff was never independently reviewed"
+        [ "$REVIEW_RC" -ne 2 ] && REVIEWER_RESULT="approved-live-verify-needed"
         github_comment "$ISSUE_NUMBER" "Agent opened a pull request for this issue: ${PR_URL}
 
 Tests and build verified green by the coordinator. The independent reviewer ${ESCALATION_REASON}. Auto-merge was NOT enabled — please verify before merging."
         github_label "$ISSUE_NUMBER" "needs-review"
         github_remove_label "$ISSUE_NUMBER" "in-progress"
+        OUTCOME="needs-review"; GH_LABEL="needs-review"; PR_OUTCOME="opened-escalated"
         log "Issue #${ISSUE_NUMBER}: PR opened at ${PR_URL}, escalated (${ESCALATION_REASON}), auto-merge NOT enabled"
         telegram "PR ready for issue #${ISSUE_NUMBER} but ESCALATED for human review: ${ISSUE_TITLE} — ${PR_URL}"
       else
@@ -563,11 +787,13 @@ Tests and build verified green by the coordinator. The independent reviewer ${ES
         local PR_NODE_ID
         PR_NODE_ID=$(github_get_pr_node_id "$PR_NUMBER")
         if [ -n "$PR_NODE_ID" ] && github_enable_automerge "$PR_NODE_ID"; then
+          PR_OUTCOME="opened-auto-merge-enabled"
           log "Issue #${ISSUE_NUMBER}: auto-merge enabled on PR ${PR_URL}"
           github_comment "$ISSUE_NUMBER" "Agent opened a pull request for this issue: ${PR_URL}
 
 Tests and build verified green by the coordinator, and an independent reviewer approved the diff. Auto-merge has been enabled — GitHub will merge it once the required checks pass."
         else
+          PR_OUTCOME="opened-auto-merge-failed"
           log "Issue #${ISSUE_NUMBER}: failed to enable auto-merge on PR ${PR_URL}"
           github_comment "$ISSUE_NUMBER" "Agent opened a pull request for this issue: ${PR_URL}
 
@@ -575,10 +801,13 @@ Tests and build verified green by the coordinator, and an independent reviewer a
         fi
         github_label "$ISSUE_NUMBER" "pr-open"
         github_remove_label "$ISSUE_NUMBER" "in-progress"
+        OUTCOME="success"; GH_LABEL="pr-open"
         log "Issue #${ISSUE_NUMBER}: PR opened at ${PR_URL}"
         telegram "PR ready for issue #${ISSUE_NUMBER}: ${ISSUE_TITLE} — ${PR_URL}"
       fi
     else
+      OUTCOME="needs-review"; GH_LABEL="needs-review"
+      PR_OUTCOME="creation-failed"
       github_label "$ISSUE_NUMBER" "needs-review"
       github_remove_label "$ISSUE_NUMBER" "in-progress"
       log "Issue #${ISSUE_NUMBER}: branch pushed but PR creation failed"
@@ -603,6 +832,10 @@ ${FAIL_OUTPUT}
 \`\`\`
 
 </details>"
+    # The agent failed; GitHub gets needs-review so a human picks it up. The
+    # trace records both facts rather than collapsing them into one.
+    OUTCOME="failed"; GH_LABEL="needs-review"
+    PR_OUTCOME="not-attempted"
     github_label "$ISSUE_NUMBER" "needs-review"
     github_remove_label "$ISSUE_NUMBER" "in-progress"
     cd "$APP_DIR"
@@ -612,6 +845,11 @@ ${FAIL_OUTPUT}
     telegram "Failed after 2 attempts: issue #${ISSUE_NUMBER}: ${ISSUE_TITLE} — labeled needs-review, branch deleted"
     run_retrospective "$ISSUE_NUMBER" "$ISSUE_TITLE" "FAILURE — 2 attempts exhausted (verification or review failed)" "$TASK_DIFF"
   fi
+
+  # One trace per issue, written after the run has fully finished either way.
+  lf_emit "$ISSUE_NUMBER" "$ISSUE_TITLE" "$BRANCH" "$OUTCOME" "$ATTEMPTS_USED" \
+    "$GH_LABEL" "$RUN_START" "$(lf_now_ns)" "$TEST_RESULT" "$BUILD_RESULT" \
+    "$REVIEWER_RESULT" "$PR_OUTCOME"
 
   rm -f "$CLAUDE_OUT" "$VERIFY_OUT"
 }

--- a/docs/agent-pipeline.md
+++ b/docs/agent-pipeline.md
@@ -102,7 +102,7 @@ If any of these fail, escalate the task to a stronger model or a human review pa
 
 ## Planned Observability
 
-The next instrumentation step is Langfuse, self-hosted on the VPS:
+The next instrumentation step is Langfuse Cloud, with keys stored on the VPS:
 
 - Log every agent run.
 - Capture model, provider, latency, tokens, cost, issue number, branch, verification result, reviewer verdict, and final PR result.

--- a/scripts/langfuse_trace.py
+++ b/scripts/langfuse_trace.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Write one Langfuse trace for one agent-coordinator run.
+
+Reads run data as JSON on stdin, emits a single trace, exits 0. Always.
+
+This is the ONLY place in the repo that talks to Langfuse. It is observability
+only: it never influences the coordinator's control flow, and every failure mode
+(bad input, missing SDK, unreachable host, hung export) is swallowed and
+reported on stderr so a Langfuse outage can never break an agent run.
+
+Input contract (stdin, JSON):
+
+    {
+      "trace": {
+        "issue_number": 84,
+        "issue_title": "Hide the unbuilt Full Access UI",
+        "branch": "task-84-hide-the-unbuilt-full-acce",
+        "repo": "neinna/AdmitDay",
+        "outcome": "success" | "failed" | "needs-review",
+        "attempts": 1,
+        "github_label": "pr-open",
+        "start_ns": 1754300000000000000,
+        "end_ns":   1754301800000000000
+      },
+      "spans": [
+        {"name": "implement", "start_ns": ..., "end_ns": ...,
+         "model": "claude-sonnet-4-6", "input_tokens": 3, "output_tokens": 4,
+         "cache_read_tokens": 10738, "cache_creation_tokens": 4796,
+         "cost_usd": 0.0212754, "attempt": 1},
+        {"name": "test",  "start_ns": ..., "end_ns": ..., "ok": true},
+        {"name": "build", "start_ns": ..., "end_ns": ..., "ok": true,
+         "status": "passed"}
+      ]
+    }
+
+Every field is optional. If "spans" is empty or unusable, a single span named
+"run" is emitted covering the whole trace, so a run is never invisible.
+
+PRIVACY — load-bearing, do not relax:
+Only the keys listed above are read. Everything else on stdin is dropped by
+_pick() before any Langfuse call. No prompt text, no diffs, no file contents, no
+agent output, no issue body ever leaves this process. The issue *title* is sent
+deliberately, because a trace you cannot identify is not worth writing.
+
+Config (read from the environment, never from arguments, never logged):
+    LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_HOST
+If the keys are unset, this exits 0 without doing anything.
+"""
+
+import json
+import os
+import signal
+import sys
+
+# Hard ceiling on this process. Belt and braces: the SDK gets an HTTP timeout
+# below, but a wedged socket or a slow retry loop must never hold up the agent
+# loop, so we also arm a wall-clock alarm that exits 0 no matter what.
+WATCHDOG_SECONDS = int(os.environ.get("LANGFUSE_TRACE_TIMEOUT", "20"))
+HTTP_TIMEOUT_SECONDS = 5
+
+TRACE_NAME = "agent-run"
+VALID_OUTCOMES = ("success", "failed", "needs-review")
+
+# Phases that represent an LLM call become Langfuse generations (they carry
+# model + tokens + cost). Everything else is a plain span.
+SPAN_KEYS = (
+    "name",
+    "start_ns",
+    "end_ns",
+    "model",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_creation_tokens",
+    "cost_usd",
+    "attempt",
+    "ok",
+    "status",
+)
+TRACE_KEYS = (
+    "issue_number",
+    "issue_title",
+    "branch",
+    "repo",
+    "outcome",
+    "attempts",
+    "github_label",
+    "test_result",
+    "build_result",
+    "reviewer_result",
+    "pr_outcome",
+    "metadata_file",
+    "start_ns",
+    "end_ns",
+)
+
+
+def warn(msg):
+    """Diagnostics go to stderr only. The caller pipes stderr to its log."""
+    sys.stderr.write("langfuse_trace: %s\n" % msg)
+
+
+def _bail(signum, frame):
+    warn("watchdog fired after %ss, giving up (run unaffected)" % WATCHDOG_SECONDS)
+    os._exit(0)
+
+
+def _pick(src, keys):
+    """Whitelist. The privacy guarantee is enforced here and nowhere else."""
+    if not isinstance(src, dict):
+        return {}
+    return {k: src[k] for k in keys if src.get(k) is not None}
+
+
+def _int(v):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _ms(start_ns, end_ns):
+    if start_ns is None or end_ns is None or end_ns < start_ns:
+        return None
+    return round((end_ns - start_ns) / 1e6, 1)
+
+
+def build_payload(raw):
+    """Normalize stdin into exactly what we are willing to send."""
+    trace = _pick(raw.get("trace"), TRACE_KEYS)
+
+    outcome = trace.get("outcome")
+    if outcome not in VALID_OUTCOMES:
+        # Never invent an outcome. An unknown one is itself worth seeing.
+        trace["outcome"] = "needs-review" if outcome is None else str(outcome)
+
+    spans = []
+    for item in raw.get("spans") or []:
+        span = _pick(item, SPAN_KEYS)
+        if span.get("name"):
+            spans.append(span)
+
+    t_start = _int(trace.get("start_ns"))
+    t_end = _int(trace.get("end_ns"))
+
+    if not spans:
+        # Documented fallback: phase boundaries were not available, so the run
+        # still gets exactly one span rather than disappearing.
+        warn("no usable spans on stdin, falling back to a single 'run' span")
+        spans = [{"name": "run", "start_ns": t_start, "end_ns": t_end}]
+
+    # Bound the trace by its spans when the caller did not supply its own edges.
+    starts = [s for s in (_int(x.get("start_ns")) for x in spans) if s is not None]
+    ends = [e for e in (_int(x.get("end_ns")) for x in spans) if e is not None]
+    if t_start is None and starts:
+        t_start = min(starts)
+    if t_end is None and ends:
+        t_end = max(ends)
+
+    return trace, spans, t_start, t_end
+
+
+def usage_for(span):
+    """Langfuse usage_details. Token counts only — that is the whole point."""
+    usage = {}
+    for key, field in (
+        ("input", "input_tokens"),
+        ("output", "output_tokens"),
+        ("cache_read_input_tokens", "cache_read_tokens"),
+        ("cache_creation_input_tokens", "cache_creation_tokens"),
+    ):
+        value = _int(span.get(field))
+        if value is not None:
+            usage[key] = value
+    if usage:
+        usage["total"] = sum(usage.values())
+    return usage
+
+
+def cost_for(span):
+    """Prefer the cost the Claude CLI actually reported.
+
+    Langfuse can derive cost from model + tokens, but only for models in its
+    price table. Passing the CLI's own figure means the cost column is populated
+    even for a model the server has never heard of, which matters the week a new
+    model ships. When the CLI gives us nothing, we omit this and let Langfuse
+    compute it from the token counts.
+    """
+    try:
+        cost = float(span["cost_usd"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return {"total": cost} if cost >= 0 else None
+
+
+def emit(raw):
+    from langfuse import Langfuse, LangfuseGeneration, LangfuseSpan, propagate_attributes
+    from opentelemetry import trace as otel_trace
+
+    trace_meta, spans, t_start, t_end = build_payload(raw)
+
+    client = Langfuse(
+        public_key=os.environ["LANGFUSE_PUBLIC_KEY"],
+        secret_key=os.environ["LANGFUSE_SECRET_KEY"],
+        host=os.environ.get("LANGFUSE_HOST") or None,
+        timeout=HTTP_TIMEOUT_SECONDS,
+        flush_at=512,
+    )
+    tracer = client._otel_tracer  # only private API used; see new_span() fallback
+
+    issue_number = trace_meta.get("issue_number")
+    models = sorted({s["model"] for s in spans if s.get("model")})
+
+    # Raw nanosecond edges are already the span's own start/end; keep them out of
+    # metadata so the UI shows the one timing number a human reads.
+    metadata = {k: v for k, v in trace_meta.items() if k not in ("start_ns", "end_ns")}
+    metadata["latency_ms"] = _ms(t_start, t_end)
+    metadata["models"] = models
+
+    # Tags are what make the UI answer "which model, and did it work" in one
+    # click, and later "did routing change the mix" without a query.
+    tags = ["outcome:%s" % trace_meta["outcome"]] + ["model:%s" % m for m in models]
+
+    def new_span(name, start_ns, parent_ctx, cls, **kwargs):
+        """Create a span with a backdated start time.
+
+        This script runs after the fact, so a span started 'now' would report a
+        nonsensical duration. OTel accepts an explicit start_time; the Langfuse
+        wrapper classes accept a raw otel_span. If a future SDK moves the tracer
+        we fall back to the public constructor: timings collapse, but the trace
+        still carries model, tokens and cost, and latency_ms in metadata keeps
+        the real durations readable either way.
+        """
+        as_type = "generation" if cls is LangfuseGeneration else "span"
+        try:
+            otel_span = tracer.start_span(name, context=parent_ctx, start_time=start_ns)
+            return cls(otel_span=otel_span, langfuse_client=client, **kwargs)
+        except Exception as exc:
+            warn("backdated span %r unavailable (%s), using live timing" % (name, exc))
+            return client.start_observation(name=name, as_type=as_type, **kwargs)
+
+    with propagate_attributes(
+        trace_name=TRACE_NAME,
+        metadata=metadata,
+        tags=tags,
+        # One session per issue, so a re-run of the same issue lines up next to
+        # its earlier attempts instead of scattering across the trace list.
+        session_id="issue-%s" % issue_number if issue_number is not None else None,
+    ):
+        root = new_span(TRACE_NAME, t_start, None, LangfuseSpan)
+        root.update(metadata=metadata, output={"outcome": trace_meta["outcome"]})
+
+        # Nest the phases under the run. If the SDK ever stops exposing the
+        # underlying otel span, fall back to a flat trace rather than no trace.
+        root_otel = getattr(root, "_otel_span", None)
+        parent_ctx = otel_trace.set_span_in_context(root_otel) if root_otel else None
+
+        for span in spans:
+            usage = usage_for(span)
+            cost = cost_for(span)
+            is_generation = bool(span.get("model") or usage)
+
+            span_meta = {
+                "latency_ms": _ms(_int(span.get("start_ns")), _int(span.get("end_ns")))
+            }
+            for key in ("attempt", "ok", "status"):
+                if span.get(key) is not None:
+                    span_meta[key] = span[key]
+
+            kwargs = {"metadata": span_meta}
+            if is_generation:
+                kwargs.update(model=span.get("model"), usage_details=usage or None)
+                if cost:
+                    kwargs["cost_details"] = cost
+
+            child = new_span(
+                span["name"],
+                _int(span.get("start_ns")),
+                parent_ctx,
+                LangfuseGeneration if is_generation else LangfuseSpan,
+                **kwargs
+            )
+            if span.get("ok") is False:
+                child.update(level="ERROR", status_message="%s failed" % span["name"])
+            child.end(end_time=_int(span.get("end_ns")))
+
+        if trace_meta["outcome"] != "success":
+            root.update(level="WARNING", status_message=trace_meta["outcome"])
+        root.end(end_time=t_end)
+
+    client.flush()
+    # "submitted", not "wrote": the OTel exporter reports its own delivery
+    # failures on stderr just above this line, and we deliberately do not treat
+    # a failed delivery as our problem.
+    warn(
+        "submitted trace for issue #%s (outcome=%s, spans=%d)"
+        % (issue_number, trace_meta["outcome"], len(spans))
+    )
+
+
+def main():
+    if hasattr(signal, "SIGALRM"):
+        signal.signal(signal.SIGALRM, _bail)
+        signal.alarm(WATCHDOG_SECONDS)
+
+    if not (os.environ.get("LANGFUSE_PUBLIC_KEY") and os.environ.get("LANGFUSE_SECRET_KEY")):
+        warn("LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY not set, skipping")
+        return
+
+    try:
+        raw = json.loads(sys.stdin.read() or "{}")
+    except Exception as exc:
+        warn("could not parse stdin as JSON: %s" % exc)
+        return
+    if not isinstance(raw, dict):
+        warn("stdin was not a JSON object, skipping")
+        return
+
+    try:
+        emit(raw)
+    except ImportError as exc:
+        warn("langfuse SDK not installed (%s), skipping" % exc)
+    except Exception as exc:
+        # Unreachable host, auth rejection, SDK change — all the same to us.
+        warn("%s: %s" % (type(exc).__name__, exc))
+
+
+if __name__ == "__main__":
+    main()
+    # Explicit: no code path may hand a nonzero status back to the coordinator.
+    sys.exit(0)


### PR DESCRIPTION
## Summary
- add sanitized per-run metadata artifacts under /home/agent/agent-run-metadata
- send model, cost, token, latency, test/build, reviewer, and PR outcome fields to Langfuse
- document self-hosted Langfuse env setup for the VPS
- pin privacy/baseline invariants in coordinator tests

## Verification
- bash -n agent-coordinator.sh
- python3 -c 'p="scripts/langfuse_trace.py"; compile(open(p).read(), p, "exec")'
- npm test -- --runTestsByPath __tests__/schools.test.ts
- npm test
- npm run build

## Privacy
The trace writer whitelists metadata only. It does not send prompts, diffs, file contents, agent output, issue bodies, or private roadmap material.