### PR TITLE
Automate VPS coordinator self-update

### DIFF
--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -182,6 +182,15 @@ describe('agent-coordinator.sh PR flow', () => {
     expect(coordinatorSource).toContain('maybe_self_update_or_exit')
   })
 
+  it('treats provider or billing outages as provider-unavailable, not failed implementation', () => {
+    expect(coordinatorSource).toContain('claude_provider_unavailable()')
+    expect(coordinatorSource).toContain('credit balance|usage limit|rate limit|overloaded|temporarily unavailable|api_error')
+    expect(coordinatorSource).toContain('OUTCOME="provider-unavailable"')
+    expect(coordinatorSource).toContain('github_label "$ISSUE_NUMBER" "$TRIGGER_LABEL"')
+    expect(coordinatorSource).toContain('return 75')
+    expect(coordinatorSource).toContain('Provider halt: sleeping 10 minutes before retrying.')
+  })
+
   it('records the baseline fields needed before model routing', () => {
     for (const field of ['test_result', 'build_result', 'reviewer_result', 'pr_outcome']) {
       expect(coordinatorSource).toContain(field)

--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -87,7 +87,7 @@ describe('parseIssueCommand', () => {
 // The coordinator no longer deploys from the VPS (Vercel deploys from main).
 // It runs the agent on a branch, verifies objectively, and opens a PR for
 // human review. These tests pin that contract so a regression can't quietly
-// reintroduce self-merge-to-main or VPS deploy steps.
+// reintroduce self-merge-to-main or app deploy steps.
 
 describe('agent-coordinator.sh PR flow', () => {
   const coordinatorSource = fs.readFileSync(path.join(__dirname, '../agent-coordinator.sh'), 'utf-8')
@@ -98,12 +98,12 @@ describe('agent-coordinator.sh PR flow', () => {
     expect(coordinatorSource).toContain('TRIGGER_LABEL="agent-ok"')
   })
 
-  it('does NOT reference pm2 (VPS deploy retired; Vercel deploys from main)', () => {
-    expect(coordinatorSource).not.toMatch(/pm2/)
+  it('does NOT manage the app with pm2 (Vercel deploys the app from main)', () => {
+    expect(coordinatorSource).not.toMatch(/pm2\s+(start|restart|reload|delete)\s+(hs-navigator|admitday|next|npm)/)
   })
 
   it('never merges or pushes to main — it opens a PR for review instead', () => {
-    expect(coordinatorSource).not.toMatch(/git merge/)
+    expect(coordinatorSource).not.toMatch(/git merge(\s|$)/)
     expect(coordinatorSource).not.toMatch(/git push origin main\b/)
   })
 
@@ -169,6 +169,17 @@ describe('agent-coordinator.sh PR flow', () => {
   it('uses the dedicated agent observability venv for Langfuse emission when present', () => {
     expect(coordinatorSource).toContain('LF_TRACE_PYTHON="${LF_TRACE_PYTHON:-/home/agent/.venvs/agent-observability/bin/python}"')
     expect(coordinatorSource).toContain('timeout 30 "$LF_TRACE_PYTHON" "$LF_TRACE_SCRIPT"')
+  })
+
+  it('self-updates from origin/main only while idle on main', () => {
+    expect(coordinatorSource).toContain('SELF_UPDATE_INTERVAL_SECONDS="${SELF_UPDATE_INTERVAL_SECONDS:-300}"')
+    expect(coordinatorSource).toContain('self_update_from_main()')
+    expect(coordinatorSource).toContain('git fetch --quiet origin main')
+    expect(coordinatorSource).toContain('git pull --ff-only --quiet origin main')
+    expect(coordinatorSource).toContain('pm2 restart agent-coordinator --update-env')
+    expect(coordinatorSource).toContain('if [ "$BRANCH" != "main" ]; then')
+    expect(coordinatorSource).toContain('git status --porcelain --untracked-files=no')
+    expect(coordinatorSource).toContain('maybe_self_update_or_exit')
   })
 
   it('records the baseline fields needed before model routing', () => {

--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -166,6 +166,11 @@ describe('agent-coordinator.sh PR flow', () => {
     expect(coordinatorSource).toContain('metadata_file')
   })
 
+  it('uses the dedicated agent observability venv for Langfuse emission when present', () => {
+    expect(coordinatorSource).toContain('LF_TRACE_PYTHON="${LF_TRACE_PYTHON:-/home/agent/.venvs/agent-observability/bin/python}"')
+    expect(coordinatorSource).toContain('timeout 30 "$LF_TRACE_PYTHON" "$LF_TRACE_SCRIPT"')
+  })
+
   it('records the baseline fields needed before model routing', () => {
     for (const field of ['test_result', 'build_result', 'reviewer_result', 'pr_outcome']) {
       expect(coordinatorSource).toContain(field)

--- a/agent-coordinator.sh
+++ b/agent-coordinator.sh
@@ -392,6 +392,32 @@ except Exception:
 "
 }
 
+claude_provider_unavailable() {
+  # claude_provider_unavailable FILE
+  # Returns 0 when the claude JSON result represents provider/billing/rate-limit
+  # unavailability rather than agent implementation failure.
+  python3 - "$1" << 'PYEOF'
+import json
+import re
+import sys
+
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+
+text = " ".join(str(data.get(k, "")) for k in ("result", "terminal_reason", "error", "message"))
+providerish = re.search(
+    r"credit balance|usage limit|rate limit|overloaded|temporarily unavailable|api_error",
+    text,
+    re.I,
+)
+status = data.get("api_error_status")
+is_api_error = data.get("is_error") is True and (status is not None or data.get("terminal_reason") == "api_error")
+sys.exit(0 if is_api_error and providerish else 1)
+PYEOF
+}
+
 # Coordinator-owned verification: the ONLY success signal.
 # This VPS has <600MB free disk and Next's webpack filesystem cache alone is
 # ~400MB, so: wipe .next before building and keep pruning .next/cache while
@@ -768,6 +794,21 @@ Instructions:
     fi
     [ -z "$SESSION_ID" ] && SESSION_ID=$(claude_json_field "$CLAUDE_OUT" "session_id")
 
+    if [ $RC -ne 0 ] && claude_provider_unavailable "$CLAUDE_OUT"; then
+      OUTCOME="provider-unavailable"; GH_LABEL="$TRIGGER_LABEL"; PR_OUTCOME="not-attempted"
+      log "Issue #${ISSUE_NUMBER}: provider unavailable (billing, rate limit, or API outage). Work was never attempted; restoring the issue to the queue."
+      github_label "$ISSUE_NUMBER" "$TRIGGER_LABEL"
+      github_remove_label "$ISSUE_NUMBER" "in-progress"
+      cd "$APP_DIR"
+      git checkout main >> "$LOG_FILE" 2>&1
+      git branch -D "$BRANCH" 2>/dev/null
+      lf_emit "$ISSUE_NUMBER" "$ISSUE_TITLE" "$BRANCH" "$OUTCOME" "$ATTEMPTS_USED" \
+        "$GH_LABEL" "$RUN_START" "$(lf_now_ns)" "$TEST_RESULT" "$BUILD_RESULT" \
+        "$REVIEWER_RESULT" "$PR_OUTCOME"
+      rm -f "$CLAUDE_OUT" "$VERIFY_OUT"
+      return 75
+    fi
+
     FAIL_REASON=""
     # Objective verification by the coordinator — the only success signal.
     if [ $RC -eq 0 ] && verify_app "$VERIFY_OUT"; then
@@ -961,9 +1002,21 @@ except Exception:
     pass
 ")
 
+  BILLING_HALT=0
   for NUMBER in $ISSUE_NUMBERS; do
     run_agent "$NUMBER"
+    RUN_AGENT_RC=$?
+    if [ "$RUN_AGENT_RC" -eq 75 ]; then
+      BILLING_HALT=1
+      log "Provider halt: leaving the rest of the queue untouched. Re-checking later."
+      break
+    fi
   done
 
-  sleep 60
+  if [ "$BILLING_HALT" -eq 1 ]; then
+    log "Provider halt: sleeping 10 minutes before retrying."
+    sleep 600
+  else
+    sleep 60
+  fi
 done

--- a/agent-coordinator.sh
+++ b/agent-coordinator.sh
@@ -29,9 +29,77 @@ LF_TRACE_SCRIPT="${APP_DIR}/scripts/langfuse_trace.py"
 LF_TRACE_PYTHON="${LF_TRACE_PYTHON:-/home/agent/.venvs/agent-observability/bin/python}"
 RUN_METADATA_DIR="/home/agent/agent-run-metadata"
 LF_RUN_FILE=""
+SELF_UPDATE_INTERVAL_SECONDS="${SELF_UPDATE_INTERVAL_SECONDS:-300}"
+SELF_UPDATE_STAMP="/tmp/agent-coordinator-self-update.last"
+SELF_UPDATE_LOCK="/tmp/agent-coordinator-self-update.lock"
 
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+self_update_from_main() {
+  local NOW LAST
+  NOW=$(date +%s)
+  LAST=$(cat "$SELF_UPDATE_STAMP" 2>/dev/null || echo 0)
+  if [ $((NOW - LAST)) -lt "$SELF_UPDATE_INTERVAL_SECONDS" ]; then
+    return 0
+  fi
+  echo "$NOW" > "$SELF_UPDATE_STAMP" 2>/dev/null || true
+
+  (
+    flock -n 9 || exit 0
+    cd "$APP_DIR" || exit 0
+
+    local BRANCH
+    BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+    if [ "$BRANCH" != "main" ]; then
+      log "Self-update: on ${BRANCH:-unknown}, skipping until coordinator is idle on main"
+      exit 0
+    fi
+
+    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+      log "Self-update: tracked local changes present, skipping pull"
+      exit 0
+    fi
+
+    if ! git fetch --quiet origin main >> "$LOG_FILE" 2>&1; then
+      log "Self-update: fetch failed"
+      exit 0
+    fi
+
+    local LOCAL_SHA REMOTE_SHA BASE_SHA
+    LOCAL_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+    REMOTE_SHA=$(git rev-parse origin/main 2>/dev/null || echo "")
+    [ -n "$LOCAL_SHA" ] && [ "$LOCAL_SHA" = "$REMOTE_SHA" ] && exit 0
+
+    BASE_SHA=$(git merge-base HEAD origin/main 2>/dev/null || echo "")
+    if [ "$BASE_SHA" != "$LOCAL_SHA" ]; then
+      log "Self-update: local main diverged from origin/main, skipping pull"
+      exit 0
+    fi
+
+    log "Self-update: fast-forwarding main from ${LOCAL_SHA:0:7} to ${REMOTE_SHA:0:7}"
+    if ! git pull --ff-only --quiet origin main >> "$LOG_FILE" 2>&1; then
+      log "Self-update: fast-forward pull failed"
+      exit 0
+    fi
+
+    log "Self-update: pulled latest main, restarting coordinator under PM2"
+    (sleep 1; pm2 restart agent-coordinator --update-env >> "$LOG_FILE" 2>&1) &
+    exit 42
+  ) 9>"$SELF_UPDATE_LOCK"
+
+  local UPDATE_RC=$?
+  [ "$UPDATE_RC" -eq 42 ] && return 42
+  return 0
+}
+
+maybe_self_update_or_exit() {
+  self_update_from_main
+  local UPDATE_RC=$?
+  if [ "$UPDATE_RC" -eq 42 ]; then
+    exit 0
+  fi
 }
 
 # --- Langfuse instrumentation -------------------------------------------------
@@ -859,6 +927,7 @@ ${FAIL_OUTPUT}
 }
 
 log "Coordinator started"
+maybe_self_update_or_exit
 
 # Write a notify helper the inner agent can call to send Telegram updates
 cat > /home/agent/notify.sh << 'NOTIFY'
@@ -874,6 +943,7 @@ chmod +x /home/agent/notify.sh
 telegram "Coordinator started, watching for ${TRIGGER_LABEL} issues (PR flow — never pushes to main). Commands: /issue <title>, /goal <goal>"
 
 while true; do
+  maybe_self_update_or_exit
   handle_telegram_commands
 
   ISSUE_NUMBERS=$(curl -sL \

--- a/agent-coordinator.sh
+++ b/agent-coordinator.sh
@@ -26,6 +26,7 @@ LESSONS_FILE="/home/agent/app/LESSONS.md"
 TRIGGER_LABEL="agent-ok"
 CLAUDE_TIMEOUT=1800
 LF_TRACE_SCRIPT="${APP_DIR}/scripts/langfuse_trace.py"
+LF_TRACE_PYTHON="${LF_TRACE_PYTHON:-/home/agent/.venvs/agent-observability/bin/python}"
 RUN_METADATA_DIR="/home/agent/agent-run-metadata"
 LF_RUN_FILE=""
 
@@ -119,13 +120,16 @@ lf_emit() {
     rm -f "$RUN_FILE"
     return 0
   fi
+  if [ ! -x "$LF_TRACE_PYTHON" ]; then
+    LF_TRACE_PYTHON="python3"
+  fi
 
   LF_ISSUE="$1" LF_TITLE="$2" LF_BRANCH="$3" LF_OUTCOME="$4" LF_ATTEMPTS="$5" \
   LF_LABEL="$6" LF_TSTART="$7" LF_TEND="$8" LF_SPANS="$RUN_FILE" \
   LF_TEST_RESULT="$9" LF_BUILD_RESULT="${10}" LF_REVIEWER_RESULT="${11}" \
   LF_PR_OUTCOME="${12}" LF_METADATA_DIR="$RUN_METADATA_DIR" \
   GITHUB_REPO="$GITHUB_REPO" \
-  python3 << 'PYEOF' 2>> "$LOG_FILE" | timeout 30 python3 "$LF_TRACE_SCRIPT" 2>> "$LOG_FILE"
+  python3 << 'PYEOF' 2>> "$LOG_FILE" | timeout 30 "$LF_TRACE_PYTHON" "$LF_TRACE_SCRIPT" 2>> "$LOG_FILE"
 import json, os
 
 spans = []


### PR DESCRIPTION
## Summary\n- let the coordinator prefer /home/agent/.venvs/agent-observability/bin/python for Langfuse emission\n- add idle self-update from origin/main on startup and every 5 minutes\n- fast-forward only when the checkout is on main with no tracked local changes\n- restart agent-coordinator under PM2 after a successful self-update\n- classify Claude provider/billing/rate-limit outages as provider-unavailable, restore agent-ok, and pause the queue instead of marking implementation failure\n- cover the behavior in the coordinator contract tests\n\n## Tests\n- bash -n agent-coordinator.sh\n- npm test -- --runTestsByPath __tests__/schools.test.ts\n\n## Note\nVercel preview is expected to fail on unsigned branch commits in this project; production deploys from GitHub-verified main merge commits.