### PR TITLE
Cap Claude coordinator spend

### DIFF
--- a/.env.agents.example
+++ b/.env.agents.example
@@ -40,3 +40,21 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # Optional: seconds before the trace writer gives up and exits (default 20).
 # A dead or slow Langfuse can never cost a run more than this.
 # LANGFUSE_TRACE_TIMEOUT=20
+
+# --- Claude API cost controls ---
+# These keep the coordinator on the Anthropic/Claude API while making spend
+# explicit. Models use Claude CLI aliases. Max budgets cap each individual
+# Claude CLI call; they are not a daily/monthly billing cap.
+#
+# Recommended baseline after the August spend review: Sonnet for every phase,
+# with small per-call caps. A normal issue can use up to two implementation
+# attempts plus review and retrospective, so the default ceiling is roughly
+# $5 per issue before any external provider/billing halt.
+CLAUDE_IMPLEMENT_MODEL=sonnet
+CLAUDE_REVIEW_MODEL=sonnet
+CLAUDE_PLANNER_MODEL=sonnet
+CLAUDE_RETRO_MODEL=sonnet
+CLAUDE_IMPLEMENT_MAX_USD=2.00
+CLAUDE_REVIEW_MAX_USD=0.75
+CLAUDE_PLANNER_MAX_USD=0.50
+CLAUDE_RETRO_MAX_USD=0.25

--- a/__tests__/schools.test.ts
+++ b/__tests__/schools.test.ts
@@ -191,6 +191,31 @@ describe('agent-coordinator.sh PR flow', () => {
     expect(coordinatorSource).toContain('Provider halt: sleeping 10 minutes before retrying.')
   })
 
+  it('keeps Claude API but caps cost and chooses models per coordinator phase', () => {
+    for (const setting of [
+      'CLAUDE_IMPLEMENT_MODEL="${CLAUDE_IMPLEMENT_MODEL:-sonnet}"',
+      'CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-sonnet}"',
+      'CLAUDE_PLANNER_MODEL="${CLAUDE_PLANNER_MODEL:-sonnet}"',
+      'CLAUDE_RETRO_MODEL="${CLAUDE_RETRO_MODEL:-sonnet}"',
+      'CLAUDE_IMPLEMENT_MAX_USD="${CLAUDE_IMPLEMENT_MAX_USD:-2.00}"',
+      'CLAUDE_REVIEW_MAX_USD="${CLAUDE_REVIEW_MAX_USD:-0.75}"',
+      'CLAUDE_PLANNER_MAX_USD="${CLAUDE_PLANNER_MAX_USD:-0.50}"',
+      'CLAUDE_RETRO_MAX_USD="${CLAUDE_RETRO_MAX_USD:-0.25}"',
+      '--model "$MODEL"',
+      '--max-budget-usd "$MAX_BUDGET_USD"',
+      '< /dev/null',
+    ]) {
+      expect(coordinatorSource).toContain(setting)
+    }
+
+    expect(coordinatorSource).toContain('"$CLAUDE_REVIEW_MODEL" "$CLAUDE_REVIEW_MAX_USD"')
+    expect(coordinatorSource).toContain('"$CLAUDE_RETRO_MODEL" "$CLAUDE_RETRO_MAX_USD"')
+    expect(coordinatorSource).toContain('"$CLAUDE_PLANNER_MODEL" "$CLAUDE_PLANNER_MAX_USD"')
+    expect(coordinatorSource).toContain('"$CLAUDE_IMPLEMENT_MODEL" "$CLAUDE_IMPLEMENT_MAX_USD"')
+    expect(envAgentsExampleSource).toContain('CLAUDE_IMPLEMENT_MAX_USD=2.00')
+    expect(envAgentsExampleSource).toContain('Max budgets cap each individual')
+  })
+
   it('records the baseline fields needed before model routing', () => {
     for (const field of ['test_result', 'build_result', 'reviewer_result', 'pr_outcome']) {
       expect(coordinatorSource).toContain(field)

--- a/agent-coordinator.sh
+++ b/agent-coordinator.sh
@@ -25,6 +25,14 @@ OFFSET_FILE="/home/agent/.tg_offset"
 LESSONS_FILE="/home/agent/app/LESSONS.md"
 TRIGGER_LABEL="agent-ok"
 CLAUDE_TIMEOUT=1800
+CLAUDE_IMPLEMENT_MODEL="${CLAUDE_IMPLEMENT_MODEL:-sonnet}"
+CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-sonnet}"
+CLAUDE_PLANNER_MODEL="${CLAUDE_PLANNER_MODEL:-sonnet}"
+CLAUDE_RETRO_MODEL="${CLAUDE_RETRO_MODEL:-sonnet}"
+CLAUDE_IMPLEMENT_MAX_USD="${CLAUDE_IMPLEMENT_MAX_USD:-2.00}"
+CLAUDE_REVIEW_MAX_USD="${CLAUDE_REVIEW_MAX_USD:-0.75}"
+CLAUDE_PLANNER_MAX_USD="${CLAUDE_PLANNER_MAX_USD:-0.50}"
+CLAUDE_RETRO_MAX_USD="${CLAUDE_RETRO_MAX_USD:-0.25}"
 LF_TRACE_SCRIPT="${APP_DIR}/scripts/langfuse_trace.py"
 LF_TRACE_PYTHON="${LF_TRACE_PYTHON:-/home/agent/.venvs/agent-observability/bin/python}"
 RUN_METADATA_DIR="/home/agent/agent-run-metadata"
@@ -350,21 +358,36 @@ except Exception:
 }
 
 # Run one claude agent call with timeout, capturing the JSON result.
-# Reads the prompt from $PROMPT. run_claude OUT_FILE [RESUME_ID] [TOOLS]
+# Reads the prompt from $PROMPT.
+# run_claude OUT_FILE [RESUME_ID] [TOOLS] [MODEL] [MAX_BUDGET_USD]
 # Returns: 0 on success, 124 on timeout, 1 on any other error.
 run_claude() {
   local OUT_FILE="$1"
   local RESUME_ID="$2"
   local TOOLS="${3:-Bash,Read,Write,Edit,Glob,Grep}"
+  local MODEL="${4:-}"
+  local MAX_BUDGET_USD="${5:-}"
   local RESUME_ARGS=()
+  local MODEL_ARGS=()
+  local BUDGET_ARGS=()
   if [ -n "$RESUME_ID" ]; then
     RESUME_ARGS=(--resume "$RESUME_ID")
   fi
+  if [ -n "$MODEL" ]; then
+    MODEL_ARGS=(--model "$MODEL")
+  fi
+  if [ -n "$MAX_BUDGET_USD" ]; then
+    BUDGET_ARGS=(--max-budget-usd "$MAX_BUDGET_USD")
+  fi
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Claude call: model=${MODEL:-default} max_budget_usd=${MAX_BUDGET_USD:-none} tools=${TOOLS}" >> "$LOG_FILE"
   ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" timeout "$CLAUDE_TIMEOUT" claude \
     -p "$PROMPT" \
     --output-format json \
     --allowedTools "$TOOLS" \
+    "${MODEL_ARGS[@]}" \
+    "${BUDGET_ARGS[@]}" \
     "${RESUME_ARGS[@]}" \
+    < /dev/null \
     > "$OUT_FILE" 2>> "$LOG_FILE"
   local RC=$?
   if [ $RC -eq 124 ]; then
@@ -490,7 +513,7 @@ RISK: LIVE-VERIFY-NEEDED"
   # No log() calls in this function: its stdout is the review text.
   local T0 T1
   T0=$(lf_now_ns)
-  run_claude "$REVIEW_OUT" "" "Read,Glob,Grep"
+  run_claude "$REVIEW_OUT" "" "Read,Glob,Grep" "$CLAUDE_REVIEW_MODEL" "$CLAUDE_REVIEW_MAX_USD"
   local RC=$?
   T1=$(lf_now_ns)
   local REVIEW_TEXT
@@ -552,7 +575,7 @@ Write the complete new content of LESSONS.md and nothing else (no fences, no com
 
   local T0 T1
   T0=$(lf_now_ns)
-  run_claude "$RETRO_OUT" "" "Read"
+  run_claude "$RETRO_OUT" "" "Read" "$CLAUDE_RETRO_MODEL" "$CLAUDE_RETRO_MAX_USD"
   local RC=$?
   T1=$(lf_now_ns)
   lf_record "retrospective" "$T0" "$T1" "$([ $RC -eq 0 ] && echo 1 || echo 0)" "$RETRO_OUT" ""
@@ -585,7 +608,7 @@ Output ONLY a JSON object, no markdown fences, in exactly this shape:
 {\"issues\": [{\"title\": \"...\", \"body\": \"...\"}]}
 Each body: what to change, where (file paths), and acceptance criteria."
 
-  run_claude "$PLAN_OUT" "" "Read,Glob,Grep"
+  run_claude "$PLAN_OUT" "" "Read,Glob,Grep" "$CLAUDE_PLANNER_MODEL" "$CLAUDE_PLANNER_MAX_USD"
   local RC=$?
   if [ $RC -ne 0 ]; then
     telegram "Planner failed for goal: ${GOAL}"
@@ -781,7 +804,8 @@ Instructions:
     ATTEMPTS_USED=$ATTEMPT
     local T0 T1
     T0=$(lf_now_ns)
-    run_claude "$CLAUDE_OUT" "$([ $ATTEMPT -gt 1 ] && echo "$SESSION_ID")"
+    run_claude "$CLAUDE_OUT" "$([ $ATTEMPT -gt 1 ] && echo "$SESSION_ID")" \
+      "Bash,Read,Write,Edit,Glob,Grep" "$CLAUDE_IMPLEMENT_MODEL" "$CLAUDE_IMPLEMENT_MAX_USD"
     local RC=$?
     T1=$(lf_now_ns)
     lf_record "implement" "$T0" "$T1" "$([ $RC -eq 0 ] && echo 1 || echo 0)" \


### PR DESCRIPTION
## Summary
- keep the autonomous coordinator on the existing Claude/Anthropic API path
- add phase-specific Claude model settings for implementation, review, planning, and retrospectives
- add per-call Claude CLI max-budget caps so a refilled account cannot spike unchecked
- document the VPS env knobs in .env.agents.example

## Verification
- bash -n agent-coordinator.sh
- npm test -- --runTestsByPath __tests__/schools.test.ts