### PR TITLE
Disable Vercel previews for agent branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "agent-*": false,
+      "task-*": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add vercel.json with git.deploymentEnabled disabled for agent-* and task-* branches
- keep production deployments from main enabled
- avoid repeated red Vercel preview checks for autonomous-agent branches that fail before build logs

## Verification
- node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); console.log('vercel.json ok')"