### PR TITLE
fix: issue #135 - Scrape per-program data from MySchools (module + fixtures only, no pipeline changes)

### DIFF
--- a/scripts/myschools_fixtures/laguardia_03M485.json
+++ b/scripts/myschools_fixtures/laguardia_03M485.json
@@ -1,0 +1,896 @@
+{
+  "id": 86492,
+  "name": "Fiorello H. LaGuardia High School of Music & Art and Performing Arts (03M485)",
+  "school": {
+    "name": "FIORELLO H. LAGUARDIA HIGH SCHOOL OF MUSIC & ART AND PERFORMING ARTS (03M485)",
+    "dbn": "03M485",
+    "accessibility": "Fully Accessible",
+    "magnet": false,
+    "school_year": "2025-26 School Year",
+    "district": {
+      "id": 74,
+      "borough": "Manhattan",
+      "code": "03",
+      "name": "DISTRICT 03",
+      "name_en": "DISTRICT 03",
+      "name_ar": null,
+      "name_bn": null,
+      "name_zh_hant": null,
+      "name_zh_hans": null,
+      "name_sq": null,
+      "name_fr": null,
+      "name_ht": null,
+      "name_ko": null,
+      "name_ru": null,
+      "name_es": null,
+      "name_ur": null,
+      "name_uk": null,
+      "name_uz": null,
+      "is_under_represented": true,
+      "is_in_person": true
+    },
+    "school_type": {
+      "id": 9,
+      "name": "PUBLIC"
+    },
+    "address": {
+      "id": 80690,
+      "address_1": "100 Amsterdam Avenue",
+      "address_2": "",
+      "street_number": "100",
+      "street_name": "Amsterdam Avenue",
+      "city": "Manhattan",
+      "sublocality": null,
+      "state": "NY",
+      "zip_code": "10023",
+      "country": "US",
+      "primary": false,
+      "latitude": "40.774203",
+      "longitude": "-73.985977",
+      "xcoord": null,
+      "ycoord": null,
+      "source": "('Geosupport API',)",
+      "needs_geocoding": false,
+      "last_geocoded": "2025-09-19T17:40:52.403239-04:00",
+      "gis_location": "SRID=4326;POINT (-73.98597700000001 40.774203)",
+      "created_at": "2025-09-19T17:40:52.400235-04:00",
+      "updated_at": "2025-09-19T17:40:52.403239-04:00"
+    },
+    "full_address": "100 Amsterdam Avenue, Manhattan, NY 10023",
+    "directory_school_ids": [
+      86492
+    ],
+    "accessibility_more_info": null
+  },
+  "programs": [
+    {
+      "id": 123790,
+      "directory_school_id": 86492,
+      "program": {
+        "code": "M80K",
+        "name": "Dance",
+        "admission_process": "LaGuardia",
+        "is_shs": false,
+        "is_lg": true,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": false,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "Dance (M80K)",
+      "interest_areas": [
+        {
+          "name": "Performing Arts"
+        }
+      ],
+      "admissions_method": {
+        "name": "Audition",
+        "description": "Students are ranked by the school based on their auditions. Offers are made in priority group and rank order.",
+        "name_en": "Audition",
+        "loo_contents": []
+      },
+      "description": "Dancers receive four years of challenging conservatory-style training in ballet and modern dance through block programming. Supplementary courses include: anatomy, dance history, choreography, theater dance (tap and jazz), career management, repertory, and professional skills.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": 19,
+          "seats": 85,
+          "applicants": 1585,
+          "all_seats_filled": true
+        }
+      },
+      "selection_criteria": [],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": true,
+      "seats_10th_number": null,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": "",
+      "provider_email": "",
+      "provider_phone_number": "",
+      "operating_weekdays": "",
+      "site_contact_name": "",
+      "site_contact_email": "",
+      "site_contact_phone_number": "",
+      "portfolio_id": "",
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    },
+    {
+      "id": 123797,
+      "directory_school_id": 86492,
+      "program": {
+        "code": "M80N",
+        "name": "Drama",
+        "admission_process": "LaGuardia",
+        "is_shs": false,
+        "is_lg": true,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": false,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "Drama (M80N)",
+      "interest_areas": [
+        {
+          "name": "Performing Arts"
+        }
+      ],
+      "admissions_method": {
+        "name": "Audition",
+        "description": "Students are ranked by the school based on their auditions. Offers are made in priority group and rank order.",
+        "name_en": "Audition",
+        "loo_contents": []
+      },
+      "description": "The Drama program focuses on acting preparation through block-programmed courses in acting (Meisner and Stanislavsky method), voice and diction, physical techniques, theater history, musical theater, acting on film, career management, and script analysis. Students have numerous opportunities to perform in professional theater spaces throughout their four years, culminating in our Senior Drama Festival.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": 21,
+          "seats": 87,
+          "applicants": 1852,
+          "all_seats_filled": true
+        }
+      },
+      "selection_criteria": [],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": true,
+      "seats_10th_number": null,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": "",
+      "provider_email": "",
+      "provider_phone_number": "",
+      "operating_weekdays": "",
+      "site_contact_name": "",
+      "site_contact_email": "",
+      "site_contact_phone_number": "",
+      "portfolio_id": "",
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    },
+    {
+      "id": 123787,
+      "directory_school_id": 86492,
+      "program": {
+        "code": "M80J",
+        "name": "Fine Arts",
+        "admission_process": "LaGuardia",
+        "is_shs": false,
+        "is_lg": true,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": false,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "Fine Arts (M80J)",
+      "interest_areas": [
+        {
+          "name": "Visual Art & Design"
+        }
+      ],
+      "admissions_method": {
+        "name": "Audition",
+        "description": "Students are ranked by the school based on their auditions. Offers are made in priority group and rank order.",
+        "name_en": "Audition",
+        "loo_contents": []
+      },
+      "description": "The first two years comprise of training in traditional skills and disciplines, which include drawing, painting in water-based media, graphic design, and painting in oils and acrylics. After taking the core art courses, students take advanced courses in the subjects listed and with other elective offerings such as architecture, art history, ceramics, computer graphics, digital media, fashion illustration, mural painting, photography, print making, and sculpture.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": 10,
+          "seats": 279,
+          "applicants": 2928,
+          "all_seats_filled": true
+        }
+      },
+      "selection_criteria": [],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": true,
+      "seats_10th_number": null,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": "",
+      "provider_email": "",
+      "provider_phone_number": "",
+      "operating_weekdays": "",
+      "site_contact_name": "",
+      "site_contact_email": "",
+      "site_contact_phone_number": "",
+      "portfolio_id": "",
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    },
+    {
+      "id": 123792,
+      "directory_school_id": 86492,
+      "program": {
+        "code": "M80L",
+        "name": "Instrumental Music",
+        "admission_process": "LaGuardia",
+        "is_shs": false,
+        "is_lg": true,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": false,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "Instrumental Music (M80L)",
+      "interest_areas": [
+        {
+          "name": "Performing Arts"
+        }
+      ],
+      "admissions_method": {
+        "name": "Audition",
+        "description": "Students are ranked by the school based on their auditions. Offers are made in priority group and rank order.",
+        "name_en": "Audition",
+        "loo_contents": []
+      },
+      "description": "Participants study sight singing, music theory, and music history. This studio's performing groups include four symphony orchestras, two concert bands, two jazz bands, and two musical pit orchestras. Participants also have the opportunity to compose, conduct, and perform original repertoire and utilize a state-of-the-art SoundLab recording studio.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": 6,
+          "seats": 217,
+          "applicants": 1296,
+          "all_seats_filled": true
+        }
+      },
+      "selection_criteria": [],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": true,
+      "seats_10th_number": null,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": "",
+      "provider_email": "",
+      "provider_phone_number": "",
+      "operating_weekdays": "",
+      "site_contact_name": "",
+      "site_contact_email": "",
+      "site_contact_phone_number": "",
+      "portfolio_id": "",
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    },
+    {
+      "id": 123800,
+      "directory_school_id": 86492,
+      "program": {
+        "code": "M80P",
+        "name": "Technical Theater",
+        "admission_process": "LaGuardia",
+        "is_shs": false,
+        "is_lg": true,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": false,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "Technical Theater (M80P)",
+      "interest_areas": [
+        {
+          "name": "Performing Arts"
+        }
+      ],
+      "admissions_method": {
+        "name": "Audition",
+        "description": "Students are ranked by the school based on their auditions. Offers are made in priority group and rank order.",
+        "name_en": "Audition",
+        "loo_contents": []
+      },
+      "description": "In block programs, students receive practical training in scenic carpentry, electrics, lighting technology, costume construction, sound properties, stage management, technical drawing (AutoCAD and Autodesk 3DS Max), welding, career management, and design. Students participate in both the production and performance aspects for the various school events. Students may earn transferable college credit through SUNY Potsdam.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": 14,
+          "seats": 66,
+          "applicants": 954,
+          "all_seats_filled": true
+        }
+      },
+      "selection_criteria": [],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": true,
+      "seats_10th_number": null,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": "",
+      "provider_email": "",
+      "provider_phone_number": "",
+      "operating_weekdays": "",
+      "site_contact_name": "",
+      "site_contact_email": "",
+      "site_contact_phone_number": "",
+      "portfolio_id": "",
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    },
+    {
+      "id": 123794,
+      "directory_school_id": 86492,
+      "program": {
+        "code": "M80M",
+        "name": "Vocal Music",
+        "admission_process": "LaGuardia",
+        "is_shs": false,
+        "is_lg": true,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": false,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "Vocal Music (M80M)",
+      "interest_areas": [
+        {
+          "name": "Performing Arts"
+        }
+      ],
+      "admissions_method": {
+        "name": "Audition",
+        "description": "Students are ranked by the school based on their auditions. Offers are made in priority group and rank order.",
+        "name_en": "Audition",
+        "loo_contents": []
+      },
+      "description": "Participants study sight singing, music theory, and music history. Students receive training in Italian, German, and French vocal literature. This studio's performing groups include Elementary, Mixed, Girls, Women's, and Senior Choruses; Gospel Choir; and Show Choir. In addition there is an annual full-scale opera production. Music electives include chamber music, guitar, music technology, piano, and songwriting.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": 8,
+          "seats": 201,
+          "applicants": 1706,
+          "all_seats_filled": true
+        }
+      },
+      "selection_criteria": [],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": true,
+      "seats_10th_number": null,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": "",
+      "provider_email": "",
+      "provider_phone_number": "",
+      "operating_weekdays": "",
+      "site_contact_name": "",
+      "site_contact_email": "",
+      "site_contact_phone_number": "",
+      "portfolio_id": "",
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    }
+  ],
+  "overview": "Our students complete two parallel paths of study: conservatory-level pre-professional training in the arts and college-preparatory academics; all students are equipped with post-secondary planning skills. Our alumni are creative thinkers, confident collaborators, culturally engaged innovators, and open-minded citizens. They distinguish themselves in virtually every field of endeavor. LaGuardia Arts is a large, NYC Specialized High School and the only Specialized High School that admits students based on a competitive audition and not the Specialized High School Admissions Test (SHSAT.)",
+  "grades_description": "9 to 12",
+  "academic_opportunities": [],
+  "admissions_open": false,
+  "waitlist_open": false,
+  "results_enabled": false,
+  "admission_process": "LG",
+  "ell_programs": [],
+  "language_classes": [],
+  "advanced_placement_courses": [
+    {
+      "name": "Algebra II (Advanced Math)"
+    },
+    {
+      "name": "AP Biology"
+    },
+    {
+      "name": "AP Calculus AB"
+    },
+    {
+      "name": "AP Calculus BC"
+    },
+    {
+      "name": "AP Chemistry"
+    },
+    {
+      "name": "AP Chinese Language and Culture"
+    },
+    {
+      "name": "AP Comparative Government and Politics"
+    },
+    {
+      "name": "AP Computer Science Principles"
+    },
+    {
+      "name": "AP English Language and Composition"
+    },
+    {
+      "name": "AP English Literature and Composition"
+    },
+    {
+      "name": "AP Environmental Science"
+    },
+    {
+      "name": "AP French Language and Culture"
+    },
+    {
+      "name": "AP Italian Language and Culture"
+    },
+    {
+      "name": "AP Japanese Language and Culture"
+    },
+    {
+      "name": "AP Physics 1"
+    },
+    {
+      "name": "AP Psychology"
+    },
+    {
+      "name": "AP Spanish Language and Culture"
+    },
+    {
+      "name": "AP Statistics"
+    },
+    {
+      "name": "AP United States Government and Politics"
+    },
+    {
+      "name": "AP United States History"
+    },
+    {
+      "name": "AP World History: Modern"
+    },
+    {
+      "name": "Calculus (Advanced Math)"
+    },
+    {
+      "name": "Chemistry (Advanced Science)"
+    },
+    {
+      "name": "Physics (Advanced Science)"
+    },
+    {
+      "name": "World Languages (Advanced World Languages)"
+    }
+  ],
+  "art_courses": [
+    {
+      "name": "Traditional and Studio Art"
+    },
+    {
+      "name": "Digital Media Arts"
+    },
+    {
+      "name": "Design and Applied Arts"
+    },
+    {
+      "name": "Art History"
+    },
+    {
+      "name": "Theater Production"
+    },
+    {
+      "name": "Theater Making/Performance"
+    },
+    {
+      "name": "Theater Literacy"
+    },
+    {
+      "name": "Theater Design"
+    },
+    {
+      "name": "General Theater"
+    },
+    {
+      "name": "Orchestra/Strings"
+    },
+    {
+      "name": "Music Industry & Contemporary Music"
+    },
+    {
+      "name": "Exploring Music"
+    },
+    {
+      "name": "Chorus/Singing"
+    },
+    {
+      "name": "Dance Techniques and Performance"
+    },
+    {
+      "name": "Dance Foundations and History"
+    },
+    {
+      "name": "Dance Careers and Production"
+    },
+    {
+      "name": "Choreographic Practices"
+    }
+  ],
+  "diploma_endorsements": [],
+  "other_features": [
+    {
+      "name": "10th Grade Seats Available"
+    },
+    {
+      "name": "Career and Technical Education (CTE)"
+    },
+    {
+      "name": "Computer Science Coursework"
+    },
+    {
+      "name": "Expert College and Career Advisor On Staff"
+    },
+    {
+      "name": "Financial Literacy Coursework"
+    },
+    {
+      "name": "Online Grading System"
+    }
+  ],
+  "affiliated_schools": [],
+  "instruction_and_performance_rating": {
+    "label": "Excellent",
+    "score": 4
+  },
+  "safety_and_school_climate_rating": {
+    "label": "Good",
+    "score": 3
+  },
+  "relationships_with_families_rating": {
+    "label": "Fair",
+    "score": 2
+  },
+  "performance_labels": {
+    "instruction_and_performance_label": "Instruction and Performance",
+    "safety_and_school_climate_label": "Safety and School Climate",
+    "relationships_with_families_label": "Relationships with Families",
+    "school_quality_snapshot_html": "<a target=\"_blank\" rel=\"noopener\" href=\"https://tools.nycenet.edu/snapshot/0/03M485/HS/?utm_source=myschools.nyc&utm_medium=DOE_App_referral&utm_campaign=MySchools\">See the School Quality Snapshot</a>."
+  },
+  "stat_graduation": 98,
+  "stat_enroll_college_career": 82,
+  "stat_attendance": null,
+  "stat_safety": 91,
+  "stat_variety": 92,
+  "subway": "",
+  "subway_line": [
+    {
+      "name": "1",
+      "color": "#EE352E"
+    },
+    {
+      "name": "2",
+      "color": "#EE352E"
+    },
+    {
+      "name": "3",
+      "color": "#EE352E"
+    },
+    {
+      "name": "A",
+      "color": "#0039A6"
+    },
+    {
+      "name": "B",
+      "color": "#FF6319"
+    },
+    {
+      "name": "C",
+      "color": "#0039A6"
+    },
+    {
+      "name": "D",
+      "color": "#FF6319"
+    }
+  ],
+  "bus": "",
+  "shared_space": false,
+  "building_code": "M485",
+  "email": "admissions@laguardiahs.org",
+  "telephone": "212-496-0700",
+  "independent_website": "https://www.laguardiahs.org/",
+  "secondary_website": "https://tools.nycenet.edu/snapshot/0/03M485/HS/?utm_source=myschools.nyc&utm_medium=DOE_App_referral&utm_campaign=MySchools",
+  "start_time": "08:00am",
+  "end_time": "03:35pm",
+  "uniform": false,
+  "open_house_information": "",
+  "bap_url": "https://nycdoe.sharepoint.com/:w:/s/BAP/EUK_AyOEEsFCrcponBYEmhkB7rEKTt38JfnZrbS1Yld9Iw",
+  "total_enrollment": "2717",
+  "enrollment_range": "2,000+",
+  "eligibility": [
+    {
+      "name": "10th Grade Seats Available",
+      "name_en": "10th Grade Seats Available"
+    }
+  ],
+  "activities": [],
+  "sports_boys": [
+    {
+      "name": "Baseball"
+    },
+    {
+      "name": "Basketball"
+    },
+    {
+      "name": "Cross Country"
+    },
+    {
+      "name": "Fencing"
+    },
+    {
+      "name": "Gymnastics"
+    },
+    {
+      "name": "Indoor Track"
+    },
+    {
+      "name": "Outdoor Track"
+    },
+    {
+      "name": "Soccer"
+    },
+    {
+      "name": "Volleyball"
+    }
+  ],
+  "sports_girls": [
+    {
+      "name": "Basketball"
+    },
+    {
+      "name": "Bowling"
+    },
+    {
+      "name": "Cross Country"
+    },
+    {
+      "name": "Fencing"
+    },
+    {
+      "name": "Handball"
+    },
+    {
+      "name": "Indoor Track"
+    },
+    {
+      "name": "Outdoor Track"
+    },
+    {
+      "name": "Soccer"
+    },
+    {
+      "name": "Softball"
+    },
+    {
+      "name": "Swimming"
+    },
+    {
+      "name": "Volleyball"
+    }
+  ],
+  "sports_coed": [],
+  "school_sports": [
+    {
+      "name": "Cheerleading"
+    },
+    {
+      "name": "Dance"
+    },
+    {
+      "name": "Step"
+    },
+    {
+      "name": "Ultimate Frisbee"
+    }
+  ],
+  "sports_description": "Cheerleading, Dance, Step, Ultimate Frisbee",
+  "meals": [],
+  "electives_description": "",
+  "activities_description": "Clubs are student-generated at the beginning of each school year.  The 2023-20234 club offerings include: A-List Step Team,  Aro-spec,  Art for the Heart,  Black Student Union,  Ceramics,  Character Creation, Chinese Student Association,  Choral Intertwine,  Christian Students Association,  Cosplay,  Debate,  DECA, Disney VoluntEARS Mentoring Program,  Fashion,  Green Team,  ,Gender Sexuality Alliance (GSA), Italian Culture , Japanese , Jazz Vocal , Jewish Student Union, Key Club, Latinos Unidos, Math Empowerment , Mock Trial, Model United Nations , Neuroscience , Red Cross, Slavic , South Asian Association, Stock Market Analysis , Students for Planned Parenthood,  UNICEF,  and Unity Dance Crew.",
+  "contact_name": "",
+  "stat_core_courses": null,
+  "stat_state_ela": null,
+  "stat_state_math": null,
+  "frequently_attended_hs": [],
+  "diversity_in_admissions": "",
+  "stat_parents_satisfaction": null,
+  "virtual_learning": "",
+  "co_located_schools": [],
+  "classification": [],
+  "class_program_ratio": [],
+  "bridge": [],
+  "assessment_type": [],
+  "distance": null,
+  "switches": {
+    "show_GE_SWD_toggle_on_application_program_admissions": true,
+    "show_GE_SWD_toggle_on_public_program_admissions": true
+  }
+}

--- a/scripts/myschools_fixtures/malformed_missing_programs.json
+++ b/scripts/myschools_fixtures/malformed_missing_programs.json
@@ -1,0 +1,275 @@
+{
+  "id": 88733,
+  "name": "Malformed Fixture School (99X999)",
+  "school": {
+    "name": "47 THE AMERICAN SIGN LANGUAGE AND ENGLISH SECONDARY SCHOOL (02M047)",
+    "dbn": "99X999",
+    "accessibility": "Fully Accessible",
+    "magnet": false,
+    "school_year": "2025-26 School Year",
+    "district": {
+      "id": 73,
+      "borough": "Manhattan",
+      "code": "02",
+      "name": "DISTRICT 02",
+      "name_en": "DISTRICT 02",
+      "name_ar": null,
+      "name_bn": null,
+      "name_zh_hant": null,
+      "name_zh_hans": null,
+      "name_sq": null,
+      "name_fr": null,
+      "name_ht": null,
+      "name_ko": null,
+      "name_ru": null,
+      "name_es": null,
+      "name_ur": null,
+      "name_uk": null,
+      "name_uz": null,
+      "is_under_represented": false,
+      "is_in_person": true
+    },
+    "school_type": {
+      "id": 9,
+      "name": "PUBLIC"
+    },
+    "address": {
+      "id": 82496,
+      "address_1": "223 East 23 Street",
+      "address_2": "",
+      "street_number": "223",
+      "street_name": "East 23 Street",
+      "city": "Manhattan",
+      "sublocality": null,
+      "state": "NY",
+      "zip_code": "10010",
+      "country": "US",
+      "primary": false,
+      "latitude": "40.738482",
+      "longitude": "-73.981358",
+      "xcoord": null,
+      "ycoord": null,
+      "source": "('Geosupport API',)",
+      "needs_geocoding": false,
+      "last_geocoded": "2025-09-30T13:45:44.327311-04:00",
+      "gis_location": "SRID=4326;POINT (-73.981358 40.738482)",
+      "created_at": "2025-09-19T17:43:40.078930-04:00",
+      "updated_at": "2025-09-30T13:45:44.327311-04:00"
+    },
+    "full_address": "223 East 23 Street, Manhattan, NY 10010",
+    "directory_school_ids": [
+      88733
+    ],
+    "accessibility_more_info": null
+  },
+  "overview": "At \"47\" the American Sign Language and English High School, we believe that all students have the right to learn in an inclusive, academically rigorous environment. Our graduates emerge proficient in American Sign Language (ASL). Our small school community nurtures responsible citizens of the world, addressing all aspects of young adult development by providing the necessary individual supports for our students to be college and career ready.",
+  "grades_description": "9 to 12",
+  "academic_opportunities": [],
+  "admissions_open": false,
+  "waitlist_open": false,
+  "results_enabled": true,
+  "admission_process": "HS",
+  "ell_programs": [],
+  "language_classes": [
+    {
+      "name": "American Sign Language"
+    }
+  ],
+  "advanced_placement_courses": [
+    {
+      "name": "Algebra II (Advanced Math)"
+    },
+    {
+      "name": "AP Biology"
+    },
+    {
+      "name": "AP Calculus AB"
+    },
+    {
+      "name": "AP English Language and Composition"
+    },
+    {
+      "name": "AP English Literature and Composition"
+    },
+    {
+      "name": "AP Human Geography"
+    },
+    {
+      "name": "AP Psychology"
+    },
+    {
+      "name": "AP Statistics"
+    },
+    {
+      "name": "AP United States History"
+    },
+    {
+      "name": "AP World History: Modern"
+    },
+    {
+      "name": "Physics (Advanced Science)"
+    },
+    {
+      "name": "World Languages (Advanced World Languages)"
+    }
+  ],
+  "art_courses": [
+    {
+      "name": "Traditional and Studio Art"
+    }
+  ],
+  "diploma_endorsements": [],
+  "other_features": [
+    {
+      "name": "10th Grade Seats Available"
+    },
+    {
+      "name": "College Courses Offered"
+    },
+    {
+      "name": "College Trips"
+    },
+    {
+      "name": "Community School"
+    },
+    {
+      "name": "Internships Available"
+    },
+    {
+      "name": "Online Grading System"
+    },
+    {
+      "name": "Orientation"
+    },
+    {
+      "name": "Program(s) with 1 GE Applicant Per Seat"
+    },
+    {
+      "name": "Student Parent Orientation"
+    },
+    {
+      "name": "Summer Orientation"
+    }
+  ],
+  "affiliated_schools": [],
+  "instruction_and_performance_rating": {
+    "label": "Excellent",
+    "score": 4
+  },
+  "safety_and_school_climate_rating": {
+    "label": "Fair",
+    "score": 2
+  },
+  "relationships_with_families_rating": {
+    "label": "Excellent",
+    "score": 4
+  },
+  "performance_labels": {
+    "instruction_and_performance_label": "Instruction and Performance",
+    "safety_and_school_climate_label": "Safety and School Climate",
+    "relationships_with_families_label": "Relationships with Families",
+    "school_quality_snapshot_html": "<a target=\"_blank\" rel=\"noopener\" href=\"https://tools.nycenet.edu/snapshot/0/02M047/HS/?utm_source=myschools.nyc&utm_medium=DOE_App_referral&utm_campaign=MySchools\">See the School Quality Snapshot</a>."
+  },
+  "stat_graduation": 100,
+  "stat_enroll_college_career": 83,
+  "stat_attendance": null,
+  "stat_safety": 89,
+  "stat_variety": 64,
+  "subway": "6 to 23rd St; L to 3rd Av",
+  "subway_line": [
+    {
+      "name": "6",
+      "color": "#00933C"
+    },
+    {
+      "name": "L",
+      "color": "#A7A9AC"
+    },
+    {
+      "name": "R",
+      "color": "#FCCC0A"
+    },
+    {
+      "name": "W",
+      "color": "#FCCC0A"
+    }
+  ],
+  "bus": "BM1, BM2, BM3, BM4, BxM1, BxM10, BxM11, BxM18, BxM3, BxM4, BxM6, BxM7, BxM8, BxM9, M1, M101, M102, M103, M14A-SBS, M14D-SBS, M15, M15-SBS, M2, M23-SBS, M3, M34-SBS, M34A-SBS, M55, M9, QM21, QM63, QM64, QM68, SIM10, SIM11, SIM1C, SIM3, SIM31, SIM33C, SIM3C, SIM4C, SIM6, X27, X28, X37, X38",
+  "shared_space": true,
+  "building_code": "M047",
+  "email": "wshama@schools.nyc.gov",
+  "telephone": "917-326-6668",
+  "independent_website": "https://www.47aslhs.net/",
+  "secondary_website": "https://tools.nycenet.edu/snapshot/0/02M047/HS/?utm_source=myschools.nyc&utm_medium=DOE_App_referral&utm_campaign=MySchools",
+  "start_time": "08:25am",
+  "end_time": "02:45pm",
+  "uniform": false,
+  "open_house_information": "",
+  "bap_url": "https://nycdoe.sharepoint.com/:w:/s/BAP/Efc3Gdn6whBNigKZR4Ydre8BSyAE96jcoWJnQeIPzPi1bg",
+  "total_enrollment": "222",
+  "enrollment_range": "0-499",
+  "eligibility": [
+    {
+      "name": "10th Grade Seats Available",
+      "name_en": "10th Grade Seats Available"
+    }
+  ],
+  "activities": [],
+  "sports_boys": [
+    {
+      "name": "Basketball"
+    },
+    {
+      "name": "Outdoor Track"
+    },
+    {
+      "name": "Soccer"
+    }
+  ],
+  "sports_girls": [
+    {
+      "name": "Outdoor Track"
+    },
+    {
+      "name": "Volleyball"
+    }
+  ],
+  "sports_coed": [
+    {
+      "name": "Stunt"
+    }
+  ],
+  "school_sports": [
+    {
+      "name": "Cheerleading"
+    },
+    {
+      "name": "Fitness"
+    },
+    {
+      "name": "Soccer"
+    }
+  ],
+  "sports_description": "Cheerleading, Fitness, Soccer",
+  "meals": [],
+  "electives_description": "",
+  "activities_description": "Anime, Boardgames, Crochet, Dungeons and Dragons, Fashion, Fitness,Gender Sexuality Alliance (GSA), Literary Magazine, National Honor Society, Performing Arts, Student Equity,  and Student Government",
+  "contact_name": "",
+  "stat_core_courses": null,
+  "stat_state_ela": null,
+  "stat_state_math": null,
+  "frequently_attended_hs": [],
+  "diversity_in_admissions": "",
+  "stat_parents_satisfaction": null,
+  "virtual_learning": "",
+  "co_located_schools": [],
+  "classification": [],
+  "class_program_ratio": [],
+  "bridge": [],
+  "assessment_type": [],
+  "distance": null,
+  "switches": {
+    "show_GE_SWD_toggle_on_application_program_admissions": true,
+    "show_GE_SWD_toggle_on_public_program_admissions": true
+  }
+}

--- a/scripts/myschools_fixtures/mixed_methods_gramercy_02M374.json
+++ b/scripts/myschools_fixtures/mixed_methods_gramercy_02M374.json
@@ -1,0 +1,668 @@
+{
+  "id": 93437,
+  "name": "Gramercy Arts High School (02M374)",
+  "school": {
+    "name": "GRAMERCY ARTS HIGH SCHOOL (02M374)",
+    "dbn": "02M374",
+    "accessibility": "Partially Accessible",
+    "magnet": false,
+    "school_year": "2025-26 School Year",
+    "district": {
+      "id": 73,
+      "borough": "Manhattan",
+      "code": "02",
+      "name": "DISTRICT 02",
+      "name_en": "DISTRICT 02",
+      "name_ar": null,
+      "name_bn": null,
+      "name_zh_hant": null,
+      "name_zh_hans": null,
+      "name_sq": null,
+      "name_fr": null,
+      "name_ht": null,
+      "name_ko": null,
+      "name_ru": null,
+      "name_es": null,
+      "name_ur": null,
+      "name_uk": null,
+      "name_uz": null,
+      "is_under_represented": false,
+      "is_in_person": true
+    },
+    "school_type": {
+      "id": 9,
+      "name": "PUBLIC"
+    },
+    "address": {
+      "id": 87695,
+      "address_1": "40 Irving Place",
+      "address_2": "",
+      "street_number": "40",
+      "street_name": "Irving Place",
+      "city": "Manhattan",
+      "sublocality": null,
+      "state": "NY",
+      "zip_code": "10003",
+      "country": "US",
+      "primary": false,
+      "latitude": "40.735326",
+      "longitude": "-73.987089",
+      "xcoord": null,
+      "ycoord": null,
+      "source": "('Geosupport API',)",
+      "needs_geocoding": false,
+      "last_geocoded": "2025-09-30T13:45:50.022438-04:00",
+      "gis_location": "SRID=4326;POINT (-73.987089 40.735326)",
+      "created_at": "2025-09-19T17:54:43.187672-04:00",
+      "updated_at": "2025-09-30T13:45:50.022438-04:00"
+    },
+    "full_address": "40 Irving Place, Manhattan, NY 10003",
+    "directory_school_ids": [
+      93437
+    ],
+    "accessibility_more_info": null
+  },
+  "programs": [
+    {
+      "id": 123732,
+      "directory_school_id": 93437,
+      "program": {
+        "code": "M66I",
+        "name": "Capstone Scholars",
+        "admission_process": "High School",
+        "is_shs": false,
+        "is_lg": false,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": true,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "Capstone Scholars (M66I)",
+      "interest_areas": [
+        {
+          "name": "Performing Arts/Visual Art & Design"
+        }
+      ],
+      "admissions_method": {
+        "name": "Screened With Assessment",
+        "description": "Students are admitted based on a school-based assessment, and in some cases also their course grades.",
+        "name_en": "Screened With Assessment",
+        "loo_contents": []
+      },
+      "description": "Our rigorous Capstone Scholars program provides a supportive academic experience designed to prepare students for college and career success. Students gain early access to AP classes starting as early as 9th grade, personalized 1:1 advising, and comprehensive SAT prep. They receive dedicated support throughout the college application process and can earn early college credits. Career exploration includes internships, mentored opportunities, and work-based learning. Scholars also choose between creative tracks in Visual Arts or Theater Arts, fostering both academic excellence and artistic growth.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": 1,
+          "seats": 20,
+          "applicants": 20,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": 0,
+          "seats": 6,
+          "applicants": 2,
+          "all_seats_filled": true,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false
+        }
+      },
+      "selection_criteria": [
+        {
+          "name": "Average Course Grades - 75%",
+          "order": 1
+        },
+        {
+          "name": "Essay - 25%",
+          "order": 2
+        }
+      ],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": false,
+      "seats_10th_number": 0,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [
+        {
+          "id": 567166,
+          "order": 1,
+          "name": "New York City residents",
+          "ge_priority_group_description": "There were about 20 applicants in this group and all received offers last year.",
+          "swd_priority_group_description": "There were fewer than 10 applicants in this group and all received offers last year."
+        }
+      ],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": null,
+      "provider_email": null,
+      "provider_phone_number": null,
+      "operating_weekdays": null,
+      "site_contact_name": null,
+      "site_contact_email": null,
+      "site_contact_phone_number": null,
+      "portfolio_id": null,
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    },
+    {
+      "id": 123729,
+      "directory_school_id": 93437,
+      "program": {
+        "code": "M66B",
+        "name": "Theater Arts",
+        "admission_process": "High School",
+        "is_shs": false,
+        "is_lg": false,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": true,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "Theater Arts (M66B)",
+      "interest_areas": [
+        {
+          "name": "Performing Arts"
+        }
+      ],
+      "admissions_method": {
+        "name": "Audition",
+        "description": "Students are ranked by the school based on their auditions. Offers are made in priority group and rank order.",
+        "name_en": "Audition",
+        "loo_contents": []
+      },
+      "description": "Our Theater Arts program invites students to experience the magic of the stage through collaborative projects, improvisation, and original ethno-drama creation. They develop performance skills, theatrical vocabulary, and directing techniques while exploring character development, script analysis, and vocal ensemble singing. Students gain practical experience in acting, directing, and technical theater, with opportunities to be cast or work behind the scenes in our Fall Play and Spring Musical. Industry insights and audition preparation prepare students for future success in theater arts. All of this is in addition to the rigorous academic preparation, four years of support around college and career readiness, and valuable internships and work-based learning opportunities.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": 1,
+          "seats": 43,
+          "applicants": 31,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": 0,
+          "seats": 12,
+          "applicants": 1,
+          "all_seats_filled": false,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false
+        }
+      },
+      "selection_criteria": [],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": true,
+      "seats_10th_number": 5,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [
+        {
+          "id": 567165,
+          "order": 1,
+          "name": "New York City residents",
+          "ge_priority_group_description": "There were about 30 applicants in this group and about 30 received offers last year.",
+          "swd_priority_group_description": "There were fewer than 10 applicants in this group and none received offers last year."
+        }
+      ],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": null,
+      "provider_email": null,
+      "provider_phone_number": null,
+      "operating_weekdays": null,
+      "site_contact_name": null,
+      "site_contact_email": null,
+      "site_contact_phone_number": null,
+      "portfolio_id": null,
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    },
+    {
+      "id": 123726,
+      "directory_school_id": 93437,
+      "program": {
+        "code": "M66A",
+        "name": "Visual Arts",
+        "admission_process": "High School",
+        "is_shs": false,
+        "is_lg": false,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": true,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "Visual Arts (M66A)",
+      "interest_areas": [
+        {
+          "name": "Computer Science & Technology"
+        },
+        {
+          "name": "Visual Art & Design"
+        }
+      ],
+      "admissions_method": {
+        "name": "Audition",
+        "description": "Students are ranked by the school based on their auditions. Offers are made in priority group and rank order.",
+        "name_en": "Audition",
+        "loo_contents": []
+      },
+      "description": "Our Visual Arts and Design program immerses students in both traditional and digital media, including charcoal, watercolor, and Adobe Creative Suite, while integrating design techniques used in professional spaces. Students build physical and digital portfolios mastering key concepts like typography, composition, and branding, with real-world applications in advertising and marketing. They develop critical thinking, creative problem-solving, and professional skills essential for careers in graphic design, illustration, and branding. This program also offers valuable work-based learning opportunities in these dynamic industries. All of this is in addition to rigorous academics, college and career readiness support, and internships.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": 1,
+          "seats": 65,
+          "applicants": 51,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": 1,
+          "seats": 19,
+          "applicants": 15,
+          "all_seats_filled": true,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false
+        }
+      },
+      "selection_criteria": [],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": true,
+      "seats_10th_number": 0,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [
+        {
+          "id": 567164,
+          "order": 1,
+          "name": "New York City residents",
+          "ge_priority_group_description": "There were about 50 applicants in this group and about 40 received offers last year.",
+          "swd_priority_group_description": "There were about 20 applicants in this group and about 10 received offers last year."
+        }
+      ],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": null,
+      "provider_email": null,
+      "provider_phone_number": null,
+      "operating_weekdays": null,
+      "site_contact_name": null,
+      "site_contact_email": null,
+      "site_contact_phone_number": null,
+      "portfolio_id": null,
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    }
+  ],
+  "overview": "Our arts-themed college preparatory high school is where creativity and academic rigor come together to prepare students for success. Our dynamic curriculum encourages students to explore a wide range of artistic and intellectual disciplines. Students develop critical thinking and communication skills by investigating real-world issues, crafting well-supported arguments, and presenting their ideas with confidence. They engage deeply with both nonfiction and creative storytelling, gaining hands-on experience in visual arts, digital design, & performance, while building impressive portfolios that showcase their talents.\nStudents and families can choose from three admissions options: Visual Arts, Theater Arts, and Capstone, allowing them to tailor their educational experience to their passions and goals. Beyond the classroom, our supportive advisory program & comprehensive secondary school experience help students navigate their academic and personal growth. We provide individualized support throughout the college application process, guiding each student and family to find the best fit and successfully transition to higher education. Students also benefit from work-based learning, career-connected learning, and exploration opportunities that prepare them for future careers in the arts and beyond. We offer exciting experiences such as internships, a Fall Play, and a Spring Musical, allowing students to apply their skills in real-world settings & showcase their creativity. Our annual lower house trips include a retreat to Fairview Lake, fostering community and reflection, & a cultural exploration of museums in Washington, D.C. Join us to unlock your creativity, develop essential skills, and become part of a vibrant community dedicated to artistic & academic excellence.",
+  "grades_description": "9 to 12",
+  "academic_opportunities": [
+    {
+      "name": "10% of students scoring 1300+ on their SATs",
+      "order": 1
+    },
+    {
+      "name": "12+ AP classes to challenge students and strengthen college applications",
+      "order": 2
+    },
+    {
+      "name": "Comprehensive college support with personalized counseling and application guidance to ensure every student\u0080\u0099s success",
+      "order": 3
+    },
+    {
+      "name": "Collaborative partnerships with businesses and colleges to provide students with hands-on experience and networking opportunities",
+      "order": 4
+    },
+    {
+      "name": "Career-connected learning opportunities including internships, mentorships, and real-world projects to prepare students for the workforce",
+      "order": 5
+    }
+  ],
+  "admissions_open": false,
+  "waitlist_open": false,
+  "results_enabled": true,
+  "admission_process": "HS",
+  "ell_programs": [],
+  "language_classes": [
+    {
+      "name": "Spanish"
+    }
+  ],
+  "advanced_placement_courses": [
+    {
+      "name": "Algebra II (Advanced Math)"
+    },
+    {
+      "name": "AP African American Studies"
+    },
+    {
+      "name": "AP Art History"
+    },
+    {
+      "name": "AP Biology"
+    },
+    {
+      "name": "AP Calculus AB"
+    },
+    {
+      "name": "AP English Language and Composition"
+    },
+    {
+      "name": "AP Environmental Science"
+    },
+    {
+      "name": "AP Psychology"
+    },
+    {
+      "name": "AP Seminar"
+    },
+    {
+      "name": "AP Statistics"
+    },
+    {
+      "name": "AP United States Government and Politics"
+    },
+    {
+      "name": "AP United States History"
+    },
+    {
+      "name": "AP World History: Modern"
+    },
+    {
+      "name": "Arts (Advanced Placement)"
+    },
+    {
+      "name": "Chemistry (Advanced Science)"
+    },
+    {
+      "name": "Physics (Advanced Science)"
+    },
+    {
+      "name": "World Languages (Advanced World Languages)"
+    }
+  ],
+  "art_courses": [
+    {
+      "name": "Chorus/Singing"
+    },
+    {
+      "name": "Traditional and Studio Art"
+    },
+    {
+      "name": "Digital Media Arts"
+    },
+    {
+      "name": "Design and Applied Arts"
+    },
+    {
+      "name": "Art History"
+    },
+    {
+      "name": "Theater Production"
+    },
+    {
+      "name": "Theater Making/Performance"
+    },
+    {
+      "name": "Theater Literacy"
+    },
+    {
+      "name": "General Theater"
+    }
+  ],
+  "diploma_endorsements": [
+    {
+      "name": "Arts"
+    }
+  ],
+  "other_features": [
+    {
+      "name": "10th Grade Seats Available"
+    },
+    {
+      "name": "College Courses Offered"
+    },
+    {
+      "name": "College Courses onsite"
+    },
+    {
+      "name": "College Trips"
+    },
+    {
+      "name": "Community Service Expected"
+    },
+    {
+      "name": "Computer Science Coursework"
+    },
+    {
+      "name": "Financial Literacy Coursework"
+    },
+    {
+      "name": "FutureReadyNYC School"
+    },
+    {
+      "name": "Health Center"
+    },
+    {
+      "name": "Internships"
+    },
+    {
+      "name": "Online Grading System"
+    },
+    {
+      "name": "Paid Apprenticeships"
+    },
+    {
+      "name": "Paid Internships"
+    },
+    {
+      "name": "Program(s) with 1 GE Applicant Per Seat"
+    },
+    {
+      "name": "Program(s) with 1 SWD Applicant Per Seat"
+    },
+    {
+      "name": "Summer Bridge"
+    }
+  ],
+  "affiliated_schools": [],
+  "instruction_and_performance_rating": {
+    "label": "Good",
+    "score": 3
+  },
+  "safety_and_school_climate_rating": {
+    "label": "Fair",
+    "score": 2
+  },
+  "relationships_with_families_rating": {
+    "label": "Good",
+    "score": 3
+  },
+  "performance_labels": {
+    "instruction_and_performance_label": "Instruction and Performance",
+    "safety_and_school_climate_label": "Safety and School Climate",
+    "relationships_with_families_label": "Relationships with Families",
+    "school_quality_snapshot_html": "<a target=\"_blank\" rel=\"noopener\" href=\"https://tools.nycenet.edu/snapshot/0/02M374/HS/?utm_source=myschools.nyc&utm_medium=DOE_App_referral&utm_campaign=MySchools\">See the School Quality Snapshot</a>."
+  },
+  "stat_graduation": 98,
+  "stat_enroll_college_career": 79,
+  "stat_attendance": null,
+  "stat_safety": 93,
+  "stat_variety": 84,
+  "subway": "4, 5, 6, L, N, Q, R to 14th St-Union Square",
+  "subway_line": [
+    {
+      "name": "4",
+      "color": "#00933C"
+    },
+    {
+      "name": "5",
+      "color": "#00933C"
+    },
+    {
+      "name": "6",
+      "color": "#00933C"
+    },
+    {
+      "name": "L",
+      "color": "#A7A9AC"
+    },
+    {
+      "name": "N",
+      "color": "#FCCC0A"
+    },
+    {
+      "name": "Q",
+      "color": "#FCCC0A"
+    },
+    {
+      "name": "R",
+      "color": "#FCCC0A"
+    },
+    {
+      "name": "W",
+      "color": "#FCCC0A"
+    }
+  ],
+  "bus": "BM1, BM2, BM3, BM4, BxM10, BxM6, BxM7, BxM8, BxM9, M1, M101, M102, M103, M14A-SBS, M14D-SBS, M15, M15-SBS, M2, M23-SBS, M3, M34-SBS, M34A-SBS, M55, M8, M9, QM21, QM63, QM64, QM68, SIM10, SIM11, SIM1C, SIM3, SIM31, SIM33, SIM33C, SIM3C, SIM4C, SIM6, SIM7, SIM9, X27, X28, X37, X38",
+  "shared_space": true,
+  "building_code": "M460",
+  "email": "BFaughnan@gramercyhs.org",
+  "telephone": "212-253-7076",
+  "independent_website": "https://www.gramercyhs.org/",
+  "secondary_website": "https://tools.nycenet.edu/snapshot/0/02M374/HS/?utm_source=myschools.nyc&utm_medium=DOE_App_referral&utm_campaign=MySchools",
+  "start_time": "8:20am",
+  "end_time": "2:40pm",
+  "uniform": false,
+  "open_house_information": "",
+  "bap_url": "https://nycdoe.sharepoint.com/:w:/s/BAP/ERxY8nzMbvBCmpehbTYuvwwBAWjFCZHNXflvWb-qkCDLBQ",
+  "total_enrollment": "483",
+  "enrollment_range": "0-499",
+  "eligibility": [
+    {
+      "name": "10th Grade Seats Available",
+      "name_en": "10th Grade Seats Available"
+    }
+  ],
+  "activities": [],
+  "sports_boys": [
+    {
+      "name": "Baseball"
+    },
+    {
+      "name": "Basketball"
+    },
+    {
+      "name": "Handball"
+    },
+    {
+      "name": "Soccer"
+    },
+    {
+      "name": "Volleyball"
+    }
+  ],
+  "sports_girls": [
+    {
+      "name": "Basketball"
+    },
+    {
+      "name": "Soccer"
+    },
+    {
+      "name": "Softball"
+    },
+    {
+      "name": "Volleyball"
+    }
+  ],
+  "sports_coed": [],
+  "school_sports": [
+    {
+      "name": "Basketball"
+    },
+    {
+      "name": "Fitness"
+    },
+    {
+      "name": "Volleyball"
+    },
+    {
+      "name": "Yoga"
+    }
+  ],
+  "sports_description": "Basketball, Fitness, Volleyball, Yoga",
+  "meals": [],
+  "electives_description": "",
+  "activities_description": "Spring Musical, Fall Play, Equity Team, Student Government, Art Laboratory, Newspaper, Anime, Gender Sexuality Alliance (GSA), Cleary Gottlieb, Career Day, Yearbook, Community Service, Camping @ Manice Education Center, Internships, Work based learning, Mock Trial, Ambassadors Program",
+  "contact_name": "",
+  "stat_core_courses": null,
+  "stat_state_ela": null,
+  "stat_state_math": null,
+  "frequently_attended_hs": [],
+  "diversity_in_admissions": "",
+  "stat_parents_satisfaction": null,
+  "virtual_learning": "",
+  "co_located_schools": [],
+  "classification": [],
+  "class_program_ratio": [],
+  "bridge": [],
+  "assessment_type": [],
+  "distance": null,
+  "switches": {
+    "show_GE_SWD_toggle_on_application_program_admissions": true,
+    "show_GE_SWD_toggle_on_public_program_admissions": true
+  }
+}

--- a/scripts/myschools_fixtures/single_program_02M047.json
+++ b/scripts/myschools_fixtures/single_program_02M047.json
@@ -1,0 +1,374 @@
+{
+  "id": 88733,
+  "name": "47 The American Sign Language and English Secondary School (02M047)",
+  "school": {
+    "name": "47 THE AMERICAN SIGN LANGUAGE AND ENGLISH SECONDARY SCHOOL (02M047)",
+    "dbn": "02M047",
+    "accessibility": "Fully Accessible",
+    "magnet": false,
+    "school_year": "2025-26 School Year",
+    "district": {
+      "id": 73,
+      "borough": "Manhattan",
+      "code": "02",
+      "name": "DISTRICT 02",
+      "name_en": "DISTRICT 02",
+      "name_ar": null,
+      "name_bn": null,
+      "name_zh_hant": null,
+      "name_zh_hans": null,
+      "name_sq": null,
+      "name_fr": null,
+      "name_ht": null,
+      "name_ko": null,
+      "name_ru": null,
+      "name_es": null,
+      "name_ur": null,
+      "name_uk": null,
+      "name_uz": null,
+      "is_under_represented": false,
+      "is_in_person": true
+    },
+    "school_type": {
+      "id": 9,
+      "name": "PUBLIC"
+    },
+    "address": {
+      "id": 82496,
+      "address_1": "223 East 23 Street",
+      "address_2": "",
+      "street_number": "223",
+      "street_name": "East 23 Street",
+      "city": "Manhattan",
+      "sublocality": null,
+      "state": "NY",
+      "zip_code": "10010",
+      "country": "US",
+      "primary": false,
+      "latitude": "40.738482",
+      "longitude": "-73.981358",
+      "xcoord": null,
+      "ycoord": null,
+      "source": "('Geosupport API',)",
+      "needs_geocoding": false,
+      "last_geocoded": "2025-09-30T13:45:44.327311-04:00",
+      "gis_location": "SRID=4326;POINT (-73.981358 40.738482)",
+      "created_at": "2025-09-19T17:43:40.078930-04:00",
+      "updated_at": "2025-09-30T13:45:44.327311-04:00"
+    },
+    "full_address": "223 East 23 Street, Manhattan, NY 10010",
+    "directory_school_ids": [
+      88733
+    ],
+    "accessibility_more_info": null
+  },
+  "programs": [
+    {
+      "id": 123674,
+      "directory_school_id": 88733,
+      "program": {
+        "code": "M54A",
+        "name": "American Sign Language Studies Program",
+        "admission_process": "High School",
+        "is_shs": false,
+        "is_lg": false,
+        "is_gt": false,
+        "is_ms": false,
+        "is_pk": false,
+        "is_3k": false,
+        "is_el": false,
+        "is_hs": true,
+        "enable_waitlist_on_parent_portal": false
+      },
+      "name": "American Sign Language Studies Program (M54A)",
+      "interest_areas": [
+        {
+          "name": "Humanities & Interdisciplinary"
+        }
+      ],
+      "admissions_method": {
+        "name": "Screened",
+        "description": "Students are admitted based on their course grades",
+        "name_en": "Screened",
+        "loo_contents": []
+      },
+      "description": "Students partake in a four-year ASL program graduating with a proficiency in American Sign Language. Graduates can expect to obtain the knowledge and skills necessary to work with the Deaf and Hard of Hearing communities. In addition to learning American Sign Language, students are exposed to the culture and social perspective of the Deaf and Hard of Hearing communities.",
+      "eligibility_description": "",
+      "demand_last_year": {
+        "general_education": {
+          "applications_per_seat": 1,
+          "seats": 54,
+          "applicants": 27,
+          "seats_description": "",
+          "all_seats_filled": false
+        },
+        "students_with_disabilities": {
+          "applications_per_seat": 0,
+          "seats": 15,
+          "applicants": 5,
+          "all_seats_filled": true,
+          "is_swd": false
+        },
+        "specialized_education": {
+          "applications_per_seat": null,
+          "seats": null,
+          "applicants": null,
+          "all_seats_filled": false
+        }
+      },
+      "selection_criteria": [],
+      "audition_information": [],
+      "audition_schedule": [],
+      "selection_criteria_note": "",
+      "seats_10th_available": true,
+      "seats_10th_number": 15,
+      "seats_description": "",
+      "testing_not_registered": false,
+      "program_priority_groups": [
+        {
+          "id": 567134,
+          "order": 1,
+          "name": "47 The American Sign Language and English Lower School students",
+          "ge_priority_group_description": "There were fewer than 10 applicants in this group and all received offers last year.",
+          "swd_priority_group_description": "There were fewer than 10 applicants in this group and all received offers last year."
+        },
+        {
+          "id": 567135,
+          "order": 2,
+          "name": "New York City residents",
+          "ge_priority_group_description": "There were about 30 applicants in this group and all received offers last year.",
+          "swd_priority_group_description": "There were fewer than 10 applicants in this group and all received offers last year."
+        }
+      ],
+      "diversity_in_admission_1": "",
+      "diversity_in_admission_2": "",
+      "lowest_priority": "",
+      "preference": "",
+      "start_date": null,
+      "end_date": null,
+      "start_time": "",
+      "end_time": "",
+      "provider_website": null,
+      "provider_email": null,
+      "provider_phone_number": null,
+      "operating_weekdays": null,
+      "site_contact_name": null,
+      "site_contact_email": null,
+      "site_contact_phone_number": null,
+      "portfolio_id": null,
+      "grades_description": "",
+      "other_features": [],
+      "languages_spoken_by_providers": []
+    }
+  ],
+  "overview": "At \"47\" the American Sign Language and English High School, we believe that all students have the right to learn in an inclusive, academically rigorous environment. Our graduates emerge proficient in American Sign Language (ASL). Our small school community nurtures responsible citizens of the world, addressing all aspects of young adult development by providing the necessary individual supports for our students to be college and career ready.",
+  "grades_description": "9 to 12",
+  "academic_opportunities": [],
+  "admissions_open": false,
+  "waitlist_open": false,
+  "results_enabled": true,
+  "admission_process": "HS",
+  "ell_programs": [],
+  "language_classes": [
+    {
+      "name": "American Sign Language"
+    }
+  ],
+  "advanced_placement_courses": [
+    {
+      "name": "Algebra II (Advanced Math)"
+    },
+    {
+      "name": "AP Biology"
+    },
+    {
+      "name": "AP Calculus AB"
+    },
+    {
+      "name": "AP English Language and Composition"
+    },
+    {
+      "name": "AP English Literature and Composition"
+    },
+    {
+      "name": "AP Human Geography"
+    },
+    {
+      "name": "AP Psychology"
+    },
+    {
+      "name": "AP Statistics"
+    },
+    {
+      "name": "AP United States History"
+    },
+    {
+      "name": "AP World History: Modern"
+    },
+    {
+      "name": "Physics (Advanced Science)"
+    },
+    {
+      "name": "World Languages (Advanced World Languages)"
+    }
+  ],
+  "art_courses": [
+    {
+      "name": "Traditional and Studio Art"
+    }
+  ],
+  "diploma_endorsements": [],
+  "other_features": [
+    {
+      "name": "10th Grade Seats Available"
+    },
+    {
+      "name": "College Courses Offered"
+    },
+    {
+      "name": "College Trips"
+    },
+    {
+      "name": "Community School"
+    },
+    {
+      "name": "Internships Available"
+    },
+    {
+      "name": "Online Grading System"
+    },
+    {
+      "name": "Orientation"
+    },
+    {
+      "name": "Program(s) with 1 GE Applicant Per Seat"
+    },
+    {
+      "name": "Student Parent Orientation"
+    },
+    {
+      "name": "Summer Orientation"
+    }
+  ],
+  "affiliated_schools": [],
+  "instruction_and_performance_rating": {
+    "label": "Excellent",
+    "score": 4
+  },
+  "safety_and_school_climate_rating": {
+    "label": "Fair",
+    "score": 2
+  },
+  "relationships_with_families_rating": {
+    "label": "Excellent",
+    "score": 4
+  },
+  "performance_labels": {
+    "instruction_and_performance_label": "Instruction and Performance",
+    "safety_and_school_climate_label": "Safety and School Climate",
+    "relationships_with_families_label": "Relationships with Families",
+    "school_quality_snapshot_html": "<a target=\"_blank\" rel=\"noopener\" href=\"https://tools.nycenet.edu/snapshot/0/02M047/HS/?utm_source=myschools.nyc&utm_medium=DOE_App_referral&utm_campaign=MySchools\">See the School Quality Snapshot</a>."
+  },
+  "stat_graduation": 100,
+  "stat_enroll_college_career": 83,
+  "stat_attendance": null,
+  "stat_safety": 89,
+  "stat_variety": 64,
+  "subway": "6 to 23rd St; L to 3rd Av",
+  "subway_line": [
+    {
+      "name": "6",
+      "color": "#00933C"
+    },
+    {
+      "name": "L",
+      "color": "#A7A9AC"
+    },
+    {
+      "name": "R",
+      "color": "#FCCC0A"
+    },
+    {
+      "name": "W",
+      "color": "#FCCC0A"
+    }
+  ],
+  "bus": "BM1, BM2, BM3, BM4, BxM1, BxM10, BxM11, BxM18, BxM3, BxM4, BxM6, BxM7, BxM8, BxM9, M1, M101, M102, M103, M14A-SBS, M14D-SBS, M15, M15-SBS, M2, M23-SBS, M3, M34-SBS, M34A-SBS, M55, M9, QM21, QM63, QM64, QM68, SIM10, SIM11, SIM1C, SIM3, SIM31, SIM33C, SIM3C, SIM4C, SIM6, X27, X28, X37, X38",
+  "shared_space": true,
+  "building_code": "M047",
+  "email": "wshama@schools.nyc.gov",
+  "telephone": "917-326-6668",
+  "independent_website": "https://www.47aslhs.net/",
+  "secondary_website": "https://tools.nycenet.edu/snapshot/0/02M047/HS/?utm_source=myschools.nyc&utm_medium=DOE_App_referral&utm_campaign=MySchools",
+  "start_time": "08:25am",
+  "end_time": "02:45pm",
+  "uniform": false,
+  "open_house_information": "",
+  "bap_url": "https://nycdoe.sharepoint.com/:w:/s/BAP/Efc3Gdn6whBNigKZR4Ydre8BSyAE96jcoWJnQeIPzPi1bg",
+  "total_enrollment": "222",
+  "enrollment_range": "0-499",
+  "eligibility": [
+    {
+      "name": "10th Grade Seats Available",
+      "name_en": "10th Grade Seats Available"
+    }
+  ],
+  "activities": [],
+  "sports_boys": [
+    {
+      "name": "Basketball"
+    },
+    {
+      "name": "Outdoor Track"
+    },
+    {
+      "name": "Soccer"
+    }
+  ],
+  "sports_girls": [
+    {
+      "name": "Outdoor Track"
+    },
+    {
+      "name": "Volleyball"
+    }
+  ],
+  "sports_coed": [
+    {
+      "name": "Stunt"
+    }
+  ],
+  "school_sports": [
+    {
+      "name": "Cheerleading"
+    },
+    {
+      "name": "Fitness"
+    },
+    {
+      "name": "Soccer"
+    }
+  ],
+  "sports_description": "Cheerleading, Fitness, Soccer",
+  "meals": [],
+  "electives_description": "",
+  "activities_description": "Anime, Boardgames, Crochet, Dungeons and Dragons, Fashion, Fitness,Gender Sexuality Alliance (GSA), Literary Magazine, National Honor Society, Performing Arts, Student Equity,  and Student Government",
+  "contact_name": "",
+  "stat_core_courses": null,
+  "stat_state_ela": null,
+  "stat_state_math": null,
+  "frequently_attended_hs": [],
+  "diversity_in_admissions": "",
+  "stat_parents_satisfaction": null,
+  "virtual_learning": "",
+  "co_located_schools": [],
+  "classification": [],
+  "class_program_ratio": [],
+  "bridge": [],
+  "assessment_type": [],
+  "distance": null,
+  "switches": {
+    "show_GE_SWD_toggle_on_application_program_admissions": true,
+    "show_GE_SWD_toggle_on_public_program_admissions": true
+  }
+}

--- a/scripts/scrape_myschools.py
+++ b/scripts/scrape_myschools.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""
+AdmitDay - MySchools Program Scraper (issue #135)
+
+Fetches per-program admissions data from MySchools and returns structured
+Program records with source provenance. This module is standalone: it does
+not touch `data/schools.json`, does not run as part of `build_school_data.py`,
+and is not wired into any pipeline. Integration is a follow-up issue.
+
+## Why this scrapes a JSON endpoint, not HTML
+
+The issue's starting assumption was that https://www.myschools.nyc/en/schools/
+is server-rendered HTML, matching the technique `build_school_data.py` uses
+against NYC-SIFT. That turned out not to hold: fetching that URL returns an
+Angular single-page-app shell with an empty mount point (`<div id="app">`) --
+there is no program data in the initial HTML to parse.
+
+That shell's own bootstrap config, embedded in the page as `window.App`,
+discloses `apiUrl` and `state.school.admissionInstances`. Those point at the
+same JSON endpoint the page's own client-side JS calls, unauthenticated, to
+render the page for a logged-out visitor browsing the public directory:
+
+    GET https://www.myschools.nyc/en/api/v2/schools/process/{process_id}/{dbn}/
+
+`process_id` selects which admissions process's programs to return.
+`PROCESS_ID_HIGH_SCHOOL = 1` is the one AdmitDay cares about (confirmed via
+`admissionInstances["high-school"]` in the page's bootstrap config; other
+processes -- kindergarten, 3-K, G&T, District 75, etc. -- have their own ids
+and are out of scope here). No login, application, or cookie is required.
+
+This module fetches that endpoint directly. It is still "scraping MySchools"
+in every sense the issue cares about (no official/documented API, same site,
+same politeness obligations) -- it just targets the JSON the page's own code
+fetches instead of re-deriving the same data from rendered markup.
+
+`https://www.myschools.nyc/en/calendar/` (event calendar, filterable by
+admission process and school) was noted per the issue but not explored
+further -- out of scope here, left for a follow-up issue.
+
+## Record shapes
+
+`Program` (see dataclass below) is the per-program record. Fields the source
+page does not publish for a given program are omitted entirely -- never an
+empty string or a zero -- consistent with how the rest of the app treats
+missing data. Only `dbn`, `school_name`, and `program_name` are guaranteed
+present; everything else is Optional and dropped by `to_dict()` when absent.
+
+`Provenance` (nested under `Program.provenance`) records where a record came
+from and when, captured at scrape time from the response itself:
+  - `source`: always "MySchools" (the site, not a per-record derived value)
+  - `url`: the exact API URL fetched for this record
+  - `fetched_at`: UTC ISO-8601 timestamp of the fetch
+  - `admissions_cycle`: the cycle label MySchools itself publishes on the
+    school record (e.g. "2025-26 School Year"), if present -- this is what
+    makes the app's displayed "last verified" date correct automatically
+    once this data replaces the stale 2018 DOE directory (see #138), instead
+    of being a typed string nobody remembers to update.
+
+## What's actually available vs. what the issue hoped for
+
+Available directly on each program object: program name, program code,
+admissions method (name + description), a free-text program description,
+per-category demand-last-year seat/applicant counts (general education,
+students with disabilities, specialized education), 10th-grade seat
+availability, selection criteria, selection-criteria notes, audition
+information/schedule, priority-group and diversity-in-admission notes, and
+program-level grade span text (frequently blank -- see below).
+
+Available on the *school*, not per program, and used here as a fallback:
+grade span (`grades_description`, e.g. "9 to 12") and a general eligibility
+list (e.g. "10th Grade Seats Available"). Every program in a school observed
+so far shares the school's grade span, so `Program.grade_span` falls back to
+the school-level value when the program itself doesn't specify one -- this
+is a deliberate choice, not a bug, and is called out in `_program_grade_span`.
+
+Not observed on any fixture pulled during this issue: a structured
+essay/interview/portfolio-required boolean, or a single canonical deadline
+date. What MySchools publishes instead is free text (`selection_criteria`,
+`selection_criteria_note`, `audition_information`, `audition_schedule`) that
+would need per-school-type parsing to turn into structured booleans/dates --
+that's follow-up work, not something to guess at here. `Program.requirements`
+carries that free text through as-is.
+
+## Politeness
+
+- `USER_AGENT` identifies the tool and purpose.
+- `fetch_school` sleeps `DEFAULT_DELAY_SECONDS` before each network request.
+- `fetch_school` retries transient failures (429/5xx/timeout) with capped
+  exponential backoff.
+- Responses are cached to disk (`DEFAULT_CACHE_DIR`) keyed by the exact URL,
+  so re-running against the same schools does not re-hit the site.
+- Nothing in this module issues concurrent requests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+import time
+import urllib.parse
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+USER_AGENT = "Mozilla/5.0 (compatible; AdmitDay/1.0; +https://github.com/admitday; research tool, per-program scraper)"
+API_BASE = "https://www.myschools.nyc/en/api/v2/schools/process"
+PROCESS_ID_HIGH_SCHOOL = 1
+
+DEFAULT_DELAY_SECONDS = 1.5
+DEFAULT_TIMEOUT_SECONDS = 20
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_CACHE_DIR = Path(__file__).parent / ".myschools_cache"
+
+DBN_RE = re.compile(r"\b(\d{2}[A-Z]\d{3})\b")
+
+
+class MySchoolsError(Exception):
+    """Raised when a request fails or a response cannot be resolved."""
+
+
+class MySchoolsParseError(MySchoolsError):
+    """Raised when a response's shape doesn't match what this module expects.
+
+    Deliberately loud: a page-shape change upstream should surface as a
+    failure here, not as a silent empty list of programs.
+    """
+
+
+@dataclass
+class Provenance:
+    url: str
+    fetched_at: str
+    source: str = "MySchools"
+    admissions_cycle: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return _drop_absent(
+            {
+                "source": self.source,
+                "url": self.url,
+                "fetched_at": self.fetched_at,
+                "admissions_cycle": self.admissions_cycle,
+            }
+        )
+
+
+@dataclass
+class Program:
+    dbn: str
+    school_name: str
+    program_name: str
+    provenance: Provenance
+    program_code: Optional[str] = None
+    admissions_method: Optional[str] = None
+    admissions_method_description: Optional[str] = None
+    grade_span: Optional[str] = None
+    seats: Optional[dict] = None
+    eligibility: Optional[dict] = None
+    requirements: Optional[dict] = None
+    description: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return _drop_absent(
+            {
+                "dbn": self.dbn,
+                "school_name": self.school_name,
+                "program_name": self.program_name,
+                "program_code": self.program_code,
+                "admissions_method": self.admissions_method,
+                "admissions_method_description": self.admissions_method_description,
+                "grade_span": self.grade_span,
+                "seats": self.seats,
+                "eligibility": self.eligibility,
+                "requirements": self.requirements,
+                "description": self.description,
+                "provenance": self.provenance.to_dict(),
+            }
+        )
+
+
+def _is_absent(value: Any) -> bool:
+    """True for values that mean "the page didn't publish this" -- None,
+    "", [], {} -- but NOT for a real 0, which some fields (e.g.
+    applications_per_seat) publish as a meaningful value."""
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict)) and len(value) == 0:
+        return True
+    return False
+
+
+def _drop_absent(d: dict) -> dict:
+    out = {}
+    for k, v in d.items():
+        if isinstance(v, dict):
+            v = _drop_absent(v)
+        if _is_absent(v):
+            continue
+        out[k] = v
+    return out
+
+
+def extract_dbn(dbn_or_url: str) -> str:
+    """Accepts a bare DBN ("03M485") or a MySchools school URL
+    (".../en/schools/03M485/") and returns the DBN."""
+    match = DBN_RE.search(dbn_or_url)
+    if not match:
+        raise MySchoolsError(f"Could not find a DBN in {dbn_or_url!r}")
+    return match.group(1)
+
+
+def build_school_url(dbn: str, process_id: int = PROCESS_ID_HIGH_SCHOOL) -> str:
+    return f"{API_BASE}/{process_id}/{urllib.parse.quote(dbn)}/"
+
+
+def _cache_path(cache_dir: Path, url: str) -> Path:
+    key = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return cache_dir / f"{key}.json"
+
+
+def fetch_school(
+    dbn_or_url: str,
+    process_id: int = PROCESS_ID_HIGH_SCHOOL,
+    cache_dir: Optional[Path] = DEFAULT_CACHE_DIR,
+    delay_seconds: float = DEFAULT_DELAY_SECONDS,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    session: Optional[requests.Session] = None,
+) -> tuple[dict, str, str]:
+    """Fetch a school's MySchools record. Returns (raw_json, url, fetched_at_iso).
+
+    Politeness: checks the on-disk cache first; only hits the network on a
+    cache miss, after sleeping `delay_seconds`, retrying transient failures
+    with exponential backoff.
+    """
+    dbn = extract_dbn(dbn_or_url)
+    url = build_school_url(dbn, process_id)
+
+    if cache_dir is not None:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = _cache_path(cache_dir, url)
+        if cache_file.exists():
+            cached = json.loads(cache_file.read_text())
+            return cached["raw"], cached["url"], cached["fetched_at"]
+
+    session = session or requests.Session()
+    last_error: Optional[Exception] = None
+    for attempt in range(max_retries):
+        time.sleep(delay_seconds)
+        try:
+            response = session.get(
+                url,
+                headers={"User-Agent": USER_AGENT},
+                timeout=timeout_seconds,
+            )
+            if response.status_code == 429 or response.status_code >= 500:
+                last_error = MySchoolsError(
+                    f"{url} -> HTTP {response.status_code}"
+                )
+                time.sleep(delay_seconds * (2**attempt))
+                continue
+            response.raise_for_status()
+            raw = response.json()
+            fetched_at = datetime.now(timezone.utc).isoformat()
+            if cache_dir is not None:
+                cache_file.write_text(
+                    json.dumps({"raw": raw, "url": url, "fetched_at": fetched_at})
+                )
+            return raw, url, fetched_at
+        except requests.RequestException as exc:
+            last_error = exc
+            time.sleep(delay_seconds * (2**attempt))
+
+    raise MySchoolsError(f"Failed to fetch {url} after {max_retries} attempts") from last_error
+
+
+def _program_grade_span(program: dict, response: dict) -> Optional[str]:
+    """Program-level grade span if MySchools publishes one for this program,
+    else the school's overall grade span (every program observed so far
+    shares its school's span; there is no per-program override in the data
+    seen during this issue)."""
+    own = program.get("grades_description")
+    if own:
+        return own
+    return response.get("grades_description")
+
+
+def _program_seats(program: dict) -> Optional[dict]:
+    demand = program.get("demand_last_year") or {}
+    seats: dict = {}
+    for category in ("general_education", "students_with_disabilities", "specialized_education"):
+        entry = demand.get(category) or {}
+        cleaned = _drop_absent(
+            {
+                "seats": entry.get("seats"),
+                "applicants": entry.get("applicants"),
+                "applications_per_seat": entry.get("applications_per_seat"),
+            }
+        )
+        if cleaned:
+            seats[category] = cleaned
+    tenth_grade = _drop_absent(
+        {
+            "available": program.get("seats_10th_available") or None,
+            "number": program.get("seats_10th_number"),
+            "description": program.get("seats_description"),
+        }
+    )
+    if tenth_grade:
+        seats["tenth_grade"] = tenth_grade
+    return seats or None
+
+
+def _program_eligibility(program: dict, response: dict) -> Optional[dict]:
+    return _drop_absent(
+        {
+            "description": program.get("eligibility_description"),
+            "priority_groups": program.get("program_priority_groups"),
+            "lowest_priority": program.get("lowest_priority"),
+            "preference": program.get("preference"),
+            "diversity_in_admission": [
+                v
+                for v in (
+                    program.get("diversity_in_admission_1"),
+                    program.get("diversity_in_admission_2"),
+                )
+                if v
+            ],
+            "school_eligibility": [e.get("name") for e in (response.get("eligibility") or []) if e.get("name")],
+        }
+    ) or None
+
+
+def _program_requirements(program: dict) -> Optional[dict]:
+    return _drop_absent(
+        {
+            "selection_criteria": program.get("selection_criteria"),
+            "selection_criteria_note": program.get("selection_criteria_note"),
+            "audition_information": program.get("audition_information"),
+            "audition_schedule": program.get("audition_schedule"),
+            "deadline_text": program.get("end_date") or program.get("start_date"),
+        }
+    ) or None
+
+
+def parse_programs(raw: dict, url: str, fetched_at: str) -> list[Program]:
+    """Parse a raw MySchools school-detail JSON response into Program records.
+
+    Raises MySchoolsParseError -- rather than returning [] -- if the response
+    doesn't have the shape this module expects, so an upstream page-shape
+    change fails loudly instead of silently producing no data.
+    """
+    if not isinstance(raw, dict):
+        raise MySchoolsParseError(f"Expected a JSON object, got {type(raw).__name__}")
+
+    school = raw.get("school")
+    if not isinstance(school, dict) or not school.get("dbn"):
+        raise MySchoolsParseError("Response is missing school.dbn")
+
+    programs_raw = raw.get("programs")
+    if not isinstance(programs_raw, list):
+        raise MySchoolsParseError(
+            "Response is missing a 'programs' list -- MySchools page shape may have changed"
+        )
+    if len(programs_raw) == 0:
+        raise MySchoolsParseError(f"{school.get('dbn')} has zero programs -- expected at least one")
+
+    dbn = school["dbn"]
+    school_name = raw.get("name") or school.get("name") or dbn
+    admissions_cycle = school.get("school_year")
+    provenance = Provenance(url=url, fetched_at=fetched_at, admissions_cycle=admissions_cycle)
+
+    programs = []
+    for entry in programs_raw:
+        if not isinstance(entry, dict):
+            raise MySchoolsParseError(f"Program entry is not an object: {entry!r}")
+        program_info = entry.get("program")
+        if not isinstance(program_info, dict) or not program_info.get("name"):
+            raise MySchoolsParseError(f"Program entry is missing program.name: {entry!r}")
+
+        method = entry.get("admissions_method") or {}
+
+        programs.append(
+            Program(
+                dbn=dbn,
+                school_name=school_name,
+                program_name=program_info["name"],
+                program_code=program_info.get("code"),
+                admissions_method=method.get("name"),
+                admissions_method_description=method.get("description"),
+                grade_span=_program_grade_span(entry, raw),
+                seats=_program_seats(entry),
+                eligibility=_program_eligibility(entry, raw),
+                requirements=_program_requirements(entry),
+                description=entry.get("description"),
+                provenance=provenance,
+            )
+        )
+    return programs
+
+
+def scrape_school_programs(
+    dbn_or_url: str,
+    process_id: int = PROCESS_ID_HIGH_SCHOOL,
+    cache_dir: Optional[Path] = DEFAULT_CACHE_DIR,
+    **fetch_kwargs,
+) -> list[Program]:
+    """Fetch + parse in one call: given a DBN or MySchools school URL,
+    return that school's Program records."""
+    raw, url, fetched_at = fetch_school(dbn_or_url, process_id=process_id, cache_dir=cache_dir, **fetch_kwargs)
+    return parse_programs(raw, url, fetched_at)
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: scrape_myschools.py <DBN or MySchools school URL> [...]", file=sys.stderr)
+        return 1
+    all_programs = []
+    for arg in argv:
+        try:
+            programs = scrape_school_programs(arg)
+        except MySchoolsError as exc:
+            print(f"error: {arg}: {exc}", file=sys.stderr)
+            return 1
+        all_programs.extend(p.to_dict() for p in programs)
+    print(json.dumps(all_programs, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/test_scrape_myschools.py
+++ b/scripts/test_scrape_myschools.py
@@ -1,0 +1,122 @@
+"""
+Tests for scrape_myschools.py (issue #135).
+
+Runs entirely against saved fixtures in myschools_fixtures/ -- no network
+calls. Run with: python3 -m pytest scripts/test_scrape_myschools.py
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scrape_myschools import (
+    MySchoolsParseError,
+    parse_programs,
+)
+
+FIXTURES = Path(__file__).parent / "myschools_fixtures"
+FAKE_URL = "https://www.myschools.nyc/en/api/v2/schools/process/1/fixture/"
+FAKE_FETCHED_AT = "2026-08-05T00:00:00+00:00"
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_laguardia_returns_six_distinct_programs():
+    raw = load_fixture("laguardia_03M485.json")
+    programs = parse_programs(raw, FAKE_URL, FAKE_FETCHED_AT)
+
+    assert len(programs) == 6
+
+    names = [p.program_name for p in programs]
+    assert len(set(names)) == 6, f"expected 6 distinct names, got {names}"
+    assert {"Dance", "Drama", "Fine Arts", "Instrumental Music", "Technical Theater", "Vocal Music"} == set(names)
+
+    codes = [p.program_code for p in programs]
+    assert len(set(codes)) == 6
+
+    for p in programs:
+        assert p.dbn == "03M485"
+        assert p.admissions_method == "Audition"
+
+
+def test_single_program_school_returns_one_record():
+    raw = load_fixture("single_program_02M047.json")
+    programs = parse_programs(raw, FAKE_URL, FAKE_FETCHED_AT)
+
+    assert len(programs) == 1
+    program = programs[0]
+    assert program.dbn == "02M047"
+    assert program.program_name == "American Sign Language Studies Program"
+    assert program.admissions_method == "Screened"
+
+
+def test_mixed_admissions_methods_school():
+    raw = load_fixture("mixed_methods_gramercy_02M374.json")
+    programs = parse_programs(raw, FAKE_URL, FAKE_FETCHED_AT)
+
+    assert len(programs) == 3
+    methods = {p.program_name: p.admissions_method for p in programs}
+    assert methods == {
+        "Capstone Scholars": "Screened With Assessment",
+        "Theater Arts": "Audition",
+        "Visual Arts": "Audition",
+    }
+    # Not all six programs are the same method -- distinguishes this school
+    # from LaGuardia, where a single school-level "track" would be wrong.
+    assert len(set(methods.values())) > 1
+
+
+def test_malformed_page_shape_fails_loudly():
+    raw = load_fixture("malformed_missing_programs.json")
+    with pytest.raises(MySchoolsParseError):
+        parse_programs(raw, FAKE_URL, FAKE_FETCHED_AT)
+
+
+def test_not_a_dict_fails_loudly():
+    with pytest.raises(MySchoolsParseError):
+        parse_programs(["not", "a", "dict"], FAKE_URL, FAKE_FETCHED_AT)
+
+
+def test_empty_programs_list_fails_loudly():
+    raw = load_fixture("single_program_02M047.json")
+    raw["programs"] = []
+    with pytest.raises(MySchoolsParseError):
+        parse_programs(raw, FAKE_URL, FAKE_FETCHED_AT)
+
+
+def test_provenance_is_captured_from_the_page_not_hardcoded():
+    raw = load_fixture("laguardia_03M485.json")
+    programs = parse_programs(raw, FAKE_URL, FAKE_FETCHED_AT)
+
+    for p in programs:
+        prov = p.provenance.to_dict()
+        assert prov["source"] == "MySchools"
+        assert prov["url"] == FAKE_URL
+        assert prov["fetched_at"] == FAKE_FETCHED_AT
+        # Derived from school.school_year in the fixture, not typed by hand.
+        assert prov["admissions_cycle"] == raw["school"]["school_year"]
+
+
+def test_missing_fields_are_absent_not_empty_or_zero():
+    raw = load_fixture("laguardia_03M485.json")
+    programs = parse_programs(raw, FAKE_URL, FAKE_FETCHED_AT)
+    dance = next(p for p in programs if p.program_name == "Dance")
+    serialized = dance.to_dict()
+
+    # The Dance program's own grades_description is blank in the fixture,
+    # but grade_span still comes back present via the school-level fallback.
+    assert serialized["grade_span"] == "9 to 12"
+
+    # Fields with no data anywhere (e.g. this program's general-education
+    # seat count is null in the fixture) must be absent, not "" or 0.
+    seats = serialized.get("seats", {})
+    assert "general_education" not in seats or seats["general_education"].get("seats") not in (0, "", None)
+
+    for key, value in serialized.items():
+        if isinstance(value, str):
+            assert value != "", f"{key} should be omitted, not an empty string"
+        if isinstance(value, (list, dict)):
+            assert len(value) > 0, f"{key} should be omitted, not empty"


### PR DESCRIPTION
Everything is verified green: `npm test` (33/33 suites, 779 tests), `npm run build` (exit 0), and the Python fixture-based test suite (8/8). The only untracked file is `LESSONS.md`, which is intentionally left uncommitted per instructions. The fix is already committed as `5e42a98`.

## Summary

The build/test failure the coordinator hit was pre-existing environment flakiness (`next/font` timing out fetching Google Fonts during `npm run build`), unrelated to this change — a retry succeeded cleanly. My actual work was already committed from the prior session; I verified it end-to-end rather than re-doing it.

**What #135 delivers:**
- `scripts/scrape_myschools.py` — a standalone per-program scraper for MySchools. Key discovery: `/en/schools/<dbn>/` is a client-rendered Angular shell with no data in the initial HTML, but its own bootstrap config discloses a public, unauthenticated JSON endpoint (`/en/api/v2/schools/process/{process_id}/{dbn}/`) that returns full per-program data — no login/cookie required. The module fetches that endpoint (with descriptive User-Agent, delay, retry/backoff, and disk caching) instead of parsing HTML, since there's no server-rendered markup to parse.
- `Program` and `Provenance` dataclasses define the record shape, documented in the module docstring, including which fields MySchools actually publishes vs. what was hoped for.
- `scripts/myschools_fixtures/` — real saved JSON responses: LaGuardia (6 distinct audition programs — Dance, Drama, Fine Arts, Instrumental Music, Technical Theater, Vocal Music), a single-program school, Gramercy Arts (mixed Audition/Screened With Assessment), and a crafted malformed fixture (missing `programs` key).
- `scripts/test_scrape_myschools.py` — 8 pytest tests against those fixtures only (no network), covering multi-program, single-program, mixed-methods, malformed-shape (raises `MySchoolsParseError` rather than returning `[]`), provenance capture, and the "absent, not empty/zero" missing-data rule.

`data/schools.json`, the pipeline, and all pages are untouched, matching scope.

Closes #135