### PR TITLE
fix: issue #164 - Replace the truncated DOE prose on /find rows with structured facts

### DIFF
--- a/__tests__/find-row-facts.test.ts
+++ b/__tests__/find-row-facts.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Issue #164: the /find row rationale line used to be
+ * `truncate(school.doe_data?.overview ?? '', 140)` — DOE marketing prose,
+ * identical for every parent and chopped mid-sentence. It's replaced with a
+ * few structured, DOE-published facts (lib/school-detail-utils.ts's
+ * buildFindRowFacts/buildFindRowSummary), consistent with how #116 selects
+ * and formats facts for the school detail page.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { buildFindRowFacts, buildFindRowSummary } from '../lib/school-detail-utils'
+import { School } from '../types'
+
+function makeSchool(overrides: Partial<School> & { dbn?: string } = {}): School {
+  return {
+    dbn: overrides.dbn ?? 'X000',
+    name: overrides.name ?? 'Test School',
+    borough: overrides.borough ?? 'Brooklyn',
+    size: overrides.size ?? 'medium',
+    total_students: null,
+    applicants_per_seat: null,
+    academic_score_pct: null,
+    survey_score_pct: null,
+    admissions_types: overrides.admissions_types ?? [],
+    programs: overrides.programs ?? [],
+    flags: {
+      has_shsat: false,
+      has_audition: false,
+      has_screened: false,
+      has_open: false,
+      has_borough_priority: false,
+      is_hidden_gem: false,
+      has_consortium: false,
+      has_ib: false,
+      ...overrides.flags,
+    },
+    doe_data: {
+      overview: '',
+      language: '',
+      extracurriculars: '',
+      website: '',
+      phone: '',
+      address: '',
+      zip: '',
+      ...overrides.doe_data,
+    },
+    sift_url: '',
+    last_verified: '',
+    ...overrides,
+  }
+}
+
+describe('buildFindRowFacts (issue #164)', () => {
+  it('a school missing every optional field yields no facts at all', () => {
+    expect(buildFindRowFacts(makeSchool())).toEqual([])
+    expect(buildFindRowSummary(makeSchool())).toBe('')
+  })
+
+  it('selects graduation rate, college & career rate, and AP course count, in that fixed order', () => {
+    const school = makeSchool({
+      doe_data: {
+        overview: '',
+        language: '',
+        extracurriculars: '',
+        website: '',
+        phone: '',
+        address: '',
+        zip: '',
+        graduation_rate: 0.94,
+        college_career_rate: 0.88,
+        advancedplacement_courses: 'Calculus AB, Biology, US History',
+      },
+    })
+    expect(buildFindRowFacts(school)).toEqual([
+      '94% graduation rate',
+      '88% college & career rate',
+      '3 AP courses',
+    ])
+    expect(buildFindRowSummary(school)).toBe(
+      '94% graduation rate · 88% college & career rate · 3 AP courses'
+    )
+  })
+
+  it('singularizes a single AP course', () => {
+    const school = makeSchool({
+      doe_data: {
+        overview: '',
+        language: '',
+        extracurriculars: '',
+        website: '',
+        phone: '',
+        address: '',
+        zip: '',
+        advancedplacement_courses: 'Calculus AB',
+      },
+    })
+    expect(buildFindRowFacts(school)).toEqual(['1 AP course'])
+  })
+
+  it('a sparse record with only one published fact renders a short, single-fact line', () => {
+    const school = makeSchool({
+      doe_data: {
+        overview: '',
+        language: '',
+        extracurriculars: '',
+        website: '',
+        phone: '',
+        address: '',
+        zip: '',
+        graduation_rate: 0.72,
+      },
+    })
+    expect(buildFindRowFacts(school)).toEqual(['72% graduation rate'])
+    expect(buildFindRowSummary(school)).toBe('72% graduation rate')
+  })
+
+  it('omits a missing rate rather than rendering it as zero, while a genuine DOE-reported 0 still shows', () => {
+    const missing = makeSchool()
+    expect(buildFindRowFacts(missing)).not.toContain('0% graduation rate')
+
+    const genuineZero = makeSchool({
+      doe_data: {
+        overview: '',
+        language: '',
+        extracurriculars: '',
+        website: '',
+        phone: '',
+        address: '',
+        zip: '',
+        graduation_rate: 0,
+      },
+    })
+    expect(buildFindRowFacts(genuineZero)).toContain('0% graduation rate')
+  })
+
+  it('never emits an empty string or orphaned separator when facts are missing', () => {
+    const school = makeSchool({
+      doe_data: {
+        overview: '',
+        language: '',
+        extracurriculars: '',
+        website: '',
+        phone: '',
+        address: '',
+        zip: '',
+        college_career_rate: 0.81,
+      },
+    })
+    const summary = buildFindRowSummary(school)
+    expect(summary).toBe('81% college & career rate')
+    expect(summary).not.toMatch(/·\s*·/)
+    expect(summary.startsWith('·')).toBe(false)
+    expect(summary.endsWith('·')).toBe(false)
+  })
+})
+
+describe('/find row no longer renders the DOE overview prose (issue #164)', () => {
+  const src = fs.readFileSync(path.join(__dirname, '../app/find/FindClient.tsx'), 'utf-8')
+
+  it('FindClient.tsx does not read doe_data.overview', () => {
+    expect(src).not.toContain('doe_data?.overview')
+    expect(src).not.toContain('doe_data.overview')
+  })
+
+  it('the row rationale is built from buildFindRowSummary, not a raw truncated string', () => {
+    expect(src).toContain('buildFindRowSummary(school)')
+  })
+})
+
+describe('SchoolRow omits the rationale line entirely when empty (issue #164)', () => {
+  it('guards the rationale div with a truthiness check so a sparse row renders shorter, not with a blank line', () => {
+    const src = fs.readFileSync(path.join(__dirname, '../components/ui/SchoolRow.tsx'), 'utf-8')
+    expect(src).toMatch(/\{rationale\s*&&/)
+  })
+})
+
+describe('/find row against the real dataset (issue #164)', () => {
+  const SCHOOLS_PATH = path.resolve(__dirname, '../schools.json')
+  const dataAvailable = fs.existsSync(SCHOOLS_PATH)
+
+  ;(dataAvailable ? it : it.skip)(
+    'never produces a fact list containing an empty string, for any real school',
+    () => {
+      const schools: School[] = JSON.parse(fs.readFileSync(SCHOOLS_PATH, 'utf-8'))
+      for (const school of schools) {
+        const facts = buildFindRowFacts(school)
+        expect(facts.every((f) => f.trim().length > 0)).toBe(true)
+      }
+    }
+  )
+})

--- a/app/find/FindClient.tsx
+++ b/app/find/FindClient.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/lib/school-list-utils'
 import { extractFilters, QueryFilters, appliedSignals, removeSignal } from '@/lib/query-filters'
 import { getUnmetCriteria } from '@/lib/soft-match'
+import { buildFindRowSummary } from '@/lib/school-detail-utils'
 import { Chip, Button, SchoolRow } from '@/components/ui'
 import FindRail from './FindRail'
 
@@ -39,13 +40,6 @@ function toggleValue(list: string[], value: string): string[] {
 function formatSchoolName(name: string): string {
   if (name.endsWith(', The')) return 'The ' + name.slice(0, -5)
   return name
-}
-
-function truncate(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text
-  const cut = text.slice(0, maxLen)
-  const lastSpace = cut.lastIndexOf(' ')
-  return `${cut.slice(0, lastSpace > 0 ? lastSpace : maxLen)}…`
 }
 
 interface Props {
@@ -382,7 +376,7 @@ export default function FindClient({ schools, initialFilters }: Props) {
                     }
                     isHiddenGem={school.flags.is_hidden_gem}
                     metadata={`${neighborhood} · ${tracks} · ${students} students`}
-                    rationale={truncate(school.doe_data?.overview ?? '', 140)}
+                    rationale={buildFindRowSummary(school)}
                     statValue={
                       school.applicants_per_seat != null ? school.applicants_per_seat.toFixed(1) : '—'
                     }

--- a/components/ui/SchoolRow.tsx
+++ b/components/ui/SchoolRow.tsx
@@ -39,9 +39,11 @@ export default function SchoolRow({
           )}
         </div>
         <div className="font-sans text-[13.5px] text-faint">{metadata}</div>
-        <div className="font-sans text-[14.5px] leading-[1.5] text-ink-2 max-w-[430px]" style={{ textWrap: 'pretty' }}>
-          {rationale}
-        </div>
+        {rationale && (
+          <div className="font-sans text-[14.5px] leading-[1.5] text-ink-2 max-w-[430px]" style={{ textWrap: 'pretty' }}>
+            {rationale}
+          </div>
+        )}
       </div>
 
       <div className="flex flex-col gap-[3px] order-2 min-[900px]:order-none">

--- a/lib/school-detail-utils.ts
+++ b/lib/school-detail-utils.ts
@@ -231,6 +231,49 @@ export function getMissingActivityLabels(school: School): string[] {
   return ACTIVITY_GROUP_DEFS.filter((g) => g.get(school).length === 0).map((g) => g.missingLabel)
 }
 
+// ── Find-row facts (/find) ───────────────────────────────────────────────────
+
+// The /find row rationale line used to be doe_data.overview — DOE marketing
+// prose truncated at 140 characters — identical regardless of what the parent
+// filtered for (issue #164). These are the published facts that most affect a
+// fit decision without repeating what the row's metadata line already shows
+// (neighborhood, admissions track, enrollment): the two outcome rates DOE
+// reports for nearly every school, and how many AP courses it offers. Same
+// omit-don't-zero-fill rule as buildStatCells.
+const FIND_ROW_RATE_FACTS: {
+  key: string
+  get: (school: School) => number | null | undefined
+  format: (value: number) => string
+}[] = [
+  {
+    key: 'graduationRate',
+    get: (s) => s.doe_data?.graduation_rate,
+    format: (v) => `${ratePct(v)} graduation rate`,
+  },
+  {
+    key: 'collegeCareerRate',
+    get: (s) => s.doe_data?.college_career_rate,
+    format: (v) => `${ratePct(v)} college & career rate`,
+  },
+]
+
+/** Only the facts DOE actually published for this school, in fixed order. A school missing most of them yields a short (or empty) list, never a zero-filled one. */
+export function buildFindRowFacts(school: School): string[] {
+  const facts = FIND_ROW_RATE_FACTS.filter((f) => isPresent(f.get(school))).map((f) =>
+    f.format(f.get(school) as number)
+  )
+
+  const apCount = parseCommaList(school.doe_data?.advancedplacement_courses).length
+  if (apCount > 0) facts.push(`${apCount} AP course${apCount === 1 ? '' : 's'}`)
+
+  return facts
+}
+
+/** The /find row's replacement for the truncated DOE overview: structured facts on one line, or '' when DOE published none of them. */
+export function buildFindRowSummary(school: School): string {
+  return buildFindRowFacts(school).join(' · ')
+}
+
 /**
  * The "NOT OFFERED" sentence — a fact about the school (it doesn't run these),
  * not a DOE reporting gap, so it reads "no X" rather than "not published".


### PR DESCRIPTION
Committed. Summary:

## What changed

Replaced the truncated DOE `overview` prose on `/find` rows with structured, verified facts:

- **`lib/school-detail-utils.ts`** — added `buildFindRowFacts()` / `buildFindRowSummary()`, following the same "omit, never zero-fill" convention as #116's `buildStatCells`. Picks three facts, in fixed order:
  - **Graduation rate** and **college & career rate** — the two DOE-published outcome rates most predictive of fit, and not shown anywhere else in the row.
  - **AP course count** — a rigor/breadth signal, distinct from the admissions track already shown in the metadata line.
  
  Attendance rate, languages, diploma endorsements, and admissions method were considered but skipped: admissions method already appears in the metadata line, and the rest are either less decision-relevant at a glance or add length without adding a distinct signal — keeping the row at three facts max preserves scannability.

- **`app/find/FindClient.tsx`** — swapped `truncate(school.doe_data?.overview ?? '', 140)` for `buildFindRowSummary(school)`; removed the now-dead `truncate` helper.

- **`components/ui/SchoolRow.tsx`** — the rationale line only renders when non-empty, so a school with no published facts gets a shorter row instead of a blank line.

- **`__tests__/find-row-facts.test.ts`** (new) — covers fact selection/ordering/formatting, the sparse-record case (no facts → `''`, no orphaned `·`), the real-0-vs-missing distinction, a source-level guard that `/find` no longer reads `doe_data.overview`, and a sweep of the real dataset for empty-string facts.

`npm test` (789 tests) and `npm run build` both pass.

Closes #164