### PR TITLE
fix: issue #163 - Make /find rows obviously clickable — two of four testers never opened a school

### DIFF
--- a/__tests__/find-row-affordance.test.ts
+++ b/__tests__/find-row-affordance.test.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+// Issue #163 — /find rows must be obviously clickable. Two of four April 23
+// testers never realized a school row opened anything: the only affordance
+// was an 18px bold name with hover:underline. This suite locks in the fix:
+// the whole row becomes the navigable target (a full-row overlay link), the
+// Add button stays a separate, independently-clickable control, and the
+// affordance is visible without hovering (cursor + focus outline), not just
+// on hover.
+//
+// This repo's jest config runs in the `node` environment with no
+// jsdom/testing-library, and no existing component test renders a .tsx
+// module directly (see ui-primitives.test.ts, school-detail.test.ts) — every
+// test here follows that same source-text convention.
+
+function readSource(relPath: string): string {
+  return fs.readFileSync(path.join(__dirname, '..', relPath), 'utf-8')
+}
+
+describe('components/ui/SchoolRow — whole row is the click target (issue #163)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('components/ui/SchoolRow.tsx')
+  })
+
+  it('accepts an href prop and renders a full-row overlay Link', () => {
+    expect(src).toMatch(/href:\s*string/)
+    expect(src).toContain('<Link')
+    expect(src).toMatch(/href=\{href\}/)
+    expect(src).toContain('absolute inset-0')
+  })
+
+  it('makes the row container relatively positioned so the overlay anchors to it', () => {
+    expect(src).toMatch(/className="relative grid/)
+  })
+
+  it('shows a pointer cursor on the row link without requiring hover', () => {
+    expect(src).toMatch(/absolute inset-0[^"]*cursor-pointer/)
+  })
+
+  it('gives the row link a visible 2px accent focus outline (design system §08 Focus)', () => {
+    expect(src).toContain('focus-visible:outline')
+    expect(src).toContain('focus-visible:outline-2')
+    expect(src).toContain('focus-visible:outline-offset-2')
+    expect(src).toContain('focus-visible:outline-accent')
+  })
+
+  it('lifts the action cell above the overlay link with a positive z-index (Add stays independently clickable)', () => {
+    expect(src).toMatch(/className="relative z-10 order-3[^"]*">\{action\}/)
+  })
+
+  it('does not nest the action inside the overlay Link (no nested-anchor markup)', () => {
+    const linkStart = src.indexOf('<Link')
+    const linkEnd = src.indexOf('/>', linkStart)
+    const linkBlock = src.slice(linkStart, linkEnd)
+    expect(linkBlock).not.toContain('{action}')
+    expect(linkBlock).not.toContain('{name}')
+  })
+})
+
+describe('FindClient — row link wiring keeps Add independent and preserves detail params (issue #163)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('app/find/FindClient.tsx')
+  })
+
+  it('passes the full detailHref (with rank/total/matched params) to SchoolRow as href', () => {
+    expect(src).toContain('href={detailHref}')
+    expect(src).toContain("detailQuery.set('pos', String(i + 1))")
+    expect(src).toContain("detailQuery.set('total', String(ranked.length))")
+    expect(src).toContain("detailQuery.set('matched', matchedValues.join(','))")
+    expect(src).toContain('const detailHref = `/school/${school.dbn}?${detailQuery.toString()}`')
+  })
+
+  it('no longer wraps the row name in its own nested Link (single row-level link, not two)', () => {
+    const nameLineMatch = src.match(/name=\{[^}\n]*\}/)
+    expect(nameLineMatch).not.toBeNull()
+    expect(nameLineMatch![0]).not.toContain('Link')
+  })
+
+  it('keeps the Add/Remove button wired to toggleAdded, independent of the row link', () => {
+    const actionStart = src.indexOf('action={')
+    const actionBlock = src.slice(actionStart, actionStart + 400)
+    expect(actionBlock).toContain('onClick={() => toggleAdded(school.dbn)}')
+    expect(actionBlock).not.toContain('<Link')
+  })
+})

--- a/app/find/FindClient.tsx
+++ b/app/find/FindClient.tsx
@@ -375,11 +375,8 @@ export default function FindClient({ schools, initialFilters }: Props) {
                   <SchoolRow
                     key={school.dbn}
                     rowNumber={i + 1}
-                    name={
-                      <Link href={detailHref} className="hover:underline underline-offset-2">
-                        {formatSchoolName(school.name)}
-                      </Link>
-                    }
+                    name={formatSchoolName(school.name)}
+                    href={detailHref}
                     isHiddenGem={school.flags.is_hidden_gem}
                     metadata={`${neighborhood} · ${tracks} · ${students} students`}
                     rationale={truncate(school.doe_data?.overview ?? '', 140)}

--- a/components/ui/SchoolRow.tsx
+++ b/components/ui/SchoolRow.tsx
@@ -1,8 +1,10 @@
 import { ReactNode } from 'react'
+import Link from 'next/link'
 
 interface Props {
   rowNumber: number
   name: ReactNode
+  href: string
   isHiddenGem?: boolean
   metadata: string
   rationale: string
@@ -14,6 +16,7 @@ interface Props {
 export default function SchoolRow({
   rowNumber,
   name,
+  href,
   isHiddenGem = false,
   metadata,
   rationale,
@@ -23,8 +26,14 @@ export default function SchoolRow({
 }: Props) {
   return (
     <div
-      className="grid grid-cols-1 min-[900px]:grid-cols-[34px_1fr_128px_96px] gap-4 items-start px-9 py-[22px] border-b border-rule-light hover:bg-surface-2 transition-colors duration-[120ms] ease-out"
+      className="relative grid grid-cols-1 min-[900px]:grid-cols-[34px_1fr_128px_96px] gap-4 items-start px-9 py-[22px] border-b border-rule-light hover:bg-surface-2 transition-colors duration-[120ms] ease-out"
     >
+      <Link
+        href={href}
+        aria-label={typeof name === 'string' ? name : undefined}
+        className="absolute inset-0 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      />
+
       <div className="hidden min-[900px]:block font-mono text-[13px] text-row-index pt-[5px]">
         {String(rowNumber).padStart(2, '0')}
       </div>
@@ -49,7 +58,7 @@ export default function SchoolRow({
         <div className="font-mono text-[11.5px] tracking-[0.06em] uppercase text-faint">{statLabel}</div>
       </div>
 
-      <div className="order-3 min-[900px]:order-none max-[899px]:w-full">{action}</div>
+      <div className="relative z-10 order-3 min-[900px]:order-none max-[899px]:w-full">{action}</div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

**Problem:** On `/find`, only the 18px school name was a link (`hover:underline`); the row's larger `hover:bg-surface-2` area gave no indication it was clickable. Two of four testers never opened a school.

**Fix — whole row is the click target ("stretched link" pattern):**
- `components/ui/SchoolRow.tsx`: added an `href` prop and a full-row `<Link>` positioned `absolute inset-0` over the row (row container now `relative`). It's empty/invisible but covers the entire row, so clicking anywhere — name, metadata, rationale, stat — navigates. It carries `cursor-pointer` and a `focus-visible:outline-2 outline-offset-2 outline-accent` ring per the design system's Focus spec (§08), so the affordance is visible without hovering and on keyboard focus.
- The action cell (`Add`/`Remove` button) got `relative z-10`, lifting it in the paint/stacking order above the overlay link so it intercepts its own clicks — no `stopPropagation` needed, since it's a sibling, not nested inside the link.
- `app/find/FindClient.tsx`: removed the old per-name `<Link>` wrapper (avoiding a second, redundant tab stop) and instead passes the existing `detailHref` (with `rank`/`total`/`matched` query params, unchanged) straight to `SchoolRow` as `href`.

**Why this option:** it needed no new visual primitive (no chevron/icon, which the design system doesn't define anywhere and explicitly warns against inventing), reuses states already in the system (hover fill, cursor, focus outline), and gives the largest possible target — directly addressing "never opened a school."

**Accessibility:** single native `<a>` per row (real Tab stop, Enter-activates), plus the `Add` button as a second stop — no nested anchors, no `role="button"` hacks.

Added `__tests__/find-row-affordance.test.ts` (9 tests) covering: the overlay link/href wiring, cursor/focus classes, the z-10 lift keeping Add independent, no nested-anchor markup, and that `FindClient` preserves the `detailHref` params. Full suite (35 files, 791 tests) and `npm run build` both pass.

Closes #163