### PR TITLE
fix: issue #161 - Show academic level as an actual percentage on /find rows

### DIFF
--- a/__tests__/find-row-academic-score.test.ts
+++ b/__tests__/find-row-academic-score.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #161: academic_score_pct is on every school record and drives the
+ * academic-level filter (lib/school-list-utils.ts), but was never rendered
+ * anywhere in the UI — a parent could filter to "high academic" and never
+ * see the number behind it. This surfaces it as the leading fact in the
+ * /find row's structured-facts line (lib/school-detail-utils.ts's
+ * buildFindRowFacts/buildFindRowSummary, introduced by issue #164), using
+ * the same `pct` formatting the school detail page's "Academic score" stat
+ * cell already uses, so the figure reads identically on both screens.
+ */
+
+import { buildFindRowFacts, buildFindRowSummary } from '../lib/school-detail-utils'
+import { School } from '../types'
+
+function makeSchool(overrides: Partial<School> & { dbn?: string } = {}): School {
+  return {
+    dbn: overrides.dbn ?? 'X000',
+    name: overrides.name ?? 'Test School',
+    borough: overrides.borough ?? 'Brooklyn',
+    size: overrides.size ?? 'medium',
+    total_students: null,
+    applicants_per_seat: null,
+    academic_score_pct: null,
+    survey_score_pct: null,
+    admissions_types: overrides.admissions_types ?? [],
+    programs: overrides.programs ?? [],
+    flags: {
+      has_shsat: false,
+      has_audition: false,
+      has_screened: false,
+      has_open: false,
+      has_borough_priority: false,
+      is_hidden_gem: false,
+      has_consortium: false,
+      has_ib: false,
+      ...overrides.flags,
+    },
+    doe_data: {
+      overview: '',
+      language: '',
+      extracurriculars: '',
+      website: '',
+      phone: '',
+      address: '',
+      zip: '',
+      ...overrides.doe_data,
+    },
+    sift_url: '',
+    last_verified: '',
+    ...overrides,
+  }
+}
+
+describe('buildFindRowFacts surfaces academic_score_pct (issue #161)', () => {
+  it('renders a populated score as a rounded percentage, leading the fact list', () => {
+    const school = makeSchool({
+      academic_score_pct: 85,
+      doe_data: {
+        overview: '',
+        language: '',
+        extracurriculars: '',
+        website: '',
+        phone: '',
+        address: '',
+        zip: '',
+        graduation_rate: 0.94,
+      },
+    })
+    expect(buildFindRowFacts(school)).toEqual(['85% academic score', '94% graduation rate'])
+    expect(buildFindRowSummary(school)).toBe('85% academic score · 94% graduation rate')
+  })
+
+  it('rounds a fractional score the same way the school detail stat cell does', () => {
+    const school = makeSchool({ academic_score_pct: 82.6 })
+    expect(buildFindRowFacts(school)).toEqual(['83% academic score'])
+  })
+
+  it('a null score is omitted entirely — never rendered as 0%', () => {
+    const missing = makeSchool({ academic_score_pct: null })
+    expect(buildFindRowFacts(missing)).not.toContain('0% academic score')
+    expect(buildFindRowFacts(missing).some((f) => f.includes('academic score'))).toBe(false)
+    expect(buildFindRowSummary(missing)).not.toContain('academic score')
+  })
+
+  it('a genuine DOE-reported 0 still renders — distinguishable from a missing score', () => {
+    const school = makeSchool({ academic_score_pct: 0 })
+    expect(buildFindRowFacts(school)).toContain('0% academic score')
+  })
+
+  it('never emits an empty string or orphaned separator when only the academic score is present', () => {
+    const school = makeSchool({ academic_score_pct: 70 })
+    const summary = buildFindRowSummary(school)
+    expect(summary).toBe('70% academic score')
+    expect(summary).not.toMatch(/·\s*·/)
+    expect(summary.startsWith('·')).toBe(false)
+    expect(summary.endsWith('·')).toBe(false)
+  })
+})

--- a/lib/school-detail-utils.ts
+++ b/lib/school-detail-utils.ts
@@ -237,14 +237,22 @@ export function getMissingActivityLabels(school: School): string[] {
 // prose truncated at 140 characters — identical regardless of what the parent
 // filtered for (issue #164). These are the published facts that most affect a
 // fit decision without repeating what the row's metadata line already shows
-// (neighborhood, admissions track, enrollment): the two outcome rates DOE
-// reports for nearly every school, and how many AP courses it offers. Same
-// omit-don't-zero-fill rule as buildStatCells.
+// (neighborhood, admissions track, enrollment): the academic score the
+// filter itself ranks by (issue #161 — parents asked for the number, not
+// just a word), the two outcome rates DOE reports for nearly every school,
+// and how many AP courses it offers. Same omit-don't-zero-fill rule as
+// buildStatCells, and the same `pct` formatting school-detail's "Academic
+// score" stat cell uses, so the figure reads identically on both screens.
 const FIND_ROW_RATE_FACTS: {
   key: string
   get: (school: School) => number | null | undefined
   format: (value: number) => string
 }[] = [
+  {
+    key: 'academicScore',
+    get: (s) => s.academic_score_pct,
+    format: (v) => `${pct(v)} academic score`,
+  },
   {
     key: 'graduationRate',
     get: (s) => s.doe_data?.graduation_rate,


### PR DESCRIPTION
Committed on `task-161-show-academic-level-as-an-actu`. Summary:

## Summary

`academic_score_pct` was on every school record and drove the academic-level filter, but was never rendered on `/find` — a parent could filter to "high academic" and see no supporting number.

**Fix:** Added the academic score as the leading fact in the `/find` row's structured-facts line (`buildFindRowFacts`/`buildFindRowSummary` in `lib/school-detail-utils.ts`), formatted `85% academic score` using the same `pct` rounding the school detail page's "Academic score" stat cell already uses. Since `FindClient.tsx` already renders that line via `buildFindRowSummary(school)`, no component changes were needed.

**Design decision:** The design system freezes `SchoolRow` at one `StatCell` slot (already used for apps/seat), so I placed the figure in the existing facts line rather than inventing a second stat slot or new visual treatment — reusing the mechanism issue #164 already built for exactly this kind of DOE-published fact.

**Null handling:** A missing score is simply omitted from the facts list (same omit-don't-zero-fill rule the line already applies to graduation rate, etc.), while a genuine DOE-reported `0` still renders as `0% academic score` — never conflated with absence.

Added `__tests__/find-row-academic-score.test.ts` covering populated scores, rounding, null omission, and genuine-zero cases. `npm test` (806 tests) and `npm run build` both pass.

Closes #161