### PR TITLE
fix: issue #160 - Uncap the /find list: show 30 on first paint, not 15

### DIFF
--- a/__tests__/find-initial-count.test.ts
+++ b/__tests__/find-initial-count.test.ts
@@ -1,0 +1,47 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { INITIAL_COUNT, PAGE_SIZE } from '../lib/school-list-utils'
+
+// Issue #160 — /find showed only 15 of ~400 schools on first paint. Parent
+// research (April 23) asked for a longer list, not a shorter one: 30-50
+// visible. This suite locks the initial count at 30 so it can't silently
+// regress to PAGE_SIZE (15), while keeping PAGE_SIZE as the "N more
+// matches" increment and the pagination affordance itself intact.
+
+function readSource(relPath: string): string {
+  return fs.readFileSync(path.join(__dirname, '..', relPath), 'utf-8')
+}
+
+describe('INITIAL_COUNT (issue #160: 30 schools on first paint, not 15)', () => {
+  it('is 30, not the old 15-row cap', () => {
+    expect(INITIAL_COUNT).toBe(30)
+  })
+
+  it('keeps PAGE_SIZE at 15 as the "show more" increment', () => {
+    expect(PAGE_SIZE).toBe(15)
+  })
+})
+
+describe('FindClient — seeds and resets visibleCount from INITIAL_COUNT (issue #160)', () => {
+  let src: string
+
+  beforeAll(() => {
+    src = readSource('app/find/FindClient.tsx')
+  })
+
+  it('seeds visibleCount from INITIAL_COUNT, not PAGE_SIZE', () => {
+    expect(src).toContain('useState(INITIAL_COUNT)')
+    expect(src).not.toContain('useState(PAGE_SIZE)')
+  })
+
+  it('resets visibleCount to INITIAL_COUNT when filters change', () => {
+    const effectStart = src.indexOf('setVisibleCount(INITIAL_COUNT)')
+    expect(effectStart).toBeGreaterThan(-1)
+    const surrounding = src.slice(effectStart - 80, effectStart + 80)
+    expect(surrounding).toContain('[filters]')
+  })
+
+  it('still grows visibleCount by PAGE_SIZE on "more matches" — pagination is not removed', () => {
+    expect(src).toContain('setVisibleCount((c) => c + PAGE_SIZE)')
+  })
+})

--- a/app/find/FindClient.tsx
+++ b/app/find/FindClient.tsx
@@ -7,6 +7,7 @@ import { School } from '@/types'
 import {
   FindFilters,
   EMPTY_FIND_FILTERS,
+  INITIAL_COUNT,
   PAGE_SIZE,
   ADDED_SCHOOLS_KEY,
   applyFindFilters,
@@ -53,7 +54,7 @@ export default function FindClient({ schools, initialFilters }: Props) {
 
   const [filters, setFilters] = useState<FindFilters>(initialFilters)
   const [filtersOpen, setFiltersOpen] = useState(false)
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
+  const [visibleCount, setVisibleCount] = useState(INITIAL_COUNT)
 
   const [askText, setAskText] = useState('')
   const [askFilters, setAskFilters] = useState<QueryFilters | null>(null)
@@ -84,7 +85,7 @@ export default function FindClient({ schools, initialFilters }: Props) {
   }, [])
 
   useEffect(() => {
-    setVisibleCount(PAGE_SIZE)
+    setVisibleCount(INITIAL_COUNT)
   }, [filters])
 
   const trackOptions = useMemo(

--- a/lib/school-list-utils.ts
+++ b/lib/school-list-utils.ts
@@ -5,6 +5,9 @@ import { School, SectionGroup, SectionType, UserInputs } from '@/types'
 // list and the header count stays in sync between them.
 export const ADDED_SCHOOLS_KEY = 'admitday_find_added_schools'
 
+// Initial /find page load shows 30 rows so the list reads as a full picture,
+// not a teaser; PAGE_SIZE is the increment each "N more matches" click adds.
+export const INITIAL_COUNT = 30
 export const PAGE_SIZE = 15
 export const FREE_TIER_CAP = 15
 export const PAID_TIER_CAP = 30


### PR DESCRIPTION
Committed. Summary:

**Changes:**
- `lib/school-list-utils.ts`: added `INITIAL_COUNT = 30` (kept `PAGE_SIZE = 15` unchanged as the "show more" increment).
- `app/find/FindClient.tsx`: `visibleCount` now seeds from and resets to `INITIAL_COUNT` (30) instead of `PAGE_SIZE`; the "N more matches" click still grows by `PAGE_SIZE` (15), so pagination behavior is unchanged.
- `__tests__/find-initial-count.test.ts` (new): locks `INITIAL_COUNT` at 30 and `PAGE_SIZE` at 15, and verifies `FindClient` seeds/resets from `INITIAL_COUNT` while still incrementing by `PAGE_SIZE`.

`npm test` (806 passed) and `npm run build` both pass. No other files touched, `data/schools.json` untouched, no existing tests modified.

Closes #160