### PR TITLE
fix: issue #177 - Coordinator should honor Blocked by #N dependencies before running agent-ok issues

### DIFF
--- a/__tests__/coordinator-blocked-by.test.ts
+++ b/__tests__/coordinator-blocked-by.test.ts
@@ -1,0 +1,61 @@
+import fs from 'fs'
+import path from 'path'
+
+// ── agent-coordinator.sh: "Blocked by #N" dependency gate (issue #177) ──
+// AGENTS.md promises: "An issue whose body contains a line `Blocked by #N`
+// is skipped while issue #N is still open." The coordinator previously ran
+// every `agent-ok` issue with no such check, so a dependent issue (e.g. #176
+// "Blocked by #175") could run before its blocker was resolved. These tests
+// pin that the gate exists, runs before any label is touched, and logs why
+// an issue was skipped.
+
+describe('agent-coordinator.sh "Blocked by #N" dependency gate', () => {
+  const coordinatorSource = fs.readFileSync(path.join(__dirname, '../agent-coordinator.sh'), 'utf-8')
+
+  it('defines a helper that finds a still-open "Blocked by #N" dependency', () => {
+    expect(coordinatorSource).toContain('blocking_issue_number()')
+    const fn = coordinatorSource.match(/blocking_issue_number\(\) \{([\s\S]*?)\n\}/)
+    expect(fn).not.toBeNull()
+    const body = fn![1]
+    // Matches a line that is exactly "Blocked by #N", not just any mention.
+    expect(body).toMatch(/\^Blocked by #\[0-9\]\+/)
+    // Only treats it as blocking when the referenced issue is still open.
+    expect(body).toContain('"$STATE" = "open"')
+  })
+
+  it('checks the gate before the trigger label or any other label is touched', () => {
+    const runAgentBody = coordinatorSource.split('run_agent() {')[1]
+    expect(runAgentBody).toBeDefined()
+    const gateIndex = runAgentBody.indexOf('blocking_issue_number "$ISSUE_BODY"')
+    const firstLabelChangeIndex = runAgentBody.indexOf('github_remove_label "$ISSUE_NUMBER" "$TRIGGER_LABEL"')
+    expect(gateIndex).toBeGreaterThan(-1)
+    expect(firstLabelChangeIndex).toBeGreaterThan(-1)
+    expect(gateIndex).toBeLessThan(firstLabelChangeIndex)
+  })
+
+  function extractGateBranch() {
+    const marker = 'BLOCKER=$(blocking_issue_number "$ISSUE_BODY")'
+    const start = coordinatorSource.indexOf(marker)
+    if (start === -1) return null
+    const ifIndex = coordinatorSource.indexOf('if [ -n "$BLOCKER" ]; then', start)
+    if (ifIndex === -1 || ifIndex - (start + marker.length) > 10) return null
+    const bodyStart = ifIndex + 'if [ -n "$BLOCKER" ]; then'.length
+    const fiIndex = coordinatorSource.indexOf('fi', bodyStart)
+    if (fiIndex === -1) return null
+    return coordinatorSource.slice(bodyStart, fiIndex)
+  }
+
+  it('returns early on a block, leaving labels untouched for this loop', () => {
+    const body = extractGateBranch()
+    expect(body).not.toBeNull()
+    expect(body).toContain('return')
+    expect(body).not.toContain('github_label')
+    expect(body).not.toContain('github_remove_label')
+  })
+
+  it('logs the skip reason including the blocking issue number', () => {
+    const body = extractGateBranch()
+    expect(body).not.toBeNull()
+    expect(body).toMatch(/log ".*blocked by open issue #\$\{BLOCKER\}"/)
+  })
+})

--- a/agent-coordinator.sh
+++ b/agent-coordinator.sh
@@ -302,6 +302,29 @@ github_remove_label() {
   gh_api DELETE "/issues/$1/labels/$2" > /dev/null
 }
 
+blocking_issue_number() {
+  # blocking_issue_number ISSUE_BODY -> echoes the first still-open "Blocked by
+  # #N" dependency found in the body (AGENTS.md: "An issue whose body contains
+  # a line `Blocked by #N` is skipped while issue #N is still open"), or
+  # nothing if there is no such line or every referenced issue is closed.
+  # Supports multiple "Blocked by #N" lines; checked in order, first open wins.
+  local BODY="$1" NUM STATE
+  for NUM in $(printf '%s\n' "$BODY" | grep -oE '^Blocked by #[0-9]+\r?$' | grep -oE '[0-9]+'); do
+    STATE=$(gh_api GET "/issues/$NUM" | python3 -c "
+import json,sys
+try:
+    print(json.load(sys.stdin).get('state','') or '')
+except Exception:
+    pass
+")
+    if [ "$STATE" = "open" ]; then
+      echo "$NUM"
+      return 0
+    fi
+  done
+  return 1
+}
+
 github_comment() {
   local BODY
   BODY=$(printf '%s' "$2" | json_escape)
@@ -718,6 +741,24 @@ run_agent() {
   local ISSUE_TITLE ISSUE_BODY ISSUE_COMMENTS
   ISSUE_TITLE=$(python3 -c "import json; print(json.load(open('$ISSUE_FILE')).get('title',''))")
   ISSUE_BODY=$(python3 -c "import json; print(json.load(open('$ISSUE_FILE')).get('body') or '(no body)')")
+  rm -f "$ISSUE_FILE"
+
+  if [ -z "$ISSUE_TITLE" ]; then
+    log "Could not fetch issue #${ISSUE_NUMBER}, skipping"
+    return
+  fi
+
+  # Dependency gate: skip this loop, untouched, while a "Blocked by #N" issue
+  # is still open. Checked before the trigger label is ever touched, so a
+  # blocked issue stays exactly as it was (still "agent-ok") and becomes
+  # eligible again on a later poll once its blocker closes.
+  local BLOCKER
+  BLOCKER=$(blocking_issue_number "$ISSUE_BODY")
+  if [ -n "$BLOCKER" ]; then
+    log "Issue #${ISSUE_NUMBER}: skipping this loop, blocked by open issue #${BLOCKER}"
+    return
+  fi
+
   ISSUE_COMMENTS=$(gh_api GET "/issues/${ISSUE_NUMBER}/comments" | python3 -c "
 import json,sys
 try:
@@ -727,12 +768,6 @@ try:
 except Exception:
     print('(no comments)')
 ")
-  rm -f "$ISSUE_FILE"
-
-  if [ -z "$ISSUE_TITLE" ]; then
-    log "Could not fetch issue #${ISSUE_NUMBER}, skipping"
-    return
-  fi
 
   local SAFE_TITLE=$(echo "$ISSUE_TITLE" | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | tr -dc 'a-z0-9-' | cut -c1-30)
   local BRANCH="task-${ISSUE_NUMBER}-${SAFE_TITLE}"


### PR DESCRIPTION
The diff is scoped tightly to the issue. Both `npm test` (815 tests, 39 suites) and `npm run build` pass, and `bash -n agent-coordinator.sh` is clean.

## Summary

Fixed issue #177: the coordinator now honors `Blocked by #N` dependencies before running an `agent-ok` issue.

**Changes to `agent-coordinator.sh`:**
- Added `blocking_issue_number()`, which scans an issue body for lines exactly matching `Blocked by #N` (supports multiple such lines) and returns the first one whose referenced issue is still open on GitHub.
- In `run_agent()`, this check now runs immediately after the issue body is fetched and *before* any label is touched (before the trigger label is removed and `in-progress` is applied). If blocked, the coordinator logs the reason (`Issue #N: skipping this loop, blocked by open issue #M`) and returns early, leaving the issue's labels exactly as they were.
- Reordered the early `rm -f "$ISSUE_FILE"` / empty-title guard slightly so the gate can run right after body parsing, ahead of the (now unnecessary, in the blocked case) comments fetch.

**Tests added (`__tests__/coordinator-blocked-by.test.ts`):**
- Confirms the helper exists and only treats a dependency as blocking when the referenced issue's state is `open`.
- Confirms the gate is checked before the trigger label is ever removed.
- Confirms the skip branch returns early without any `github_label`/`github_remove_label` calls.
- Confirms the skip is logged with the blocking issue number.

Once #175 (or any `Blocked by #N` target) closes, the issue becomes eligible on the coordinator's next poll with no further code changes needed.

Closes #177