### PR TITLE
fix: issue #170 - Rename /find ask API away from legacy /api/chat; keep /find as the only live surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 AI-powered NYC public high school admissions navigator. AdmitDay helps families turn a scattered admissions process into a grounded, personalized school list.
 
 - Live app: https://www.admitday.com
-- Chat search: https://www.admitday.com/chat
-- Unified finder in progress: `/find` and `/school/[dbn]`
+- Unified finder: `/find` and `/school/[dbn]`
 
 ## Why This Exists
 
@@ -16,18 +15,16 @@ AdmitDay is built around a simple product bet: parents do not need more raw info
 
 - Builds a school list from 700+ programs across 400+ NYC public high schools.
 - Applies deterministic filters for facts that should never be guessed, including borough, admissions track, size, requirements, activities, and programs.
-- Uses RAG-powered chat for plain-language questions like "which Brooklyn schools have strong CS and soccer?"
+- Uses a RAG-powered ask box for plain-language questions like "which Brooklyn schools have strong CS and soccer?"
 - Generates grounded rationales only from retrieved school data.
 - Keeps DOE-reported facts separate from model-generated interpretation.
 
 ## Product Shape
 
-AdmitDay currently has two live discovery surfaces:
+`/find` is the live discovery surface: hard rail filters plus an ask box that re-ranks without removing schools, linked to `/school/[dbn]` detail pages.
 
 1. **Structured filters:** users narrow schools by concrete constraints, then get personalized rationale text.
-2. **RAG chat:** users ask in natural language; the system extracts exact signals, hard-filters the candidate pool, semantic-ranks within it, and cites only the schools it found.
-
-The next product surface is a unified `/find` flow: hard rail filters plus an ask box that re-ranks without removing schools, linked to `/school/[dbn]` detail pages. These routes exist but do not yet replace the older live `/list`, `/requirements`, and `/chat` flows.
+2. **RAG ask box:** users ask in natural language; the system extracts exact signals, hard-filters the candidate pool, semantic-ranks within it, and cites only the schools it found via `/api/find/ask`.
 
 ## Architecture
 

--- a/__tests__/find-ask-provider-errors.test.ts
+++ b/__tests__/find-ask-provider-errors.test.ts
@@ -1,8 +1,9 @@
 /**
- * __tests__/chat-provider-errors.test.ts
+ * __tests__/find-ask-provider-errors.test.ts
  *
- * Issue #128: a real visitor hit /api/chat in production and got a raw
- * 400 with vendor error text ("You have reached your specified API
+ * Issue #128: a real visitor hit the /find ask endpoint (then
+ * /api/chat, now /api/find/ask — issue #170) in production and got a
+ * raw 400 with vendor error text ("You have reached your specified API
  * usage limits. You will regain access on 2026-08-01 at 00:00 UTC.").
  * These tests mock the Anthropic call to fail in each of the ways a
  * provider can fail, and assert the client only ever sees one of the
@@ -37,7 +38,7 @@ jest.mock('@/lib/rag', () => ({
   ]),
 }))
 
-import { POST } from '@/app/api/chat/route'
+import { POST } from '@/app/api/find/ask/route'
 
 const FORBIDDEN_SUBSTRINGS = [
   'usage limit',
@@ -48,7 +49,7 @@ const FORBIDDEN_SUBSTRINGS = [
   'anthropic',
 ]
 
-function fakeChatRequest(question: string, ip: string): NextRequest {
+function fakeAskRequest(question: string, ip: string): NextRequest {
   return {
     headers: {
       get: (name: string) => (name.toLowerCase() === 'x-forwarded-for' ? ip : null),
@@ -62,7 +63,7 @@ beforeEach(() => {
   mockCaptureException.mockReset()
 })
 
-describe('/api/chat provider failure handling (issue #128)', () => {
+describe('/api/find/ask provider failure handling (issue #128)', () => {
   it('returns a plain-language unavailable response for a usage-limit error, and logs the real error to Sentry', async () => {
     const upstreamError = new Error(
       '400 {"type":"error","error":{"type":"invalid_request_error","message":"You have reached your specified API usage limits. You will regain access on 2026-08-01 at 00:00 UTC."}}, "request_id": "req_abc123"'
@@ -70,7 +71,7 @@ describe('/api/chat provider failure handling (issue #128)', () => {
     ;(upstreamError as unknown as { status: number }).status = 400
     mockCreate.mockRejectedValue(upstreamError)
 
-    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.1'))
+    const res = await POST(fakeAskRequest('Which schools have strong STEM?', '10.0.0.1'))
     expect(res.status).toBe(503)
 
     const bodyText = await res.text()
@@ -89,7 +90,7 @@ describe('/api/chat provider failure handling (issue #128)', () => {
     ;(upstreamError as unknown as { status: number }).status = 529
     mockCreate.mockRejectedValue(upstreamError)
 
-    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.2'))
+    const res = await POST(fakeAskRequest('Which schools have strong STEM?', '10.0.0.2'))
     expect(res.status).toBe(503)
     const body = await res.json()
     const serialized = JSON.stringify(body).toLowerCase()
@@ -103,7 +104,7 @@ describe('/api/chat provider failure handling (issue #128)', () => {
     ;(upstreamError as unknown as { status: number }).status = 429
     mockCreate.mockRejectedValue(upstreamError)
 
-    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.3'))
+    const res = await POST(fakeAskRequest('Which schools have strong STEM?', '10.0.0.3'))
     expect(res.status).toBe(429)
     const body = await res.json()
     expect(body.error).toBe(
@@ -115,7 +116,7 @@ describe('/api/chat provider failure handling (issue #128)', () => {
     const upstreamError = new Error('something exploded')
     mockCreate.mockRejectedValue(upstreamError)
 
-    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.4'))
+    const res = await POST(fakeAskRequest('Which schools have strong STEM?', '10.0.0.4'))
     expect(res.status).toBe(500)
     const body = await res.json()
     const serialized = JSON.stringify(body).toLowerCase()
@@ -130,7 +131,7 @@ describe('/api/chat provider failure handling (issue #128)', () => {
       content: [{ type: 'text', text: 'Test High School is a great fit.' }],
     })
 
-    const res = await POST(fakeChatRequest('Which schools have strong STEM?', '10.0.0.5'))
+    const res = await POST(fakeAskRequest('Which schools have strong STEM?', '10.0.0.5'))
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.answer).toBe('Test High School is a great fit.')

--- a/__tests__/find-ask-rag.test.ts
+++ b/__tests__/find-ask-rag.test.ts
@@ -14,14 +14,18 @@ describe('/find ask box wired to conversational RAG (issue #110)', () => {
     expect(src).toContain('getUnmetCriteria')
   })
 
-  it('POSTs the question to the existing /api/chat route', () => {
-    expect(src).toContain("'/api/chat'")
+  it('POSTs the question to the /find-named ask route (issue #170)', () => {
+    expect(src).toContain("'/api/find/ask'")
     expect(src).toContain("method: 'POST'")
     expect(src).toMatch(/JSON\.stringify\(\s*\{\s*question/)
   })
 
-  it('does not introduce a new LLM/RAG route', () => {
-    expect(src).not.toMatch(/fetch\(\s*['"]\/api\/(?!chat)/)
+  it('no longer calls the legacy /api/chat route', () => {
+    expect(src).not.toContain("'/api/chat'")
+  })
+
+  it('does not introduce another LLM/RAG route', () => {
+    expect(src).not.toMatch(/fetch\(\s*['"]\/api\/(?!find\/ask)/)
   })
 
   it('tracks loading state for the grounded answer', () => {

--- a/__tests__/find-ask-system-prompt.test.ts
+++ b/__tests__/find-ask-system-prompt.test.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
-describe('Chat API system prompt (issue #69)', () => {
-  const routePath = path.join(__dirname, '../app/api/chat/route.ts')
+describe('/find ask API system prompt (issue #69)', () => {
+  const routePath = path.join(__dirname, '../app/api/find/ask/route.ts')
   let src: string
 
   beforeAll(() => {

--- a/__tests__/find-filters.test.ts
+++ b/__tests__/find-filters.test.ts
@@ -279,7 +279,7 @@ describe('removeSignal + rankBySoftMatch — chip removal re-ranks without calli
     expect(softMatchSrc).not.toMatch(/fetch\(/)
   })
 
-  it("FindClient only calls /api/chat from handleAskSubmit, not from the chip-removal handler", () => {
+  it("FindClient only calls /api/find/ask from handleAskSubmit, not from the chip-removal handler", () => {
     const src = fs.readFileSync(path.join(__dirname, '../app/find/FindClient.tsx'), 'utf-8')
     const removeChipBody = src.slice(src.indexOf('function removeChip'), src.indexOf('async function handleAskSubmit'))
     expect(removeChipBody).not.toMatch(/fetch\(/)

--- a/__tests__/rag-topk.test.ts
+++ b/__tests__/rag-topk.test.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
-describe('Chat API top-K (issue #70: reverted from 10 to 5)', () => {
-  const routePath = path.join(__dirname, '../app/api/chat/route.ts')
+describe('/find ask API top-K (issue #70: reverted from 10 to 5)', () => {
+  const routePath = path.join(__dirname, '../app/api/find/ask/route.ts')
   let src: string
 
   beforeAll(() => {

--- a/__tests__/rationale-provider-errors.test.ts
+++ b/__tests__/rationale-provider-errors.test.ts
@@ -1,9 +1,9 @@
 /**
  * __tests__/rationale-provider-errors.test.ts
  *
- * Issue #128: /api/rationale has the same shape as /api/chat (an
+ * Issue #128: /api/rationale has the same shape as /api/find/ask (an
  * unwrapped Anthropic call whose failures were returned to the client
- * verbatim). Same mocking approach as chat-provider-errors.test.ts —
+ * verbatim). Same mocking approach as find-ask-provider-errors.test.ts —
  * mock the provider call to fail each way, assert only plain-language
  * responses ever reach the client.
  */

--- a/__tests__/rule-no-admissions-odds-language.test.ts
+++ b/__tests__/rule-no-admissions-odds-language.test.ts
@@ -50,7 +50,7 @@ const USER_FACING_FILES = [path.join(ROOT, 'app'), path.join(ROOT, 'components')
 // would coach the model into producing odds language even if no component
 // literally contains the string.
 const PROMPT_FILES = [
-  path.join(ROOT, 'app/api/chat/route.ts'),
+  path.join(ROOT, 'app/api/find/ask/route.ts'),
   path.join(ROOT, 'app/api/rationale/route.ts'),
 ]
 

--- a/app/api/find/ask/route.ts
+++ b/app/api/find/ask/route.ts
@@ -1,7 +1,7 @@
 /**
- * app/api/chat/route.ts
+ * app/api/find/ask/route.ts
  *
- * RAG-powered chat endpoint for AdmitDay.
+ * RAG-powered ask endpoint for the /find page.
  * Takes a user question, retrieves the most relevant schools
  * from the vector store, and passes them to Claude to generate
  * a grounded answer.

--- a/app/find/FindClient.tsx
+++ b/app/find/FindClient.tsx
@@ -168,7 +168,7 @@ export default function FindClient({ schools, initialFilters }: Props) {
     setAskSources([])
 
     try {
-      const res = await fetch('/api/chat', {
+      const res = await fetch('/api/find/ask', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ question: trimmed }),

--- a/lib/query-filters.ts
+++ b/lib/query-filters.ts
@@ -151,7 +151,7 @@ export function appliedSignals(filters: QueryFilters): AppliedSignal[] {
 /**
  * Removes a single signal from a previously-extracted QueryFilters. Pure and
  * deterministic — callers use this for chip removal so re-ranking never
- * triggers another /api/chat (LLM) call.
+ * triggers another /api/find/ask (LLM) call.
  */
 export function removeSignal(
   filters: QueryFilters,

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -2,7 +2,7 @@
  * lib/rate-limit.ts
  *
  * In-memory, per-IP fixed-window rate limiter for the unauthenticated
- * LLM-backed API routes (/api/chat, /api/rationale).
+ * LLM-backed API routes (/api/find/ask, /api/rationale).
  *
  * NOTE: This is a deliberate stopgap. Vercel lambdas do not share memory,
  * so the limit is per-instance rather than global — it caps runaway loops

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -71,7 +71,7 @@ export function hasEmptyStateBanner(html: string): boolean {
 /** Chat is healthy if it answers or cleanly rate-limits. A 5xx is never healthy. */
 export function judgeChatResponse(status: number, body: string): CheckResult {
   if (status === 429) {
-    return { name: 'POST /api/chat', severity: 'ok', detail: '429 rate-limited (expected under load)' }
+    return { name: 'POST /api/find/ask', severity: 'ok', detail: '429 rate-limited (expected under load)' }
   }
   if (status >= 500) {
     // A 503 carrying the product's own copy means the route handled an upstream
@@ -80,7 +80,7 @@ export function judgeChatResponse(status: number, body: string): CheckResult {
     // remedy is completely different.
     const graceful = /assistant is unavailable|try again shortly/i.test(body)
     return {
-      name: 'POST /api/chat',
+      name: 'POST /api/find/ask',
       // Handled outage: the route did its job, the provider is down. Warn.
       // Unhandled 5xx: that is ours to fix. Fail.
       severity: graceful ? 'warn' : 'fail',
@@ -90,16 +90,16 @@ export function judgeChatResponse(status: number, body: string): CheckResult {
     }
   }
   if (status !== 200) {
-    return { name: 'POST /api/chat', severity: 'fail', detail: `HTTP ${status}` }
+    return { name: 'POST /api/find/ask', severity: 'fail', detail: `HTTP ${status}` }
   }
   // A 200 that leaked provider error text is a failure even though it is a 200.
   if (/usage limit|credit balance|quota|request_id|anthropic/i.test(body)) {
-    return { name: 'POST /api/chat', severity: 'fail', detail: '200 but the body leaked provider error text' }
+    return { name: 'POST /api/find/ask', severity: 'fail', detail: '200 but the body leaked provider error text' }
   }
   if (body.trim().length === 0) {
-    return { name: 'POST /api/chat', severity: 'fail', detail: '200 with an empty body' }
+    return { name: 'POST /api/find/ask', severity: 'fail', detail: '200 with an empty body' }
   }
-  return { name: 'POST /api/chat', severity: 'ok', detail: `HTTP 200, ${body.length} bytes` }
+  return { name: 'POST /api/find/ask', severity: 'ok', detail: `HTTP 200, ${body.length} bytes` }
 }
 
 export function judgeFindPage(status: number, html: string): CheckResult[] {
@@ -147,7 +147,7 @@ async function run(): Promise<void> {
   const find = await fetch(`${base}/find`, { redirect: 'follow' })
   results.push(...judgeFindPage(find.status, await find.text()))
 
-  const chat = await fetch(`${base}/api/chat`, {
+  const chat = await fetch(`${base}/api/find/ask`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ question: 'Which Brooklyn schools have a strong music program?' }),


### PR DESCRIPTION
Waiting on the `npm run build` background task to finish before checking results.

Closes #170