### PR TITLE
feat: integrate MySchools program data pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 
 # python
 __pycache__/
+scripts/.myschools_cache/
 
 # typescript
 *.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ These are the shared rules for any coding agent working in this repo: Claude Cod
 
 ## Core Rules
 
+- Treat GitHub `main` as the live code source of truth, Notion as the live roadmap/task source of truth, and local checkouts or local docs as caches unless explicitly refreshed from their source.
+- If GitHub, Notion, and local files disagree, state the conflict. Prefer GitHub for code state and Notion for roadmap/task state.
 - **Never modify `data/schools.json`.** It is curated source data.
 - Filtering logic lives in `lib/school-list-utils.ts` — look there first for anything about school list filtering.
 - Tests live in `__tests__/`. **Add** new test files or cases; never overwrite or delete existing tests.

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ Source roles:
 - NYC Open Data dataset `uq7m-95z8` provides older DOE directory fields. Its rows are from the 2018-era / 2019 DOE High School Directory and should be treated as historical where MySchools has fresher fields.
 - MySchools provides current per-school/per-program admissions records. Program data includes names, codes, admissions methods, seats/demand, requirements text, eligibility/priority text, source URL, and fetch timestamp.
 
-Scheduled refresh runs from the VPS, where the env files already live. `scripts/vps-data-refresh.sh pr` sources `/root/app/.env.local`, then the root-owned secret files `/root/.env.local` and `/root/.env.agents`, runs the validated refresh with Postgres seeding disabled, rebuilds embeddings, pushes a `data/weekly-refresh` branch, dispatches CI, and opens or updates a PR with the tracked data artifacts. After that PR merges, `scripts/vps-data-refresh.sh apply` pulls `main` on the VPS and seeds Postgres from the merged `schools.json`. This keeps `OPENAI_API_KEY` and `POSTGRES_URL` out of GitHub repository secrets while preserving a reviewed data-artifact path.
+Scheduled refresh runs from the VPS, where the env files already live. `scripts/vps-data-refresh.sh pr` sources `/root/app/.env.local`, then the root-owned secret files `/root/.env.local` and `/root/.env.agents`, runs the validated refresh with Postgres seeding disabled, rebuilds embeddings, pushes a `data/weekly-refresh` branch, dispatches CI, and opens or updates a PR with the tracked data artifacts. `scripts/vps-data-refresh.sh merge` is the data refresh runner's publication gate: it merges only when the generated PR changes exactly `schools.json` and `data/school-embeddings.json`, and the GitHub CI `test` check is green. `scripts/vps-data-refresh.sh apply` then pulls `main` on the VPS and seeds Postgres from the merged `schools.json`. This keeps `OPENAI_API_KEY` and `POSTGRES_URL` out of GitHub repository secrets while preserving an auditable data-artifact path without making routine refreshes a human review task.
 
 Example VPS cron entries:
 
 ```cron
 0 9 * * 1 cd /root/app && ./scripts/vps-data-refresh.sh pr
-30 9 * * * cd /root/app && ./scripts/vps-data-refresh.sh apply
+30 9 * * 1 cd /root/app && ./scripts/vps-data-refresh.sh merge && ./scripts/vps-data-refresh.sh apply
 ```
 
 ## Evals And Guardrails

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Scheduled refresh runs from the VPS, where the app secrets already live. `script
 Example VPS cron entries:
 
 ```cron
-0 9 * * 1 cd /home/agent/app && ./scripts/vps-data-refresh.sh pr
-30 9 * * * cd /home/agent/app && ./scripts/vps-data-refresh.sh apply
+0 9 * * 1 cd /root/app && ./scripts/vps-data-refresh.sh pr
+30 9 * * * cd /root/app && ./scripts/vps-data-refresh.sh apply
 ```
 
 ## Evals And Guardrails

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 AI-powered NYC public high school admissions navigator. AdmitDay helps families turn a scattered admissions process into a grounded, personalized school list.
 
 - Live app: https://www.admitday.com
-- Chat search: https://www.admitday.com/chat
-- Unified finder in progress: `/find` and `/school/[dbn]`
+- Find schools: https://www.admitday.com/find
+- School details: `/school/[dbn]`
 
 ## Why This Exists
 
@@ -22,19 +22,18 @@ AdmitDay is built around a simple product bet: parents do not need more raw info
 
 ## Product Shape
 
-AdmitDay currently has two live discovery surfaces:
+AdmitDay currently has one live discovery surface:
 
-1. **Structured filters:** users narrow schools by concrete constraints, then get personalized rationale text.
-2. **RAG chat:** users ask in natural language; the system extracts exact signals, hard-filters the candidate pool, semantic-ranks within it, and cites only the schools it found.
+1. **Unified `/find`:** users narrow schools by hard rail filters, then use the ask box for plain-language criteria that re-rank or annotate results without silently removing schools. Rows link to `/school/[dbn]` detail pages.
 
-The next product surface is a unified `/find` flow: hard rail filters plus an ask box that re-ranks without removing schools, linked to `/school/[dbn]` detail pages. These routes exist but do not yet replace the older live `/list`, `/requirements`, and `/chat` flows.
+The older standalone `/chat` product surface is decommissioned. Some internal route names still mention chat while the `/find` ask API is being renamed, but `/find` is the live product surface.
 
 ## Architecture
 
 - **Frontend:** Next.js 14 App Router and Tailwind CSS.
 - **Design system:** token layer plus reusable UI primitives in `components/ui/`.
 - **Data:** 457 NYC public high schools in Vercel Postgres, keyed by `dbn`.
-- **Retrieval:** OpenAI `text-embedding-3-small`, semantic chunking by identity, academics, and activities, plus deterministic filtering.
+- **Retrieval:** OpenAI `text-embedding-3-small`, semantic chunking by identity, current MySchools programs, academics, and activities, plus deterministic filtering.
 - **Generation:** Claude Sonnet 5 through grounded prompts.
 - **Cost protection:** per-IP rate limiting on LLM routes.
 - **Observability:** Sentry for errors and PostHog for analytics.
@@ -48,7 +47,22 @@ Data currency is the core differentiator. One command runs the refresh pipeline:
 npm run refresh:data
 ```
 
-The pipeline runs `build_school_data.py`, validates counts and required fields, writes the validated JSON, seeds Postgres with `scripts/seed-schools.ts`, and rebuilds embeddings with `scripts/embed-schools.ts`. It refuses to write if the scrape looks structurally wrong, such as a large school-count drop, duplicate DBNs, or missing required fields.
+The pipeline runs `build_school_data.py`, validates counts and required fields, writes the validated JSON, rebuilds embeddings with `scripts/embed-schools.ts`, and then seeds Postgres with `scripts/seed-schools.ts`. Embeddings run before the DB update so a provider/key failure cannot leave `/find` data ahead of RAG. It refuses to write if the scrape looks structurally wrong, such as a large school-count drop, duplicate DBNs, missing required fields, or missing MySchools program provenance.
+
+Source roles:
+
+- NYC-SIFT provides the school list and school-level selectivity signals.
+- NYC Open Data dataset `uq7m-95z8` provides older DOE directory fields. Its rows are from the 2018-era / 2019 DOE High School Directory and should be treated as historical where MySchools has fresher fields.
+- MySchools provides current per-school/per-program admissions records. Program data includes names, codes, admissions methods, seats/demand, requirements text, eligibility/priority text, source URL, and fetch timestamp.
+
+Scheduled refresh runs from the VPS, where the app secrets already live. `scripts/vps-data-refresh.sh pr` sources the VPS env files, runs the validated refresh with Postgres seeding disabled, rebuilds embeddings, pushes a `data/weekly-refresh` branch, dispatches CI, and opens or updates a PR with the tracked data artifacts. After that PR merges, `scripts/vps-data-refresh.sh apply` pulls `main` on the VPS and seeds Postgres from the merged `schools.json`. This keeps `OPENAI_API_KEY` and `POSTGRES_URL` out of GitHub repository secrets while preserving a reviewed data-artifact path.
+
+Example VPS cron entries:
+
+```cron
+0 9 * * 1 cd /home/agent/app && ./scripts/vps-data-refresh.sh pr
+30 9 * * * cd /home/agent/app && ./scripts/vps-data-refresh.sh apply
+```
 
 ## Evals And Guardrails
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Source roles:
 - NYC Open Data dataset `uq7m-95z8` provides older DOE directory fields. Its rows are from the 2018-era / 2019 DOE High School Directory and should be treated as historical where MySchools has fresher fields.
 - MySchools provides current per-school/per-program admissions records. Program data includes names, codes, admissions methods, seats/demand, requirements text, eligibility/priority text, source URL, and fetch timestamp.
 
-Scheduled refresh runs from the VPS, where the app secrets already live. `scripts/vps-data-refresh.sh pr` sources the VPS env files, runs the validated refresh with Postgres seeding disabled, rebuilds embeddings, pushes a `data/weekly-refresh` branch, dispatches CI, and opens or updates a PR with the tracked data artifacts. After that PR merges, `scripts/vps-data-refresh.sh apply` pulls `main` on the VPS and seeds Postgres from the merged `schools.json`. This keeps `OPENAI_API_KEY` and `POSTGRES_URL` out of GitHub repository secrets while preserving a reviewed data-artifact path.
+Scheduled refresh runs from the VPS, where the env files already live. `scripts/vps-data-refresh.sh pr` sources `/root/app/.env.local`, then the root-owned secret files `/root/.env.local` and `/root/.env.agents`, runs the validated refresh with Postgres seeding disabled, rebuilds embeddings, pushes a `data/weekly-refresh` branch, dispatches CI, and opens or updates a PR with the tracked data artifacts. After that PR merges, `scripts/vps-data-refresh.sh apply` pulls `main` on the VPS and seeds Postgres from the merged `schools.json`. This keeps `OPENAI_API_KEY` and `POSTGRES_URL` out of GitHub repository secrets while preserving a reviewed data-artifact path.
 
 Example VPS cron entries:
 

--- a/__tests__/myschools-pipeline.test.ts
+++ b/__tests__/myschools-pipeline.test.ts
@@ -58,8 +58,8 @@ describe('MySchools program pipeline', () => {
   })
 
   it('runs refresh PR creation from the VPS without GitHub app secrets', () => {
-    expect(vpsRefreshSource).toContain('APP_ENV_FILE="${APP_ENV_FILE:-$APP_DIR/.env.local}"')
-    expect(vpsRefreshSource).toContain('AGENT_ENV_FILE="${AGENT_ENV_FILE:-/home/agent/.env.agents}"')
+    expect(vpsRefreshSource).toContain('APP_ENV_FILE="${APP_ENV_FILE:-/root/.env.local}"')
+    expect(vpsRefreshSource).toContain('AGENT_ENV_FILE="${AGENT_ENV_FILE:-/root/.env.agents}"')
     expect(vpsRefreshSource).toContain('require_env OPENAI_API_KEY')
     expect(vpsRefreshSource).toContain('ADMITDAY_SKIP_POSTGRES_SEED=1 npm run refresh:data')
     expect(vpsRefreshSource).toContain('git add schools.json data/school-embeddings.json')

--- a/__tests__/myschools-pipeline.test.ts
+++ b/__tests__/myschools-pipeline.test.ts
@@ -58,8 +58,10 @@ describe('MySchools program pipeline', () => {
   })
 
   it('runs refresh PR creation from the VPS without GitHub app secrets', () => {
-    expect(vpsRefreshSource).toContain('APP_ENV_FILE="${APP_ENV_FILE:-/root/.env.local}"')
+    expect(vpsRefreshSource).toContain('APP_ENV_FILE="${APP_ENV_FILE:-$APP_DIR/.env.local}"')
+    expect(vpsRefreshSource).toContain('ROOT_ENV_FILE="${ROOT_ENV_FILE:-/root/.env.local}"')
     expect(vpsRefreshSource).toContain('AGENT_ENV_FILE="${AGENT_ENV_FILE:-/root/.env.agents}"')
+    expect(vpsRefreshSource).toContain('load_env_file "$APP_ENV_FILE"\nload_env_file "$ROOT_ENV_FILE"\nload_env_file "$AGENT_ENV_FILE"')
     expect(vpsRefreshSource).toContain('require_env OPENAI_API_KEY')
     expect(vpsRefreshSource).toContain('ADMITDAY_SKIP_POSTGRES_SEED=1 npm run refresh:data')
     expect(vpsRefreshSource).toContain('git add schools.json data/school-embeddings.json')

--- a/__tests__/myschools-pipeline.test.ts
+++ b/__tests__/myschools-pipeline.test.ts
@@ -1,0 +1,82 @@
+import fs from 'fs'
+import path from 'path'
+import { spawnSync } from 'child_process'
+
+describe('MySchools program pipeline', () => {
+  const buildSource = fs.readFileSync(path.join(__dirname, '../build_school_data.py'), 'utf-8')
+  const refreshSource = fs.readFileSync(path.join(__dirname, '../scripts/refresh-data.ts'), 'utf-8')
+  const seedSource = fs.readFileSync(path.join(__dirname, '../scripts/seed-schools.ts'), 'utf-8')
+  const embedSource = fs.readFileSync(path.join(__dirname, '../scripts/embed-schools.ts'), 'utf-8')
+  const vpsRefreshSource = fs.readFileSync(path.join(__dirname, '../scripts/vps-data-refresh.sh'), 'utf-8')
+
+  it('keeps workflow YAML parseable', () => {
+    const result = spawnSync(
+      'ruby',
+      [
+        '-e',
+        "require 'yaml'; ARGV.each { |f| YAML.load_file(f) }",
+        '.github/workflows/ci.yml',
+      ],
+      { cwd: path.join(__dirname, '..'), encoding: 'utf-8' }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+  })
+
+  it('keeps the VPS refresh runner shell-parseable', () => {
+    const result = spawnSync('bash', ['-n', 'scripts/vps-data-refresh.sh'], {
+      cwd: path.join(__dirname, '..'),
+      encoding: 'utf-8',
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+  })
+
+  it('uses the MySchools scraper for per-program data during the build step', () => {
+    expect(buildSource).toContain('scrape_school_programs')
+    expect(buildSource).toContain('fetch_myschools_program_detail')
+    expect(buildSource).toContain('MYSCHOOLS_CACHE_DIR')
+    expect(buildSource).toContain('ADMITDAY_SCHOOLS_OUTPUT')
+  })
+
+  it('keeps old program fields only as compatibility aliases', () => {
+    expect(buildSource).toContain('program["program"] = program.get("program_name")')
+    expect(buildSource).toContain('program["admissions_type"] = method')
+  })
+
+  it('requires MySchools program validation in the production refresh path', () => {
+    expect(refreshSource).toContain('requireMySchoolsPrograms: true')
+  })
+
+  it('includes current program data in RAG chunks', () => {
+    expect(embedSource).toContain('chunkType: "programs"')
+    expect(embedSource).toContain('Seats and demand:')
+    expect(embedSource).toContain('Requirements:')
+    expect(embedSource).toContain('program_codes')
+  })
+
+  it('runs refresh PR creation from the VPS without GitHub app secrets', () => {
+    expect(vpsRefreshSource).toContain('APP_ENV_FILE="${APP_ENV_FILE:-$APP_DIR/.env.local}"')
+    expect(vpsRefreshSource).toContain('AGENT_ENV_FILE="${AGENT_ENV_FILE:-/home/agent/.env.agents}"')
+    expect(vpsRefreshSource).toContain('require_env OPENAI_API_KEY')
+    expect(vpsRefreshSource).toContain('ADMITDAY_SKIP_POSTGRES_SEED=1 npm run refresh:data')
+    expect(vpsRefreshSource).toContain('git add schools.json data/school-embeddings.json')
+    expect(vpsRefreshSource).toContain('gh workflow run ci.yml --repo "$REPO" --ref "$BRANCH"')
+    expect(vpsRefreshSource).toContain('gh pr create')
+  })
+
+  it('seeds Postgres from the VPS after refreshed tracked data lands on main', () => {
+    expect(vpsRefreshSource).toContain('apply_merged_data')
+    expect(vpsRefreshSource).toContain('require_env POSTGRES_URL')
+    expect(vpsRefreshSource).toContain('git pull --ff-only origin main')
+    expect(vpsRefreshSource).toContain('scripts/seed-schools.ts')
+  })
+
+  it('can seed from root schools.json in clean CI checkouts', () => {
+    expect(seedSource).toContain('data/schools.json')
+    expect(seedSource).toContain('schools.json')
+    expect(seedSource).toContain('fs.existsSync(dataSchoolsPath) ? dataSchoolsPath : rootSchoolsPath')
+  })
+})

--- a/__tests__/myschools-pipeline.test.ts
+++ b/__tests__/myschools-pipeline.test.ts
@@ -69,6 +69,14 @@ describe('MySchools program pipeline', () => {
     expect(vpsRefreshSource).toContain('gh pr create')
   })
 
+  it('lets the VPS runner merge only validated data refresh PRs', () => {
+    expect(vpsRefreshSource).toContain('merge_refresh_pr')
+    expect(vpsRefreshSource).toContain('assert_refresh_pr_files')
+    expect(vpsRefreshSource).toContain('assert_refresh_ci_green')
+    expect(vpsRefreshSource).toContain('EXPECTED_DATA_FILES="data/school-embeddings.json\nschools.json"')
+    expect(vpsRefreshSource).toContain('gh pr merge "$BRANCH"')
+  })
+
   it('seeds Postgres from the VPS after refreshed tracked data lands on main', () => {
     expect(vpsRefreshSource).toContain('apply_merged_data')
     expect(vpsRefreshSource).toContain('require_env POSTGRES_URL')

--- a/__tests__/refresh-data-script.test.ts
+++ b/__tests__/refresh-data-script.test.ts
@@ -21,6 +21,15 @@ describe('scripts/refresh-data.ts', () => {
     expect(validateIdx).toBeLessThan(writeIdx)
   })
 
+  it('scrapes to a temporary output before replacing root schools.json', () => {
+    expect(scriptSource).toContain('mkdtempSync')
+    expect(scriptSource).toContain('ADMITDAY_SCHOOLS_OUTPUT')
+    const scrapeIdx = scriptSource.indexOf("run('python3', ['build_school_data.py']")
+    const rootWriteIdx = scriptSource.indexOf('writeFileSync(ROOT_SCHOOLS_PATH')
+    expect(scrapeIdx).toBeGreaterThan(-1)
+    expect(rootWriteIdx).toBeGreaterThan(scrapeIdx)
+  })
+
   it('exits non-zero and skips the write when validation fails', () => {
     const failIdx = scriptSource.indexOf('if (!result.valid)')
     const exitIdx = scriptSource.indexOf('process.exit(1)', failIdx)
@@ -30,14 +39,19 @@ describe('scripts/refresh-data.ts', () => {
     expect(exitIdx).toBeLessThan(writeIdx)
   })
 
-  it('runs seed before embed, both after the write', () => {
+  it('runs embed before seed, both after the write', () => {
     // lastIndexOf: both filenames are also named in the file's header comment,
     // so anchor on their occurrence inside the actual run(...) calls below it.
     const writeIdx = scriptSource.indexOf('writeFileSync(DATA_SCHOOLS_PATH')
     const seedIdx = scriptSource.lastIndexOf('scripts/seed-schools.ts')
     const embedIdx = scriptSource.lastIndexOf('scripts/embed-schools.ts')
-    expect(writeIdx).toBeLessThan(seedIdx)
-    expect(seedIdx).toBeLessThan(embedIdx)
+    expect(writeIdx).toBeLessThan(embedIdx)
+    expect(embedIdx).toBeLessThan(seedIdx)
+  })
+
+  it('can skip Postgres seeding when generating a reviewed data-refresh PR', () => {
+    expect(scriptSource).toContain('ADMITDAY_SKIP_POSTGRES_SEED')
+    expect(scriptSource).toContain('Skipping Postgres seed')
   })
 
   it('prints a before/after/added/removed/failed-validation summary', () => {

--- a/__tests__/school-detail.test.ts
+++ b/__tests__/school-detail.test.ts
@@ -467,6 +467,36 @@ describe('dedupePrograms', () => {
     expect(dedupePrograms(programs)).toEqual([{ name: 'SHSAT', method: 'SHSAT' }])
   })
 
+  it('preserves distinct MySchools program names and codes', () => {
+    const programs = [
+      {
+        program_name: 'Dance',
+        program_code: 'M80K',
+        admissions_type: 'Audition',
+        provenance: {
+          source: 'MySchools',
+          url: 'https://www.myschools.nyc/en/api/v2/schools/process/1/03M485/',
+          fetched_at: '2026-08-07T00:00:00+00:00',
+        },
+      },
+      {
+        program_name: 'Drama',
+        program_code: 'M80N',
+        admissions_type: 'Audition',
+        provenance: {
+          source: 'MySchools',
+          url: 'https://www.myschools.nyc/en/api/v2/schools/process/1/03M485/',
+          fetched_at: '2026-08-07T00:00:00+00:00',
+        },
+      },
+    ] as unknown as School['programs']
+
+    expect(dedupePrograms(programs)).toEqual([
+      { name: 'Dance', method: 'Audition', code: 'M80K' },
+      { name: 'Drama', method: 'Audition', code: 'M80N' },
+    ])
+  })
+
   it('returns [] for an empty/undefined programs array', () => {
     expect(dedupePrograms([])).toEqual([])
     expect(dedupePrograms(undefined as unknown as School['programs'])).toEqual([])

--- a/__tests__/validate-school-data.test.ts
+++ b/__tests__/validate-school-data.test.ts
@@ -98,6 +98,77 @@ describe('validateSchoolData', () => {
     expect(result.removed).toEqual([previous[4].dbn])
   })
 
+  it('requires MySchools program provenance when the refresh pipeline asks for it', () => {
+    const schools = makeValidSchools(1) as any[]
+    schools[0].programs = [
+      {
+        program_name: 'Dance',
+        program_code: 'M80K',
+        admissions_type: 'Audition',
+        provenance: {
+          source: 'MySchools',
+          url: 'https://www.myschools.nyc/en/api/v2/schools/process/1/03M485/',
+          fetched_at: '2026-08-07T00:00:00+00:00',
+        },
+      },
+    ]
+
+    const result = validateSchoolData(schools, null, {
+      expectedCount: 1,
+      countTolerance: 0,
+      requireMySchoolsPrograms: true,
+    })
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('rejects empty or legacy-only program rows when MySchools programs are required', () => {
+    const schools = makeValidSchools(1) as any[]
+    schools[0].programs = [{ admissions_type: 'Audition', raw_method: 'Audition' }]
+
+    const result = validateSchoolData(schools, null, {
+      expectedCount: 1,
+      countTolerance: 0,
+      requireMySchoolsPrograms: true,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.invalidRecords[0].reasons).toEqual(
+      expect.arrayContaining([
+        'program[0] missing MySchools provenance source',
+        'program[0] missing provenance url',
+        'program[0] missing provenance fetched_at',
+      ])
+    )
+  })
+
+  it('rejects empty strings inside MySchools program rows because absent fields should be omitted', () => {
+    const schools = makeValidSchools(1) as any[]
+    schools[0].programs = [
+      {
+        program_name: 'Dance',
+        program_code: '',
+        admissions_type: 'Audition',
+        provenance: {
+          source: 'MySchools',
+          url: 'https://www.myschools.nyc/en/api/v2/schools/process/1/03M485/',
+          fetched_at: '2026-08-07T00:00:00+00:00',
+        },
+      },
+    ]
+
+    const result = validateSchoolData(schools, null, {
+      expectedCount: 1,
+      countTolerance: 0,
+      requireMySchoolsPrograms: true,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.invalidRecords[0].reasons).toContain(
+      'program[0] contains empty string; omit missing fields instead'
+    )
+  })
+
   it('default EXPECTED_SCHOOL_COUNT reflects today\'s known-good baseline (~457)', () => {
     expect(EXPECTED_SCHOOL_COUNT).toBe(457)
   })

--- a/app/school/[dbn]/SchoolDetailClient.tsx
+++ b/app/school/[dbn]/SchoolDetailClient.tsx
@@ -192,7 +192,10 @@ export default function SchoolDetailClient({
                       i < visiblePrograms.length - 1 ? 'border-b border-rule-light' : ''
                     }`}
                   >
-                    <span className="text-[15px] font-medium text-ink">{p.name}</span>
+                    <span className="text-[15px] font-medium text-ink">
+                      {p.name}
+                      {p.code && <span className="ml-2 font-mono text-[12px] text-faint">{p.code}</span>}
+                    </span>
                     <span className="text-[13.5px] text-muted">{p.method}</span>
                   </div>
                 ))}

--- a/build_school_data.py
+++ b/build_school_data.py
@@ -1,26 +1,34 @@
 #!/usr/bin/env python3
 """
 AdmitDay - School Data Builder
-Pulls all NYC public high schools from NYC-SIFT and the DOE HS Directory.
+Pulls all NYC public high schools from NYC-SIFT, the DOE HS Directory, and
+current per-program admissions data from MySchools.
 Run this on your VPS: python3 build_school_data.py
 Outputs: schools.json (used directly by the app)
 
 Sources:
   - NYC-SIFT: https://nycsift.com (aggregates DOE data, public domain)
   - DOE HS Directory: https://data.cityofnewyork.us (NYC Open Data, public domain)
+  - MySchools: https://www.myschools.nyc (current public program pages)
 
 Both are public domain / open data. Safe to use with attribution.
 """
 
 import requests
 import json
+import os
 import time
 import re
 from bs4 import BeautifulSoup
+from pathlib import Path
+
+from scripts.scrape_myschools import MySchoolsError, scrape_school_programs
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (compatible; AdmitDay/1.0; research tool)"
 }
+MYSCHOOLS_CACHE_DIR = Path("scripts") / ".myschools_cache"
+ALLOW_MYSCHOOLS_FALLBACK = os.environ.get("ADMITDAY_ALLOW_MYSCHOOLS_FALLBACK") == "1"
 
 # Minimum SHSAT score that received a specialized high school offer.
 # Source: NYC DOE "Specialized High School Offers" press release, 2024 admissions cycle.
@@ -141,6 +149,54 @@ def classify_admissions(text):
     return None
 
 
+def normalize_myschools_admissions_method(text):
+    if not text:
+        return None
+
+    normalized = classify_admissions(text)
+    if normalized:
+        return normalized
+
+    lower = text.lower().strip()
+    if "screened with assessment" in lower or "screened with assessments" in lower:
+        return "Screened with Assessment"
+    if "screened" in lower:
+        return "Screened"
+    if "audition" in lower:
+        return "Audition"
+    if "open" in lower or "unscreened" in lower:
+        return "Open"
+    return text.strip()
+
+
+def fetch_myschools_program_detail(dbn):
+    programs = [p.to_dict() for p in scrape_school_programs(dbn, cache_dir=MYSCHOOLS_CACHE_DIR)]
+    enriched = []
+    admissions_types = []
+
+    for program in programs:
+        method = normalize_myschools_admissions_method(program.get("admissions_method"))
+        if method and method not in admissions_types:
+            admissions_types.append(method)
+
+        # Compatibility fields for UI/utilities that still read the old
+        # NYC-SIFT-shaped rows while carrying the richer MySchools payload.
+        if "program" not in program:
+            program["program"] = program.get("program_name")
+        if method:
+            program["admissions_type"] = method
+        raw_method = program.get("admissions_method")
+        if raw_method and "raw_method" not in program:
+            program["raw_method"] = raw_method
+
+        enriched.append(program)
+
+    if len(enriched) == 0:
+        raise MySchoolsError(f"{dbn} returned no MySchools programs")
+
+    return admissions_types, enriched
+
+
 def fetch_school_detail(dbn, sift_url):
     """
     NYC-SIFT uses div.NYCSF_twocolumn pairs for program data.
@@ -192,7 +248,13 @@ def build_school_json(sift_schools, doe_by_dbn):
             size = "medium"
 
         print(f"  [{i+1}/{len(sift_schools)}] {school['name'][:50]}")
-        admissions_types, programs = fetch_school_detail(dbn, school["sift_url"])
+        try:
+            admissions_types, programs = fetch_myschools_program_detail(dbn)
+        except MySchoolsError as e:
+            if not ALLOW_MYSCHOOLS_FALLBACK:
+                raise
+            print(f"    MySchools failed for {dbn}, falling back to NYC-SIFT detail: {e}")
+            admissions_types, programs = fetch_school_detail(dbn, school["sift_url"])
         time.sleep(0.3)
 
         has_shsat = "SHSAT" in admissions_types
@@ -358,7 +420,7 @@ if __name__ == "__main__":
     schools = build_school_json(sift_schools, doe_by_dbn)
     validate(schools)
 
-    output_path = "schools.json"
+    output_path = os.environ.get("ADMITDAY_SCHOOLS_OUTPUT", "schools.json")
     with open(output_path, "w") as f:
         json.dump(schools, f, indent=2)
 

--- a/lib/school-detail-utils.ts
+++ b/lib/school-detail-utils.ts
@@ -329,25 +329,28 @@ export function buildNotReportedTransitLabel(missingModes: string[]): string | n
 export interface ProgramRow {
   name: string
   method: string
+  code?: string
 }
 
 /**
- * The scraped `programs` array has no distinct per-major name (only an
- * admissions_type + a raw_method string like "Screened"), and some schools
- * repeat the identical pair many times. Collapse exact duplicates so the
- * section reads as a list of distinct pathways rather than a repeated row.
+ * MySchools rows have distinct program names/codes. Older NYC-SIFT-shaped
+ * rows only had an admissions_type + raw_method string and sometimes repeated
+ * the identical pair many times. Collapse exact duplicates while preserving
+ * distinct MySchools programs.
  */
 export function dedupePrograms(programs: School['programs']): ProgramRow[] {
   const seen = new Set<string>()
   const rows: ProgramRow[] = []
   for (const p of programs ?? []) {
-    const rawMethod = (p as { raw_method?: string }).raw_method
-    const name = rawMethod || p.admissions_type
-    const method = p.admissions_type
-    const key = `${name}||${method}`
+    const rawMethod = p.raw_method
+    const name = p.program_name || p.program || rawMethod || p.admissions_type || ''
+    const method = p.admissions_type || p.admissions_method || ''
+    const code = p.program_code
+    if (!name && !method) continue
+    const key = `${code || name}||${method}`
     if (seen.has(key)) continue
     seen.add(key)
-    rows.push({ name, method })
+    rows.push(code ? { name, method, code } : { name, method })
   }
   return rows
 }

--- a/lib/validate-school-data.ts
+++ b/lib/validate-school-data.ts
@@ -38,6 +38,8 @@ export interface ValidateOptions {
   countTolerance?: number
   /** Max fraction (0-1) the count may drop versus the previous file. Defaults to MAX_DROP_VS_PREVIOUS. */
   maxDropRatio?: number
+  /** Require current MySchools per-program records with provenance. Defaults to false for small unit fixtures. */
+  requireMySchoolsPrograms?: boolean
 }
 
 export const EXPECTED_SCHOOL_COUNT = 457
@@ -46,6 +48,50 @@ export const MAX_DROP_VS_PREVIOUS = 0.1
 
 function asTrimmedString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
+}
+
+function hasEmptyString(value: unknown): boolean {
+  if (typeof value === 'string') return value.trim() === ''
+  if (Array.isArray(value)) return value.some(hasEmptyString)
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some(hasEmptyString)
+  }
+  return false
+}
+
+function validateMySchoolsPrograms(record: RawSchoolRecord): string[] {
+  const reasons: string[] = []
+  const programs = record.programs
+
+  if (!Array.isArray(programs) || programs.length === 0) {
+    reasons.push('missing MySchools programs')
+    return reasons
+  }
+
+  const seenProgramKeys = new Set<string>()
+  programs.forEach((program, programIndex) => {
+    const p = (program ?? {}) as Record<string, unknown>
+    const name = asTrimmedString(p.program_name) || asTrimmedString(p.program)
+    const code = asTrimmedString(p.program_code)
+    const provenance = (p.provenance ?? {}) as Record<string, unknown>
+    const provenanceSource = asTrimmedString(provenance.source)
+    const provenanceUrl = asTrimmedString(provenance.url)
+    const fetchedAt = asTrimmedString(provenance.fetched_at)
+
+    if (!name) reasons.push(`program[${programIndex}] missing program name`)
+    if (hasEmptyString(p)) reasons.push(`program[${programIndex}] contains empty string; omit missing fields instead`)
+    if (provenanceSource !== 'MySchools') reasons.push(`program[${programIndex}] missing MySchools provenance source`)
+    if (!provenanceUrl) reasons.push(`program[${programIndex}] missing provenance url`)
+    if (!fetchedAt) reasons.push(`program[${programIndex}] missing provenance fetched_at`)
+
+    const key = code || name
+    if (key) {
+      if (seenProgramKeys.has(key)) reasons.push(`duplicate program key: ${key}`)
+      seenProgramKeys.add(key)
+    }
+  })
+
+  return reasons
 }
 
 /**
@@ -90,6 +136,9 @@ export function validateSchoolData(
     if (!name) reasons.push('missing name')
     if (!borough) reasons.push('missing borough')
     if (dbn && seenDbns.has(dbn)) reasons.push(`duplicate dbn: ${dbn}`)
+    if (options?.requireMySchoolsPrograms) {
+      reasons.push(...validateMySchoolsPrograms(r))
+    }
 
     if (dbn) {
       seenDbns.add(dbn)

--- a/scripts/embed-schools.ts
+++ b/scripts/embed-schools.ts
@@ -10,8 +10,9 @@
  * - Schools with total chunk text <= 800 chars: one "full" chunk.
  * - Schools with total chunk text > 800 chars: split into up to 3 chunks:
  *     1. "identity" — name, borough, size, students, admissions, flags, interests, stats
- *     2. "academics" — overview, academic opportunities, AP courses, program description
- *     3. "activities" — extracurriculars, sports, additional info
+ *     2. "programs" — current MySchools program names, codes, methods, seats, requirements
+ *     3. "academics" — overview, academic opportunities, AP courses, program description
+ *     4. "activities" — extracurriculars, sports, additional info
  *   Each chunk is prefixed with a short identity line so it can stand alone.
  *   Chunks are only created if they have content beyond the prefix.
  *
@@ -48,6 +49,27 @@ interface SchoolFlags {
   has_ib: boolean;
 }
 
+interface SchoolProgram {
+  program?: string;
+  admissions_type?: string;
+  raw_method?: string;
+  program_name?: string;
+  program_code?: string;
+  admissions_method?: string;
+  admissions_method_description?: string;
+  grade_span?: string;
+  description?: string;
+  seats?: Record<string, unknown>;
+  eligibility?: Record<string, unknown>;
+  requirements?: Record<string, unknown>;
+  provenance?: {
+    source?: string;
+    url?: string;
+    fetched_at?: string;
+    admissions_cycle?: string;
+  };
+}
+
 interface DoeData {
   overview: string;
   language: string;
@@ -81,6 +103,7 @@ interface School {
   academic_score_pct: number;
   survey_score_pct: number | null;
   admissions_types: string[];
+  programs: SchoolProgram[];
   flags: SchoolFlags;
   doe_data: DoeData;
   sift_url: string;
@@ -92,7 +115,7 @@ export interface SchoolEmbedding {
   dbn: string;
   name: string;
   borough: string;
-  chunkType: "full" | "identity" | "academics" | "activities";
+  chunkType: ChunkType;
   chunk: string;
   embedding: number[];
   metadata: {
@@ -102,9 +125,32 @@ export interface SchoolEmbedding {
     academic_score_pct: number;
     neighborhood: string;
     admissions_types: string[];
+    program_codes: string[];
     interests: string[];
     flags: SchoolFlags;
   };
+}
+
+type ChunkType = "full" | "identity" | "programs" | "academics" | "activities";
+
+function isPresent(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value as Record<string, unknown>).length > 0;
+  return true;
+}
+
+function stringifyValue(value: unknown): string {
+  if (!isPresent(value)) return "";
+  if (Array.isArray(value)) return value.map(stringifyValue).filter(Boolean).join("; ");
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => isPresent(v))
+      .map(([k, v]) => `${k.replace(/_/g, " ")}: ${stringifyValue(v)}`)
+      .join("; ");
+  }
+  return String(value);
 }
 
 // ---------------------------------------------------------------------------
@@ -173,6 +219,55 @@ function buildIdentityParts(school: School): string[] {
 }
 
 /**
+ * Programs chunk: current MySchools per-program admissions data.
+ */
+function buildProgramParts(school: School): string[] {
+  const parts: string[] = [];
+
+  for (const program of school.programs ?? []) {
+    const name = program.program_name || program.program || program.raw_method || program.admissions_type;
+    const method = program.admissions_type || program.admissions_method;
+    if (!name && !method) continue;
+
+    const headerParts = [
+      name ? `Program: ${name}` : "Program",
+      program.program_code ? `code ${program.program_code}` : "",
+      method ? `admissions method ${method}` : "",
+      program.grade_span ? `grades ${program.grade_span}` : "",
+    ].filter(Boolean);
+    const lines = [headerParts.join("; ") + "."];
+
+    if (program.description) lines.push(`Description: ${program.description}`);
+    if (program.admissions_method_description) {
+      lines.push(`Admissions method details: ${program.admissions_method_description}`);
+    }
+
+    const seats = stringifyValue(program.seats);
+    if (seats) lines.push(`Seats and demand: ${seats}`);
+
+    const requirements = stringifyValue(program.requirements);
+    if (requirements) lines.push(`Requirements: ${requirements}`);
+
+    const eligibility = stringifyValue(program.eligibility);
+    if (eligibility) lines.push(`Eligibility and priority: ${eligibility}`);
+
+    if (program.provenance?.source || program.provenance?.url || program.provenance?.fetched_at) {
+      const provenance = [
+        program.provenance.source,
+        program.provenance.url,
+        program.provenance.fetched_at ? `fetched ${program.provenance.fetched_at}` : "",
+        program.provenance.admissions_cycle,
+      ].filter(Boolean);
+      parts.push(`${lines.join(" ")} Source: ${provenance.join("; ")}.`);
+    } else {
+      parts.push(lines.join(" "));
+    }
+  }
+
+  return parts;
+}
+
+/**
  * Academics chunk: overview, academic opportunities, AP courses, program description.
  */
 function buildAcademicsParts(school: School): string[] {
@@ -214,17 +309,18 @@ function buildActivitiesParts(school: School): string[] {
 // ---------------------------------------------------------------------------
 
 interface ChunkResult {
-  chunkType: "full" | "identity" | "academics" | "activities";
+  chunkType: ChunkType;
   chunk: string;
 }
 
 function schoolToChunks(school: School): ChunkResult[] {
   // Build the full text first to check length
   const identityParts = buildIdentityParts(school);
+  const programParts = buildProgramParts(school);
   const academicsParts = buildAcademicsParts(school);
   const activitiesParts = buildActivitiesParts(school);
 
-  const allParts = [...identityParts, ...academicsParts, ...activitiesParts];
+  const allParts = [...identityParts, ...programParts, ...academicsParts, ...activitiesParts];
   const fullText = allParts.join("\n");
 
   // Small school: one chunk
@@ -241,6 +337,14 @@ function schoolToChunks(school: School): ChunkResult[] {
     chunkType: "identity",
     chunk: identityParts.join("\n"),
   });
+
+  // Programs chunk: only if MySchools per-program content exists
+  if (programParts.length > 0) {
+    chunks.push({
+      chunkType: "programs",
+      chunk: prefix + "\n" + programParts.join("\n"),
+    });
+  }
 
   // Academics chunk: only if there's content
   if (academicsParts.length > 0) {
@@ -291,7 +395,7 @@ async function main() {
   // Convert to chunks (one or more per school)
   const allChunkData: {
     school: School;
-    chunkType: "full" | "identity" | "academics" | "activities";
+    chunkType: ChunkType;
     chunk: string;
   }[] = [];
 
@@ -352,6 +456,7 @@ async function main() {
       academic_score_pct: c.school.academic_score_pct,
       neighborhood: c.school.doe_data.neighborhood,
       admissions_types: c.school.admissions_types,
+      program_codes: (c.school.programs ?? []).map((p) => p.program_code).filter((code): code is string => Boolean(code)),
       interests: c.school.doe_data.interests,
       flags: c.school.flags,
     },

--- a/scripts/refresh-data.ts
+++ b/scripts/refresh-data.ts
@@ -8,18 +8,22 @@
  *   2. Validate the scrape (lib/validate-school-data.ts) -- fails loudly and
  *      exits without writing anything if the result looks broken.
  *   3. Write data/schools.json from the validated scrape.
- *   4. Reseed the Postgres `schools` table (scripts/seed-schools.ts).
- *   5. Re-embed school data (scripts/embed-schools.ts).
+ *   4. Re-embed school data (scripts/embed-schools.ts).
+ *   5. Reseed the Postgres `schools` table (scripts/seed-schools.ts).
  *
  * Run:
  *   npm run refresh:data
  *
- * Requires POSTGRES_URL and OPENAI_API_KEY in .env.local (steps 4 and 5 read
- * them the same way scripts/seed-schools.ts and scripts/embed-schools.ts
- * already do).
+ * Requires OPENAI_API_KEY for embeddings. Also requires POSTGRES_URL unless
+ * ADMITDAY_SKIP_POSTGRES_SEED=1 is set.
+ *
+ * Set ADMITDAY_SKIP_POSTGRES_SEED=1 to generate/validate/re-embed artifacts
+ * without changing the production database. The scheduled data-refresh PR
+ * uses that mode; the merge-to-main apply workflow performs the DB seed.
  */
 
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import { spawnSync } from 'child_process'
 import { validateSchoolData, RawSchoolRecord } from '../lib/validate-school-data'
@@ -33,9 +37,9 @@ function readJsonArray(filePath: string): unknown[] | null {
   return Array.isArray(parsed) ? parsed : null
 }
 
-function run(command: string, args: string[]): void {
+function run(command: string, args: string[], env?: Record<string, string>): void {
   console.log(`\n$ ${command} ${args.join(' ')}`)
-  const result = spawnSync(command, args, { stdio: 'inherit' })
+  const result = spawnSync(command, args, { stdio: 'inherit', env: { ...process.env, ...env } })
   if (result.error) {
     throw result.error
   }
@@ -70,16 +74,24 @@ async function main(): Promise<void> {
   // present, otherwise whatever schools.json already has.
   const previousSchools = readJsonArray(DATA_SCHOOLS_PATH) ?? readJsonArray(ROOT_SCHOOLS_PATH)
 
-  // 1. Scrape.
-  run('python3', ['build_school_data.py'])
+  const scrapeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'admitday-refresh-'))
+  const scrapedPath = path.join(scrapeTmpDir, 'schools.json')
 
-  const scraped = readJsonArray(ROOT_SCHOOLS_PATH)
+  // 1. Scrape to a temp file so validation failure cannot overwrite the
+  // previous known-good root schools.json.
+  run('python3', ['build_school_data.py'], {
+    ADMITDAY_SCHOOLS_OUTPUT: scrapedPath,
+  })
+
+  const scraped = readJsonArray(scrapedPath)
   if (!scraped) {
-    throw new Error(`${ROOT_SCHOOLS_PATH} was not produced by the scrape (or is not a JSON array).`)
+    throw new Error(`${scrapedPath} was not produced by the scrape (or is not a JSON array).`)
   }
 
   // 2. Validate.
-  const result = validateSchoolData(scraped as RawSchoolRecord[], previousSchools)
+  const result = validateSchoolData(scraped as RawSchoolRecord[], previousSchools, {
+    requireMySchoolsPrograms: true,
+  })
   printSummary(result.previousCount, result.schoolCount, result.added, result.removed, result.invalidRecords)
 
   if (!result.valid) {
@@ -89,21 +101,16 @@ async function main(): Promise<void> {
   }
   console.log('\nValidation passed.')
 
-  // 3. Write data/schools.json.
+  // 3. Write both school data snapshots from the validated temp scrape.
+  fs.writeFileSync(ROOT_SCHOOLS_PATH, JSON.stringify(scraped, null, 2))
+  console.log(`Wrote ${ROOT_SCHOOLS_PATH}`)
   fs.mkdirSync(path.dirname(DATA_SCHOOLS_PATH), { recursive: true })
   fs.writeFileSync(DATA_SCHOOLS_PATH, JSON.stringify(scraped, null, 2))
   console.log(`Wrote ${DATA_SCHOOLS_PATH}`)
+  fs.rmSync(scrapeTmpDir, { recursive: true, force: true })
 
-  // 4. Reseed Postgres.
-  run('npx', [
-    'ts-node',
-    '--compiler-options',
-    '{"module":"commonjs","moduleResolution":"node"}',
-    '--transpile-only',
-    'scripts/seed-schools.ts',
-  ])
-
-  // 5. Re-embed.
+  // 4. Re-embed first so a provider/key failure cannot update Postgres while
+  // leaving RAG on the previous data snapshot.
   run('npx', [
     'ts-node',
     '--compiler-options',
@@ -111,6 +118,19 @@ async function main(): Promise<void> {
     '--transpile-only',
     'scripts/embed-schools.ts',
   ])
+
+  // 5. Reseed Postgres unless this run is only preparing a reviewable data PR.
+  if (process.env.ADMITDAY_SKIP_POSTGRES_SEED === '1') {
+    console.log('\nSkipping Postgres seed because ADMITDAY_SKIP_POSTGRES_SEED=1.')
+  } else {
+    run('npx', [
+      'ts-node',
+      '--compiler-options',
+      '{"module":"commonjs","moduleResolution":"node"}',
+      '--transpile-only',
+      'scripts/seed-schools.ts',
+    ])
+  }
 
   console.log('\nData refresh complete.')
 }

--- a/scripts/seed-schools.ts
+++ b/scripts/seed-schools.ts
@@ -2,7 +2,8 @@
  * seed-schools.ts
  *
  * Seeds the Vercel Postgres (Neon) `schools` table from local scraped data.
- * Reads data/schools.json and upserts every record keyed by DBN, so the
+ * Reads data/schools.json, falling back to root schools.json in clean CI
+ * checkouts, and upserts every record keyed by DBN, so the
  * production /list and /requirements pages can load school data from the
  * database instead of the gitignored JSON file.
  *
@@ -29,9 +30,11 @@ interface School {
 
 async function main() {
   // Load schools
-  const schoolsPath = path.resolve(process.cwd(), "data", "schools.json");
+  const dataSchoolsPath = path.resolve(process.cwd(), "data", "schools.json");
+  const rootSchoolsPath = path.resolve(process.cwd(), "schools.json");
+  const schoolsPath = fs.existsSync(dataSchoolsPath) ? dataSchoolsPath : rootSchoolsPath;
   if (!fs.existsSync(schoolsPath)) {
-    console.error("data/schools.json not found.");
+    console.error("No school data found. Expected data/schools.json or schools.json.");
     process.exit(1);
   }
 

--- a/scripts/vps-data-refresh.sh
+++ b/scripts/vps-data-refresh.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 # and must not be run in GitHub Actions with app secrets duplicated there.
 
 MODE="${1:-pr}"
-APP_DIR="${APP_DIR:-/home/agent/app}"
-APP_ENV_FILE="${APP_ENV_FILE:-$APP_DIR/.env.local}"
-AGENT_ENV_FILE="${AGENT_ENV_FILE:-/home/agent/.env.agents}"
+APP_DIR="${APP_DIR:-/root/app}"
+APP_ENV_FILE="${APP_ENV_FILE:-/root/.env.local}"
+AGENT_ENV_FILE="${AGENT_ENV_FILE:-/root/.env.agents}"
 BRANCH="${DATA_REFRESH_BRANCH:-data/weekly-refresh}"
 REPO="${GITHUB_REPO:-neinna/AdmitDay}"
 

--- a/scripts/vps-data-refresh.sh
+++ b/scripts/vps-data-refresh.sh
@@ -11,6 +11,8 @@ ROOT_ENV_FILE="${ROOT_ENV_FILE:-/root/.env.local}"
 AGENT_ENV_FILE="${AGENT_ENV_FILE:-/root/.env.agents}"
 BRANCH="${DATA_REFRESH_BRANCH:-data/weekly-refresh}"
 REPO="${GITHUB_REPO:-neinna/AdmitDay}"
+EXPECTED_DATA_FILES="data/school-embeddings.json
+schools.json"
 
 load_env_file() {
   local file="$1"
@@ -30,6 +32,13 @@ require_env() {
   fi
 }
 
+require_gh_token() {
+  if [ -z "${GH_TOKEN:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GH_TOKEN="$GITHUB_TOKEN"
+  fi
+  require_env GH_TOKEN
+}
+
 prepare_checkout() {
   cd "$APP_DIR"
   git fetch origin main
@@ -44,11 +53,7 @@ install_dependencies() {
 
 open_refresh_pr() {
   require_env OPENAI_API_KEY
-
-  if [ -z "${GH_TOKEN:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
-    export GH_TOKEN="$GITHUB_TOKEN"
-  fi
-  require_env GH_TOKEN
+  require_gh_token
 
   prepare_checkout
   git switch -C "$BRANCH" origin/main
@@ -76,7 +81,7 @@ This run used the validated refresh pipeline:
 - rebuild RAG embeddings
 - skip production Postgres seeding until merge
 
-Merge this PR to publish matching tracked RAG artifacts through the normal Vercel deployment. Run `scripts/vps-data-refresh.sh apply` on the VPS after merge to seed Postgres from the merged `schools.json`.
+This PR is intended to be merged by the VPS data refresh runner, not by a human. Run `scripts/vps-data-refresh.sh merge` after CI passes; it only merges when the changed files are the expected data artifacts and the GitHub CI test is green. Then run `scripts/vps-data-refresh.sh apply` to seed Postgres from the merged `schools.json`.
 PR_BODY
 )"
 
@@ -85,6 +90,38 @@ PR_BODY
   else
     gh pr create --repo "$REPO" --base main --head "$BRANCH" --title "data: refresh school program data" --body "$body"
   fi
+}
+
+assert_refresh_pr_files() {
+  require_gh_token
+
+  local files
+  files="$(gh pr diff "$BRANCH" --repo "$REPO" --name-only | sort)"
+
+  if [ "$files" != "$EXPECTED_DATA_FILES" ]; then
+    echo "Refusing to merge data refresh PR with unexpected files:" >&2
+    echo "$files" >&2
+    exit 1
+  fi
+}
+
+assert_refresh_ci_green() {
+  require_gh_token
+
+  local passing_tests
+  passing_tests="$(gh pr view "$BRANCH" --repo "$REPO" --json statusCheckRollup --jq '[.statusCheckRollup[] | select((.name // .context) == "test") | select(((.status // "") == "COMPLETED" and (.conclusion // "") == "SUCCESS") or ((.state // "") == "SUCCESS"))] | length')"
+
+  if [ "$passing_tests" != "1" ]; then
+    echo "Refusing to merge data refresh PR before the GitHub CI test is green." >&2
+    exit 1
+  fi
+}
+
+merge_refresh_pr() {
+  assert_refresh_pr_files
+  assert_refresh_ci_green
+
+  gh pr merge "$BRANCH" --repo "$REPO" --squash --delete-branch --subject "data: refresh school program data"
 }
 
 apply_merged_data() {
@@ -104,11 +141,14 @@ case "$MODE" in
   pr)
     open_refresh_pr
     ;;
+  merge)
+    merge_refresh_pr
+    ;;
   apply)
     apply_merged_data
     ;;
   *)
-    echo "Usage: $0 [pr|apply]" >&2
+    echo "Usage: $0 [pr|merge|apply]" >&2
     exit 2
     ;;
 esac

--- a/scripts/vps-data-refresh.sh
+++ b/scripts/vps-data-refresh.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# VPS-only data refresh runner. It relies on secrets already present on the VPS
+# and must not be run in GitHub Actions with app secrets duplicated there.
+
+MODE="${1:-pr}"
+APP_DIR="${APP_DIR:-/home/agent/app}"
+APP_ENV_FILE="${APP_ENV_FILE:-$APP_DIR/.env.local}"
+AGENT_ENV_FILE="${AGENT_ENV_FILE:-/home/agent/.env.agents}"
+BRANCH="${DATA_REFRESH_BRANCH:-data/weekly-refresh}"
+REPO="${GITHUB_REPO:-neinna/AdmitDay}"
+
+load_env_file() {
+  local file="$1"
+  if [ -f "$file" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$file"
+    set +a
+  fi
+}
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "Missing required environment variable: $name" >&2
+    exit 1
+  fi
+}
+
+prepare_checkout() {
+  cd "$APP_DIR"
+  git fetch origin main
+  git switch main
+  git pull --ff-only origin main
+}
+
+install_dependencies() {
+  python3 -m pip install --user beautifulsoup4 requests
+  npm ci
+}
+
+open_refresh_pr() {
+  require_env OPENAI_API_KEY
+
+  if [ -z "${GH_TOKEN:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GH_TOKEN="$GITHUB_TOKEN"
+  fi
+  require_env GH_TOKEN
+
+  prepare_checkout
+  git switch -C "$BRANCH" origin/main
+  install_dependencies
+
+  ADMITDAY_SKIP_POSTGRES_SEED=1 npm run refresh:data
+
+  git add schools.json data/school-embeddings.json
+  if git diff --cached --quiet; then
+    echo "No tracked data changes to commit."
+    return 0
+  fi
+
+  git commit -m "data: refresh school program data"
+  git push --force-with-lease origin "$BRANCH"
+  gh workflow run ci.yml --repo "$REPO" --ref "$BRANCH"
+
+  local body
+  body="$(cat <<'PR_BODY'
+Automated weekly school data refresh.
+
+This run used the validated refresh pipeline:
+- scrape NYC-SIFT, DOE Open Data, and MySchools program data
+- validate school count, required fields, and MySchools program provenance
+- rebuild RAG embeddings
+- skip production Postgres seeding until merge
+
+Merge this PR to publish matching tracked RAG artifacts through the normal Vercel deployment. Run `scripts/vps-data-refresh.sh apply` on the VPS after merge to seed Postgres from the merged `schools.json`.
+PR_BODY
+)"
+
+  if gh pr view "$BRANCH" --repo "$REPO" --json number >/dev/null 2>&1; then
+    gh pr edit "$BRANCH" --repo "$REPO" --title "data: refresh school program data" --body "$body"
+  else
+    gh pr create --repo "$REPO" --base main --head "$BRANCH" --title "data: refresh school program data" --body "$body"
+  fi
+}
+
+apply_merged_data() {
+  require_env POSTGRES_URL
+
+  prepare_checkout
+  install_dependencies
+
+  npx ts-node --compiler-options '{"module":"commonjs","moduleResolution":"node"}' --transpile-only scripts/seed-schools.ts
+}
+
+load_env_file "$APP_ENV_FILE"
+load_env_file "$AGENT_ENV_FILE"
+
+case "$MODE" in
+  pr)
+    open_refresh_pr
+    ;;
+  apply)
+    apply_merged_data
+    ;;
+  *)
+    echo "Usage: $0 [pr|apply]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/vps-data-refresh.sh
+++ b/scripts/vps-data-refresh.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 
 MODE="${1:-pr}"
 APP_DIR="${APP_DIR:-/root/app}"
-APP_ENV_FILE="${APP_ENV_FILE:-/root/.env.local}"
+APP_ENV_FILE="${APP_ENV_FILE:-$APP_DIR/.env.local}"
+ROOT_ENV_FILE="${ROOT_ENV_FILE:-/root/.env.local}"
 AGENT_ENV_FILE="${AGENT_ENV_FILE:-/root/.env.agents}"
 BRANCH="${DATA_REFRESH_BRANCH:-data/weekly-refresh}"
 REPO="${GITHUB_REPO:-neinna/AdmitDay}"
@@ -96,6 +97,7 @@ apply_merged_data() {
 }
 
 load_env_file "$APP_ENV_FILE"
+load_env_file "$ROOT_ENV_FILE"
 load_env_file "$AGENT_ENV_FILE"
 
 case "$MODE" in

--- a/types/index.ts
+++ b/types/index.ts
@@ -37,8 +37,27 @@ export interface DoeData {
 }
 
 export interface SchoolProgram {
-  program: string
-  admissions_type: string
+  // Compatibility fields from the older NYC-SIFT-shaped program rows.
+  program?: string
+  admissions_type?: string
+  raw_method?: string
+
+  // Current MySchools per-program fields.
+  program_name?: string
+  program_code?: string
+  admissions_method?: string
+  admissions_method_description?: string
+  grade_span?: string
+  description?: string
+  seats?: Record<string, unknown>
+  eligibility?: Record<string, unknown>
+  requirements?: Record<string, unknown>
+  provenance?: {
+    source: 'MySchools' | string
+    url: string
+    fetched_at: string
+    admissions_cycle?: string
+  }
 }
 
 export interface School {


### PR DESCRIPTION
## Summary
- wire MySchools per-program records into the school data build path while preserving old compatibility fields
- validate MySchools program provenance during refresh and include program-level data in RAG chunks
- add VPS-owned data refresh runner so app secrets remain on the VPS, not in GitHub repository secrets
- document source freshness: DOE Open Data uq7m-95z8 is 2018-era / 2019 directory data; MySchools is now the current per-program source

## Verification
- npm test: 816 passed before latest main merge; focused MySchools pipeline test passes after VPS env/data-runner corrections
- npm run lint: clean
- python3 -m py_compile build_school_data.py scripts/scrape_myschools.py
- bash -n scripts/vps-data-refresh.sh
- ruby YAML parse for .github/workflows/ci.yml
- git diff --check

## Not done by this PR alone
- Production data has not been refreshed yet.
- After merge, run the VPS-owned data refresh flow from /root/app:
  1. ./scripts/vps-data-refresh.sh pr
  2. ./scripts/vps-data-refresh.sh merge
  3. ./scripts/vps-data-refresh.sh apply

## Secret boundary
OPENAI_API_KEY and POSTGRES_URL stay in the VPS env files: /root/app/.env.local, /root/.env.local, and/or /root/.env.agents. This PR does not require adding them to GitHub.